### PR TITLE
fix-symlinks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -270,3 +270,11 @@
 	path = ext/providers/vsphere
 	url = https://github.com/terraform-providers/terraform-provider-vsphere
 	branch = stable-website
+[submodule "ext/providers/do"]
+	path = ext/providers/do
+	url = https://github.com/terraform-providers/terraform-provider-digitalocean
+	branch = stable-website
+[submodule "ext/providers/atlas"]
+	path = ext/providers/atlas
+	url = https://github.com/terraform-providers/terraform-provider-atlas
+	branch = stable-website

--- a/source/docs/backends
+++ b/source/docs/backends
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/backends
+../../ext/terraform/website/source/docs/backends

--- a/source/docs/commands
+++ b/source/docs/commands
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/commands
+../../ext/terraform/website/source/docs/commands

--- a/source/docs/configuration
+++ b/source/docs/configuration
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/configuration
+../../ext/terraform/website/source/docs/configuration

--- a/source/docs/import
+++ b/source/docs/import
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/import
+../../ext/terraform/website/source/docs/import

--- a/source/docs/internals
+++ b/source/docs/internals
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/internals/
+../../ext/terraform/website/source/docs/internals

--- a/source/docs/modules
+++ b/source/docs/modules
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/modules/
+../../ext/terraform/website/source/docs/modules

--- a/source/docs/plugins
+++ b/source/docs/plugins
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/plugins/
+../../ext/terraform/website/source/docs/plugins

--- a/source/docs/providers/index.html.markdown
+++ b/source/docs/providers/index.html.markdown
@@ -1,1 +1,1 @@
-../../../ext/terraform/website/docs/providers/index.html.markdown
+../../../ext/terraform/website/source/docs/providers/index.html.markdown

--- a/source/docs/providers/terraform-enterprise
+++ b/source/docs/providers/terraform-enterprise
@@ -1,1 +1,1 @@
-../../../ext/providers/terraform-enterprise/website/docs
+../../../ext/providers/atlas/website/docs

--- a/source/docs/provisioners
+++ b/source/docs/provisioners
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/provisioners/
+../../ext/terraform/website/source/docs/provisioners

--- a/source/docs/state
+++ b/source/docs/state
@@ -1,1 +1,1 @@
-../../ext/terraform/website/docs/state/
+../../ext/terraform/website/source/docs/state

--- a/source/guides
+++ b/source/guides
@@ -1,1 +1,1 @@
-../ext/terraform/website/guides
+../ext/terraform/website/source/guides

--- a/source/intro
+++ b/source/intro
@@ -1,1 +1,1 @@
-../ext/terraform/website/intro
+../ext/terraform/website/source/intro

--- a/source/layouts/backend-types.erb
+++ b/source/layouts/backend-types.erb
@@ -1,1 +1,1 @@
-../../ext/terraform/website/layouts/backend-types.erb
+../../ext/terraform/website/source/layouts/backend-types.erb

--- a/source/layouts/commands-state.erb
+++ b/source/layouts/commands-state.erb
@@ -1,1 +1,1 @@
-../../ext/terraform/website/layouts/commands-state.erb
+../../ext/terraform/website/source/layouts/commands-state.erb

--- a/source/layouts/digitalocean.erb
+++ b/source/layouts/digitalocean.erb
@@ -1,1 +1,1 @@
-../../ext/providers/do/website/digitalocean.erb
+../../ext/terraform/website/source/layouts/digitalocean.erb

--- a/source/layouts/docs.erb
+++ b/source/layouts/docs.erb
@@ -1,1 +1,1 @@
-../../ext/terraform/website/layouts/docs.erb
+../../ext/terraform/website/source/layouts/docs.erb

--- a/source/layouts/downloads.erb
+++ b/source/layouts/downloads.erb
@@ -1,1 +1,1 @@
-../../ext/terraform/website/layouts/downloads.erb
+../../ext/terraform/website/source/layouts/downloads.erb

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -1,1 +1,1 @@
-../../ext/terraform/website/layouts/guides.erb
+../../ext/terraform/website/source/layouts/guides.erb

--- a/source/layouts/intro.erb
+++ b/source/layouts/intro.erb
@@ -1,1 +1,1 @@
-../../ext/terraform/website/layouts/intro.erb
+../../ext/terraform/website/source/layouts/intro.erb

--- a/source/layouts/terraform-enterprise.erb
+++ b/source/layouts/terraform-enterprise.erb
@@ -1,1 +1,1 @@
-../../ext/providers/terraform-enterprise/website/terraform-enterprise.erb
+../../ext/providers/atlas/website/terraform-enterprise.erb

--- a/source/upgrade-guides
+++ b/source/upgrade-guides
@@ -1,1 +1,1 @@
-../ext/terraform/website/upgrade-guides
+../ext/terraform/website/source/upgrade-guides


### PR DESCRIPTION
from a fresh checkout & sync, a bunch of the links were broken. I don't know if other people are doing weird custom things such that the old links work, but these work with what happens by default.

there are still several more broken links. I didn't fix them because I wasn't totally sure what was correct. 

- `source/layouts/commands-workspace.erb`

I think this is the same thing as `commands-env.erb`. There seems to be some kind of not-entirely-successful renaming effort in progress I don't entirely understand.

- `source/layouts/terraform-enterprise.erb`

not totally sure where this is supposed to go.

- `source/docs/providers/do`

I assume this is short for digital ocean, in which case it's missing from `.gitmodules` too. Even if I'm right, I'm not totally sure how git modules work, except for having a general impression that they're hard to use correctly, so I'm disinclined to just go ahead and add a similar entry to `.gitmodules`.

- `source/docs/providers/terraform-enterprise`

Maybe this is supposed to point to "atlas" instead of "terraform-enterprise." Either way, it's missing from `.gitmodules`.