### PR TITLE
Link to the Terraform logos for use in READMEs, etc

### DIFF
--- a/content/source/logos.html.markdown
+++ b/content/source/logos.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "inner"
+page_title: "Terraform Logos"
+---
+
+# Terraform Logos
+
+The following logos can be used in the `README` files for the core Terraform
+repository and the official providers, and for HashiCorp marketing purposes.
+
+Please refer to
+[the Terraform brand guidelines](https://www.hashicorp.com/brand/terraform/)
+for detailed guidelines on usage of these (and other) logo images.
+
+## Main Logo
+
+This is the main logo to use.
+
+![HashiCorp Terraform](/assets/images/logo-hashicorp.svg)
+
+## Simpler Logo, without "HashiCorp"
+
+This logo can be used in contexts where a simpler logo is required or where
+the "HashiCorp" reference is clear from context.
+
+![HashiCorp Terraform](/assets/images/logo-text.svg)
+
+## Square Logo
+
+The following logo is for situations where square images are required, such
+as in social media posts.
+
+![HashiCorp Terraform](/assets/images/og-image.png)


### PR DESCRIPTION
We have Terraform logos embedded in our READMEs but they currently link directly to the source repository. To decouple this, we'll expose them on the main website and link to them from there.

Middleman prunes images that aren't referenced on a page, so this page is here primarily to cause Middleman to include these images, though it also serves as a reference for the canonical URLs we should use when writing READMEs and so forth, presuming that we'll keep these URLs working in future to avoid breaking the README images again.

This page isn't linked from anywhere specific, but it will show up in the sitemap and be indexed by search engines, so it needs to remain somewhat presentable.