### PR TITLE
Update "Edit this page" links to new locations

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -111,7 +111,7 @@
               <li><a href="/assets/files/press-kit.zip">Press Kit</a></li>
             </ul>
             <ul class="footer-links nav navbar-nav navbar-right">
-              <li><a href="<%= github_url :current_page %>">Edit this page</a></li>
+              <li><a href="<%= github_edit_url(current_page) %>">Edit this page</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Since the source files for the website now come from a number of different locations, there is more complexity here than before. Since this solution for splitting the website is intended to be temporary, this change is intended as a simple stop-gap to tide us over for now.

The approach here is to use the absolute filesystem path (assuming the filesystem layout used in our docker containers) to infer which repository each file is coming from, thus allowing us to point the links at different repositories for the root pages, the docs in the core repo, and each provider's docs respectively.