### PR TITLE
Give bucket owner full control when uploading to S3

### DIFF
--- a/content/scripts/deploy.sh
+++ b/content/scripts/deploy.sh
@@ -63,6 +63,7 @@ if [ -z "$NO_UPLOAD" ]; then
     --add-header="Cache-Control: max-age=14400" \
     --add-header="x-amz-meta-surrogate-control: max-age=31536000, stale-white-revalidate=86400, stale-if-error=604800" \
     --add-header="x-amz-meta-surrogate-key: site-$PROJECT" \
+    --add-header="x-amz-acl: bucket-owner-full-control" \
     sync "$DIR/build/" "s3://hc-sites/$PROJECT/latest/"
 
   printf "Sleeping after upload..."


### PR DESCRIPTION
This is (AFAIK) necessary for cross-account uploads in this context.