### PR TITLE
DON'T MERGE: Use jQuery to activate sidebar nav sections

### DIFF
--- a/content/config.rb
+++ b/content/config.rb
@@ -49,12 +49,7 @@ helpers do
   # This helps by setting the "active" class for sidebar nav elements
   # if the YAML frontmatter matches the expected value.
   def sidebar_current(expected)
-    current = current_page.data.sidebar_current || ""
-    if current.start_with?(expected)
-      return " class=\"active\""
-    else
-      return ""
-    end
+    return ""
   end
 
   # Returns the id for this page.

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -4,7 +4,7 @@
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
 
-$( document ).ready( function() {
+document.addEventListener("turbolinks:load", function() {
     "use strict";
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
     var flexibleLocation = new RegExp(

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -3,3 +3,19 @@
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
+
+$( document ).ready( function() {
+    "use strict";
+    var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
+    var flexibleLocation = new RegExp(
+        location.pathname.replace(/(\/|\/index.html)$/, "/(index.html)?") + '$'
+    );
+    var activeLinks = docsSidebar.find("a").filter(
+        function(index, element) {
+            return flexibleLocation.test( $(element).prop("href") );
+        }
+    );
+    var activeListItems = docsSidebar.find("li").has(activeLinks);
+    console.log(activeListItems);
+    activeListItems.addClass("active");
+});

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -8,7 +8,7 @@ document.addEventListener("turbolinks:load", function() {
     "use strict";
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
     var flexibleLocation = new RegExp(
-        location.pathname.replace(/(\/|\/index.html)$/, "/(index.html)?") + '$'
+        location.pathname.replace(/(\/|\/index\.html)$/, "/(index.html)?") + '$'
     );
     var activeLinks = docsSidebar.find("a").filter(
         function(index, element) {
@@ -16,6 +16,5 @@ document.addEventListener("turbolinks:load", function() {
         }
     );
     var activeListItems = docsSidebar.find("li").has(activeLinks);
-    console.log(activeListItems);
     activeListItems.addClass("active");
 });


### PR DESCRIPTION
The Terraform website uses a collapsing sidebar navigation, where all nested sections should be collapsed except for:

- The link corresponding to the current page.
- Every section that is a parent or grandparent of that link. 

This is all governed by CSS via the `active` class. But right now, we set that class on elements at build time by doing double-bookkeeping on an extra piece of page metadata called `sidebar_current`. 

This system is hard to work with, and it's also redundant; the hierarchy of sections already tells us everything we need to figure out the active parent sections.

There should be an easy and correct way to make sidebars figure themselves out, but I'm pretty sure that way would be CSS parent selectors, which do not exist. (Yet? CSS4? Maybe?) So instead, here are three OK possibilities: 

1. Use JS to do it in the browser. This is super easy with jQuery, which we already use. This PR has a working POC. 
    * Downside: Nav doesn't work without JS. But if users with JS disabled are a concern (?!), we could default sidebars to expanded and set `inactive` classes with JS. 
2. Use Nokogiri to do it at build time. Probably easy enough to code, Nokogiri's interface isn't too bad.
    * Downside: Pulling in Nokogiri as a dependency is, uh... extreme. 
3. Stop representing sidebar navs as HTML (plus templating code), and instead represent them as data, writing a new helper method to generate HTML (with appropriate `active` classes) at build time. 
    * Downside: More work than either 1 or 2... but it's interesting work, and might let us re-use other data Middleman already has in some fun ways. 

So, let's discuss? I'd really like to stop doing this `sidebar_current` double-bookkeeping asap. 