### PR TITLE
Terraform beta API changes

### DIFF
--- a/content/source/docs/enterprise-beta/api/modules.html.md
+++ b/content/source/docs/enterprise-beta/api/modules.html.md
@@ -63,7 +63,7 @@ This endpoint can be used to publish a new module to the registry. The publishin
   "data": {
     "attributes": {
       "linkable-repo-id":"SKI/terraform-aws-instance",
-      "oauth-token-id":"1"
+      "oauth-token-id":"ot-hmAyP66qk2AMVdbJ"
     },
     "type":"registry-modules"
   }
@@ -142,4 +142,3 @@ curl \
   --request POST \
   https://atlas.hashicorp.com/api/v2/registry-modules/actions/delete/skierkowski-v2/instance
 ```
-

--- a/content/source/docs/enterprise-beta/api/modules.html.md
+++ b/content/source/docs/enterprise-beta/api/modules.html.md
@@ -53,7 +53,7 @@ This endpoint can be used to publish a new module to the registry. The publishin
 ### Parameters
 
 - `linkable-repo-id` (`string: <required>`) - Specifies the repository to be used to ingress the configuration. For Bitbucket server, the format is `<PROJECT_KEY>/<REPO>`. Bitbucket Server is currently the only supported VCS service.
-- `o-auth-token-id` (`string: <requires>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [o-auth-tokens](./o-auth-tokens.html) endpoint.
+- `oauth-token-id` (`string: <requires>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [oauth-tokens](./oauth-tokens.html) endpoint.
 
 
 ### Sample Payload
@@ -63,7 +63,7 @@ This endpoint can be used to publish a new module to the registry. The publishin
   "data": {
     "attributes": {
       "linkable-repo-id":"SKI/terraform-aws-instance",
-      "o-auth-token-id":"1"
+      "oauth-token-id":"1"
     },
     "type":"registry-modules"
   }

--- a/content/source/docs/enterprise-beta/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise-beta/api/oauth-tokens.html.md
@@ -1,14 +1,14 @@
 ---
 layout: enterprise2
 page_title: "OAuth Tokens - API Docs - Terraform Enterprise Beta"
-sidebar_current: "docs-enterprise2-api-o-auth-tokens"
+sidebar_current: "docs-enterprise2-api-oauth-tokens"
 ---
 
 # OAuth Tokens
 
 -> **Note**: These API endpoints are in beta and are subject to change.
 
-The `o-auth-token` object represents a VCS configuration which includes the OAuth connection and the assocaited OAuth token. This object is used when creating a workspace to identify which VCS connection to use.
+The `oauth-token` object represents a VCS configuration which includes the OAuth connection and the assocaited OAuth token. This object is used when creating a workspace to identify which VCS connection to use.
 
 ## List OAuth Tokens
 
@@ -16,7 +16,7 @@ List all the OAuth Tokens for a given organization
 
 | Method | Path           |
 | :----- | :------------- |
-| GET | /organizations/:organization_username/o-auth-tokens |
+| GET | /organizations/:organization_username/oauth-tokens |
 
 ### Parameters
 
@@ -27,7 +27,7 @@ List all the OAuth Tokens for a given organization
 ```shell
 curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/o-auth-tokens
+  https://atlas.hashicorp.com/api/v2/organizations/my-organization/oauth-tokens
 ```
 
 ### Sample Response
@@ -37,7 +37,7 @@ curl \
   "data": [
     {
       "id":"238560",
-      "type":"o-auth-tokens",
+      "type":"oauth-tokens",
       "attributes": {
         "uid":"885724",
         "created-at":"2017-11-02T06:37:49.284Z",
@@ -53,7 +53,7 @@ curl \
         }
       },
       "links": {
-        "self":"/api/v2/o-auth-tokens/238560"
+        "self":"/api/v2/oauth-tokens/238560"
       }
     }
   ]

--- a/content/source/docs/enterprise-beta/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise-beta/api/oauth-tokens.html.md
@@ -36,7 +36,7 @@ curl \
 {
   "data": [
     {
-      "id":"238560",
+      "id":"ot-hmAyP66qk2AMVdbJ",
       "type":"oauth-tokens",
       "attributes": {
         "uid":"885724",
@@ -47,13 +47,13 @@ curl \
       "relationships": {
         "oauth-client": {
           "data": {
-            "id":"423",
+            "id":"oc-GhHqb5rkeK19mLB8",
             "type":"oauth-clients"
           }
         }
       },
       "links": {
-        "self":"/api/v2/oauth-tokens/238560"
+        "self":"/api/v2/oauth-tokens/ot-hmAyP66qk2AMVdbJ"
       }
     }
   ]

--- a/content/source/docs/enterprise-beta/api/run.html.md
+++ b/content/source/docs/enterprise-beta/api/run.html.md
@@ -101,7 +101,7 @@ curl \
       "run-events": {...},
       "policy-checks": {...},
       "workspace": {...},
-      "workspace-comments": {...},
+      "comments": {...},
       "workspace-run-alerts": {...}
       }
     },
@@ -211,7 +211,7 @@ curl \
         "plan": {...},
         "run-events": {...},
         "policy-checks": {...},
-        "workspace-comments": {...},
+        "comments": {...},
         "workspace-run-alerts": {...},
       "links": {
         "self": "/api/v2/runs/run-bWSq4YeYpfrW4mx7"

--- a/content/source/docs/enterprise-beta/api/workspaces.html.md
+++ b/content/source/docs/enterprise-beta/api/workspaces.html.md
@@ -43,7 +43,7 @@ This endpoint is used to create a new workspace which references an `oauth-token
       "name":"workspace-demo",
       "working-directory":"",
       "linkable-repo-id":"skierkowski/terraform-test-proj",
-      "oauth-token-id": 7,
+      "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
       "ingress-trigger-attributes": {
         "branch":"",
         "vcs-root-path":"",
@@ -226,7 +226,7 @@ Update the workspace settings
     "attributes": {
       "name":"my-workspace-2",
       "working-directory":"",
-      "oauth-token-id": "238571",
+      "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
       "linkable-repo-id":"skierkowski/terraform-test-proj",
       "ingress-trigger-attributes": {
         "branch":"",

--- a/content/source/docs/enterprise-beta/api/workspaces.html.md
+++ b/content/source/docs/enterprise-beta/api/workspaces.html.md
@@ -15,7 +15,7 @@ Workspaces represent running infrastructure managed by Terraform.
 
 ## Create a Workspace with a VCS Repository
 
-This endpoint is used to create a new workspace which references an `o-auth-token`, `linkable-repo-id` and `ingress-trigger-attributes` to configure the connection to VCS.
+This endpoint is used to create a new workspace which references an `oauth-token`, `linkable-repo-id` and `ingress-trigger-attributes` to configure the connection to VCS.
 
 | Method | Path           |
 | :----- | :------------- |
@@ -26,7 +26,7 @@ This endpoint is used to create a new workspace which references an `o-auth-toke
 ### Parameters
 
 - `:organization` (`string: <required>`) - Specifies the username or organization name under which to create the workspace. The organization must already exist in the system, and the user must have permissions to create new workspaces. This parameter is specified in the URL path.
-- `o-auth-token-id` (`string: <optional>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [o-auth-tokens](./o-auth-tokens.html) endpoint.
+- `oauth-token-id` (`string: <optional>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [oauth-tokens](./oauth-tokens.html) endpoint.
 - `default-branch` (`boolean: true`) - specifies if the default branch should be used.
 - `ingress-submodules` (`boolean: false`) - Specifies whether submodules should be fetched when cloning the VCS repository.
 - `linkable-repo-id` (`string: <optional>`) - This is the reference to your VCS repository in the format :org/:repo where :org and :repo refer to the organization and repository in your VCS provider.
@@ -43,7 +43,7 @@ This endpoint is used to create a new workspace which references an `o-auth-toke
       "name":"workspace-demo",
       "working-directory":"",
       "linkable-repo-id":"skierkowski/terraform-test-proj",
-      "o-auth-token-id": 7,
+      "oauth-token-id": 7,
       "ingress-trigger-attributes": {
         "branch":"",
         "vcs-root-path":"",
@@ -210,7 +210,7 @@ Update the workspace settings
 
 - `:organization` (`string: <required>`) - Specifies the organization name under which to create the workspace. The organization must already exist in the system, and the user must have permissions to create new workspaces. This parameter is specified in the URL path.
 - `:workspace_id` (`string: <required>`) - Specifies the workspace ID to update.
-- `o-auth-token-id` (`string: <optional>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [o-auth-tokens](/docs/enterprise-beta/api/o-auth-tokens.html) endpoint.
+- `oauth-token-id` (`string: <optional>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [oauth-tokens](/docs/enterprise-beta/api/oauth-tokens.html) endpoint.
 - `default-branch` (`boolean: true`) - specifies if the default branch should be used.
 - `ingress-submodules` (`boolean: false`) - Specifies whether submodules should be fetched when cloning the VCS repository.
 - `linkable-repo-id` (`string: <required>`) - This is the reference to your VCS repository in the format :org/:repo
@@ -226,7 +226,7 @@ Update the workspace settings
     "attributes": {
       "name":"my-workspace-2",
       "working-directory":"",
-      "o-auth-token-id": "238571",
+      "oauth-token-id": "238571",
       "linkable-repo-id":"skierkowski/terraform-test-proj",
       "ingress-trigger-attributes": {
         "branch":"",

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -144,8 +144,8 @@
           <li<%= sidebar_current("docs-enterprise2-api-configuration-versions") %>>
             <a href="/docs/enterprise-beta/api/configuration-versions.html">Configuration Versions</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-o-auth-tokens") %>>
-            <a href="/docs/enterprise-beta/api/o-auth-tokens.html">OAuth Tokens</a>
+          <li<%= sidebar_current("docs-enterprise2-api-oauth-tokens") %>>
+            <a href="/docs/enterprise-beta/api/oauth-tokens.html">OAuth Tokens</a>
           </li>
           <li<%= sidebar_current("docs-enterprise2-api-organization-tokens") %>>
             <a href="/docs/enterprise-beta/api/organization-tokens.html">Organization Tokens</a>


### PR DESCRIPTION
Here are a few documentation updates based on recent changes to the Terraform Beta API:

🎉 Instances of `o-auth` have been replaced with `oauth`
✂️ `workspace-comments` has been shortened to `comments`
🆔 `oauth-tokens` and `oauth-clients` have a new ID format