### PR TITLE
Update TFE Docs for GA

### DIFF
--- a/content/source/docs/enterprise-legacy/artifacts/artifact-provider.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/artifact-provider.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Artifact Provider
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Terraform has a [provider](https://terraform.io/docs/providers/index.html) for managing Terraform Enterprise artifacts called `atlas_artifact`.
 
 This is used to make data stored in Artifacts available to Terraform for

--- a/content/source/docs/enterprise-legacy/artifacts/creating-amis.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/creating-amis.html.md
@@ -9,6 +9,8 @@ description: |-
 
 # Creating AMI Artifacts with Packer and Terraform Enterprise
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Currently, the best way to create AWS AMI artifacts is with Packer.
 
 We detail how to do this in the [Packer section of the documentation](/docs/enterprise-legacy/packer/artifacts/creating-amis.html).

--- a/content/source/docs/enterprise-legacy/artifacts/index.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # About Terraform Artifacts
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Terraform Enterprise can be used to store artifacts for use by Terraform.
 Typically, artifacts are [stored with Packer](https://packer.io/docs).
 

--- a/content/source/docs/enterprise-legacy/artifacts/managing-versions.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/managing-versions.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Managing Artifact Versions
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Artifacts stored in Terraform Enterprise are versioned and assigned a version
 number. Versions are useful to roll back, audit and deploy images specific
 versions of images to certain environments in a targeted way.

--- a/content/source/docs/enterprise-legacy/packer/artifacts/creating-amis.html.md
+++ b/content/source/docs/enterprise-legacy/packer/artifacts/creating-amis.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Creating AMI Artifacts with Terraform Enterprise
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 In an immutable infrastructure workflow, it's important to version and store
 full images (artifacts) to be deployed. This section covers storing [AWS
 AMI](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) images in

--- a/content/source/docs/enterprise-legacy/packer/artifacts/creating-vagrant-boxes.html.md
+++ b/content/source/docs/enterprise-legacy/packer/artifacts/creating-vagrant-boxes.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Creating Vagrant Boxes with Packer
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 We recommend using Packer to create boxes, as is it is fully repeatable and
 keeps a strong history of changes within Terraform Enterprise.
 

--- a/content/source/docs/enterprise-legacy/packer/artifacts/index.html.md
+++ b/content/source/docs/enterprise-legacy/packer/artifacts/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # About Packer and Artifacts
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Packer creates and uploads artifacts to Terraform Enterprise. This is done
 with the [post-processor](https://packer.io/docs/post-processors/atlas.html).
 

--- a/content/source/docs/enterprise-legacy/packer/builds/build-environment.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/build-environment.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Packer Build Environment
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 This page outlines the environment that Packer runs in within Terraform
 Enterprise.
 

--- a/content/source/docs/enterprise-legacy/packer/builds/how-builds-run.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/how-builds-run.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # How Packer Builds Run in Terraform Enterprise
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 This briefly covers the internal process of running builds in Terraform
 Enterprise. It's not necessary to know this information, but may be valuable to
 help understand implications of running or debugging failing builds.

--- a/content/source/docs/enterprise-legacy/packer/builds/index.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # About Builds
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Builds are instances of `packer build` being run within Terraform Enterprise.
 Every build belongs to a build configuration.
 

--- a/content/source/docs/enterprise-legacy/packer/builds/installing-software.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/installing-software.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Installing Software
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Please review the [Packer Build Environment](/docs/enterprise-legacy/packer/builds/build-environment.html)
 specification for important information on isolation, security, and hardware
 limitations before continuing.

--- a/content/source/docs/enterprise-legacy/packer/builds/managing-packer-versions.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/managing-packer-versions.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Managing Packer Versions
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Terraform Enterprise does not automatically upgrade the version of Packer used
 to run builds or compiles. This is intentional, as occasionally there can be
 backwards incompatible changes made to Packer that cause templates to stop

--- a/content/source/docs/enterprise-legacy/packer/builds/notifications.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/notifications.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # About Packer Build Notifications
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Terraform Enterprise can send build notifications to your organization for the
 following events:
 

--- a/content/source/docs/enterprise-legacy/packer/builds/rebuilding.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/rebuilding.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Rebuilding Builds
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Sometimes builds fail due to temporary or remotely controlled conditions.
 
 In this case, it may make sense to "rebuild" a Packer build. To do so, visit the

--- a/content/source/docs/enterprise-legacy/packer/builds/scheduling-builds.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/scheduling-builds.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Schedule Periodic Builds in Terraform Enterprise
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Terraform Enterprise can automatically run a Packer build and
 create artifacts on a specified schedule. This option is disabled by default and can be enabled by an
 organization owner on a per-[environment](/docs/enterprise-legacy/glossary#environment) basis.

--- a/content/source/docs/enterprise-legacy/packer/builds/starting.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/starting.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Starting Packer Builds in Terraform Enterprise
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Packer builds can be started in in two ways: `packer push` to upload the
 template and directory or via a GitHub connection that retrieves the contents of
 a repository after changes to the default branch (usually master).

--- a/content/source/docs/enterprise-legacy/packer/builds/troubleshooting.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/troubleshooting.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Troubleshooting Failing Builds
 
+-> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Packer builds can fail in Terraform Enterprise for a number of reasons –
 improper configuration, transient networking errors, and hardware constraints
 are all possible. Below is a list of debugging options you can use.

--- a/content/source/docs/enterprise/index.html.md
+++ b/content/source/docs/enterprise/index.html.md
@@ -6,9 +6,9 @@ description: |-
   Terraform Enterprise is a tool for safely and efficiently changing infrastructure across providers.
 ---
 
-# Terraform Enterprise Beta
+# Terraform Enterprise
 
-This is the documentation for Terraform Enterprise (TFE) Beta. [Terraform Enterprise](https://www.hashicorp.com/products/terraform/) is a product to make
+This is the documentation for Terraform Enterprise (TFE). [Terraform Enterprise](https://www.hashicorp.com/products/terraform/) is a product to make
 it easier for teams to collaborate and govern Terraform changes.
 
 If you are new to TFE, begin with the

--- a/content/source/layouts/enterprise.erb
+++ b/content/source/layouts/enterprise.erb
@@ -5,12 +5,12 @@
         <a class="back" href="/docs/index.html">Documentation Home</a>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise-home") %>>
-        <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (classic)</a>
+      <li<%= sidebar_current("docs-enterprise2-home") %>>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-home") %>>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise (beta)</a>
+      <li<%= sidebar_current("docs-enterprise-home") %>>
+        <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (legacy)</a>
       </li>
 
       <hr>

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -5,12 +5,12 @@
         <a class="back" href="/docs/index.html">Documentation Home</a>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise-home") %>>
-        <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (classic)</a>
+      <li<%= sidebar_current("docs-enterprise2-home") %>>
+        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-home") %>>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise (beta)</a>
+      <li<%= sidebar_current("docs-enterprise-home") %>>
+        <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (legacy)</a>
       </li>
 
       <hr>


### PR DESCRIPTION
This updates the documentation with two main changes per TFE GA:
- Adds a deprecation warning to Packer and Artifact Registry docs
- Renames `classic` to `legacy`