### PR TITLE
Add details/examples for using the Runs API

### DIFF
--- a/content/source/docs/enterprise/workspaces/run-api.html.md
+++ b/content/source/docs/enterprise/workspaces/run-api.html.md
@@ -21,19 +21,20 @@ Once your other tooling has decided a run should occur, it must make a series of
 
 The most significant difference in this workflow is that TFE _does not_ fetch configuration files from version control. Instead, your own tooling must upload the configurations as a `.tar.gz` file. This allows you to work with configurations from unsupported version control systems, automatically generate Terraform configurations from some other source of data, or build a variety of other integrations.
 
-## Pushing a new configuration version
+## Pushing a New Configuration Version
 
-Pushing a new configuration to an existing workspace is a multi step process. These steps will walk through each in detail using bash script as an example.
+Pushing a new configuration to an existing workspace is a multi-step process. These steps will walk through each step in detail, using an example bash script to illustrate.
 
-### 1. Define variables
+### 1. Define Variables
+
 To perform an upload, a few user parameters must be set:
 
-- **path_to_content_directory** is the folder with the terraform configuraiton, it must have a `.tf` file in the root of this path.
+- **path_to_content_directory** is the folder with the terraform configuration. There must be at least one `.tf` file in the root of this path.
 - **organization** is the organization name (not ID) for your Terraform Enterprise organization.
-- **workspace** is the name of the worksace (not ID) in the Terraform Enterprise organization.
-- **$TOKEN** is the environment variable with the API Token used for [authenticating with the TFE API](../api/index.html#authentication).
+- **workspace** is the name of the workspace (not ID) in the Terraform Enterprise organization.
+- **$TOKEN** is the API Token used for [authenticating with the TFE API](../api/index.html#authentication).
 
-This extracts the `path_to_content_directory`, `organization`, and `workspace` from the arguments passed to the script from the command-line.
+This script extracts the `path_to_content_directory`, `organization`, and `workspace` from command line arguments, and expects the `$TOKEN` as an environment variable.
 
 ```bash
 #!/bin/bash
@@ -48,7 +49,8 @@ ORG_NAME="$(cut -d'/' -f1 <<<"$2")"
 WORKSPACE_NAME="$(cut -d'/' -f2 <<<"$2")"
 ```
 
-### 2. Create the file for upload
+### 2. Create the File for Upload
+
 The [configuration version API](../api/configuration-versions.html) expects a tar.gz file to be uploaded, so the configuration directory must be packaged into a tar.gz.
 
 ```bash
@@ -56,9 +58,9 @@ UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
 tar -zcvf $UPLOAD_FILE_NAME $CONTENT_DIRECTORY
 ```
 
-### 3. Look up the Workspace ID
+### 3. Look Up the Workspace ID
 
-The first step identified the organization name and the workspace name; however, the [configuration version API](../api/configuration-versions.html)s expects the workspace ID. As such, the ID has to be looked up. If the workspace ID is already known, this step can be skipped. This step uses the [jq tool](https://stedolan.github.io/jq/) to parse the JSON output and extract the ID value into the `WORKSPACE_ID` variable.
+The first step identified the organization name and the workspace name; however, the [configuration version API](../api/configuration-versions.html) expects the workspace ID. As such, the ID has to be looked up. If the workspace ID is already known, this step can be skipped. This step uses the [`jq` tool](https://stedolan.github.io/jq/) to parse the JSON output and extract the ID value into the `WORKSPACE_ID` variable.
 
 ```bash
 WORKSPACE_ID=($(curl \
@@ -68,9 +70,9 @@ WORKSPACE_ID=($(curl \
   | jq -r '.data.id'))
 ```
 
-### 4. Create a new configuration version
+### 4. Create a New Configuration Version
 
-A `configuration-version` must first be created as a placeholder for the uploaded content to associat with the workspace. This API call performs two tasks, it creates the new configuration version and it extracts the upload URL to be used in the next step.
+Before uploading anything, you must create a `configuration-version` to associate uploaded content with the workspace. This API call performs two tasks: it creates the new configuration version and it extracts the upload URL to be used in the next step.
 
 ```bash
 echo '{"data":{"type":"configuration-version"}}' > ./create_config_version.json
@@ -84,11 +86,11 @@ UPLOAD_URL=($(curl \
   | jq -r '.data.attributes."upload-url"'))
 ```
 
-### 5. Upload the configuration content file
+### 5. Upload the Configuration Content File
 
-This uploads the configuration version tar.gz file to the upload URL extracted from the previous step.
+Next, upload the configuration version tar.gz file to the upload URL extracted from the previous step.
 
-Terraform Enterprise will automatically create a new run with a plan once the new file is uploaded. If the workspace is configured to auto-apply it will also apply if the plan succeeded. An apply can also be triggered via the [Run Apply API](../api/run.html#apply).
+Terraform Enterprise automatically creates a new run with a plan once the new file is uploaded. If the workspace is configured to auto-apply it will also apply if the plan succeeds; otherwise, an apply can be triggered via the [Run Apply API](../api/run.html#apply).
 
 ```bash
 curl \
@@ -97,18 +99,18 @@ curl \
   $UPLOAD_URL
 ```
 
-### 6. Delete the temporary files
+### 6. Delete Temporary Files
 
-In the previous steps a few files were created, they are no longer needed so they should be deleted.
+In the previous steps a few files were created; they are no longer needed so they should be deleted.
 
 ```bash
 rm $UPLOAD_FILE_NAME
 rm ./create_config_version.json
 ```
 
-### Complete script
+### Complete Script
 
-Combine all of the code blocks into a single file, `./terraform-enterprise-push.sh` and give execution permission to create a combined bash script to perform all of the operations. 
+Combine all of the code blocks into a single file, `./terraform-enterprise-push.sh` and give execution permission to create a combined bash script to perform all of the operations.
 
 ```shell
 chmod +x ./terraform-enterprise-push.sh
@@ -117,8 +119,46 @@ chmod +x ./terraform-enterprise-push.sh
 
 **Note**: This script does not have error handling, so for a more robust script consider adding error checking.
 
-### Advanced uses cases
+**`./terraform-enterprise-push.sh`:**
 
-For advanced use cases see the [TFE Automation Script](https://github.com/hashicorp/terraform-guides/tree/master/operations/automation-script) repository for automating interactions with Terraform Enterprise, including the creation of a workspace, uploading TFE code, setting of variables, and triggeirng a plan/apply.
+```bash
+#!/bin/bash
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <path_to_content_directory> <organization>/<workspace>"
+  exit 0
+fi
+
+CONTENT_DIRECTORY=$1
+ORG_NAME="$(cut -d'/' -f1 <<<"$2")"
+WORKSPACE_NAME="$(cut -d'/' -f2 <<<"$2")"
+UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
+tar -zcvf $UPLOAD_FILE_NAME $CONTENT_DIRECTORY
+WORKSPACE_ID=($(curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://atlas.hashicorp.com/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME \
+  | jq -r '.data.id'))
+echo '{"data":{"type":"configuration-version"}}' > ./create_config_version.json
+
+UPLOAD_URL=($(curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @create_config_version.json \
+  https://atlas.hashicorp.com/api/v2/workspaces/$WORKSPACE_ID/configuration-versions \
+  | jq -r '.data.attributes."upload-url"'))
+curl \
+  --request PUT \
+  -F "data=@$UPLOAD_FILE_NAME" \
+  $UPLOAD_URL
+rm $UPLOAD_FILE_NAME
+rm ./create_config_version.json
+
+```
+
+## Advanced Use Cases
+
+For advanced use cases see the [TFE Automation Script](https://github.com/hashicorp/terraform-guides/tree/master/operations/automation-script) repository for automating interactions with Terraform Enterprise, including the creation of a workspace, uploading TFE code, setting of variables, and triggering a plan/apply.
 
 In addition to uploading configurations and starting runs, you can use TFE's APIs to create and modify workspaces, edit variable values, and more. See the [API documentation](../api/index.html) for more details.

--- a/content/source/docs/enterprise/workspaces/run-api.html.md
+++ b/content/source/docs/enterprise/workspaces/run-api.html.md
@@ -17,8 +17,108 @@ In the API-driven workflow, workspaces are not directly associated with a VCS re
 
 Instead, one of your organization's other tools is in charge of deciding when configuration has changed and a run should occur. Usually this is something like a CI system, or something else capable of monitoring changes to your Terraform code and performing actions in response.
 
-Once your other tooling has decided a run should occur, it must make a series of calls to TFE's `runs` and `configuration-versions` APIs to upload configuration files and perform a run with them. For the exact series of API calls, [see the run API documentation.](../api/run.html)
+Once your other tooling has decided a run should occur, it must make a series of calls to TFE's `runs` and `configuration-versions` APIs to upload configuration files and perform a run with them. For the exact series of API calls, see the [pushing a new configuration version](#pushing-a-new-configuration-version) section.
 
 The most significant difference in this workflow is that TFE _does not_ fetch configuration files from version control. Instead, your own tooling must upload the configurations as a `.tar.gz` file. This allows you to work with configurations from unsupported version control systems, automatically generate Terraform configurations from some other source of data, or build a variety of other integrations.
+
+## Pushing a new configuration version
+
+Pushing a new configuration to an existing workspace is a multi step process. These steps will walk through each in detail using bash script as an example.
+
+### 1. Define variables
+To perform an upload, a few user parameters must be set:
+
+- **path_to_content_directory** is the folder with the terraform configuraiton, it must have a `.tf` file in the root of this path.
+- **organization** is the organization name (not ID) for your Terraform Enterprise organization.
+- **workspace** is the name of the worksace (not ID) in the Terraform Enterprise organization.
+- **$TOKEN** is the environment variable with the API Token used for [authenticating with the TFE API](../api/index.html#authentication).
+
+This extracts the `path_to_content_directory`, `organization`, and `workspace` from the arguments passed to the script from the command-line.
+
+```bash
+#!/bin/bash
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <path_to_content_directory> <organization>/<workspace>"
+  exit 0
+fi
+
+CONTENT_DIRECTORY=$1
+ORG_NAME="$(cut -d'/' -f1 <<<"$2")"
+WORKSPACE_NAME="$(cut -d'/' -f2 <<<"$2")"
+```
+
+### 2. Create the file for upload
+The [configuration version API](../api/configuration-versions.html) expects a tar.gz file to be uploaded, so the configuration directory must be packaged into a tar.gz.
+
+```bash
+UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
+tar -zcvf $UPLOAD_FILE_NAME $CONTENT_DIRECTORY
+```
+
+### 3. Look up the Workspace ID
+
+The first step identified the organization name and the workspace name; however, the [configuration version API](../api/configuration-versions.html)s expects the workspace ID. As such, the ID has to be looked up. If the workspace ID is already known, this step can be skipped. This step uses the [jq tool](https://stedolan.github.io/jq/) to parse the JSON output and extract the ID value into the `WORKSPACE_ID` variable.
+
+```bash
+WORKSPACE_ID=($(curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://atlas.hashicorp.com/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME \
+  | jq -r '.data.id'))
+```
+
+### 4. Create a new configuration version
+
+A `configuration-version` must first be created as a placeholder for the uploaded content to associat with the workspace. This API call performs two tasks, it creates the new configuration version and it extracts the upload URL to be used in the next step.
+
+```bash
+echo '{"data":{"type":"configuration-version"}}' > ./create_config_version.json
+
+UPLOAD_URL=($(curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @create_config_version.json \
+  https://atlas.hashicorp.com/api/v2/workspaces/$WORKSPACE_ID/configuration-versions \
+  | jq -r '.data.attributes."upload-url"'))
+```
+
+### 5. Upload the configuration content file
+
+This uploads the configuration version tar.gz file to the upload URL extracted from the previous step.
+
+Terraform Enterprise will automatically create a new run with a plan once the new file is uploaded. If the workspace is configured to auto-apply it will also apply if the plan succeeded. An apply can also be triggered via the [Run Apply API](../api/run.html#apply).
+
+```bash
+curl \
+  --request PUT \
+  -F "data=@$UPLOAD_FILE_NAME" \
+  $UPLOAD_URL
+```
+
+### 6. Delete the temporary files
+
+In the previous steps a few files were created, they are no longer needed so they should be deleted.
+
+```bash
+rm $UPLOAD_FILE_NAME
+rm ./create_config_version.json
+```
+
+### Complete script
+
+Combine all of the code blocks into a single file, `./terraform-enterprise-push.sh` and give execution permission to create a combined bash script to perform all of the operations. 
+
+```shell
+chmod +x ./terraform-enterprise-push.sh
+./terraform-enterprise-push.sh ./content my-organization/my-workspace
+```
+
+**Note**: This script does not have error handling, so for a more robust script consider adding error checking.
+
+### Advanced uses cases
+
+For advanced use cases see the [TFE Automation Script](https://github.com/hashicorp/terraform-guides/tree/master/operations/automation-script) repository for automating interactions with Terraform Enterprise, including the creation of a workspace, uploading TFE code, setting of variables, and triggeirng a plan/apply.
 
 In addition to uploading configurations and starting runs, you can use TFE's APIs to create and modify workspaces, edit variable values, and more. See the [API documentation](../api/index.html) for more details.


### PR DESCRIPTION
This adds a step-by-step example of using bash to automate the process of pushing a new configuration to start a new run on a workspace.