### PR TITLE
Mention that repos are only settable on workspace initial config

### DIFF
--- a/content/source/docs/enterprise/getting-started/workspaces.html.md
+++ b/content/source/docs/enterprise/getting-started/workspaces.html.md
@@ -52,6 +52,8 @@ The "repository" field is linked to data from your VCS service. You can start ty
 
 In this example, we're using the `nfagerlund/terraform-minimum` repo.
 
+~> **Note**: the repository a workspace is associated with can't be changed after it's initially set.
+
 ### Other Settings
 
 Optionally, you can set three other settings for a new workspace:

--- a/content/source/docs/enterprise/vcs/index.html.md
+++ b/content/source/docs/enterprise/vcs/index.html.md
@@ -20,6 +20,8 @@ To use configurations from VCS, TFE needs to do several things:
 - Register webhooks with your VCS provider, to get notified of new commits to a chosen branch.
 - Download the contents of a repository at a specific commit in order to run Terraform with that code.
 
+~> **Important:** Repo connections are only configured when creating or initially configuring new workspaces; the repo for a workspace can't be updated.
+
 ### Webhooks
 
 TFE uses webhooks to monitor new commits and pull requests.

--- a/content/source/docs/enterprise/workspaces/settings.html.md
+++ b/content/source/docs/enterprise/workspaces/settings.html.md
@@ -6,7 +6,7 @@ sidebar_current: "docs-enterprise2-workspaces-settings"
 
 # Workspace Settings
 
-Terraform Enterprise lets you customize workspaces with the following settings:
+In Terraform Enterprise, the workspace's associated repository can only be configured once; it can't be changed at a later date. The following settings are customizable at any point:
 
 ## Terraform Working Directory
 


### PR DESCRIPTION
Adds mentions in a few different places that the repo that a workspace is connected to can only be set once. This is a change from TFE legacy but wasn't explicitly mentioned.