### PR TITLE
Fix broken link to the migrated tfplan docs

### DIFF
--- a/content/source/docs/enterprise/sentinel/enforce.html.md
+++ b/content/source/docs/enterprise/sentinel/enforce.html.md
@@ -8,7 +8,7 @@ sidebar_current: "docs-enterprise2-sentinel-enforce"
 
 Once a policy is added to an organization it is enforced on all runs.
 
-The policy check will occur immediately after a plan is successfully executed in the run. If the plan fails, the policy check will not be performed. The policy check uses the generated tfplan file, [simulated apply object](https://docs.hashicorp.com/sentinel/app/terraform/import-tfplan#resource-applied-field), state and configuration to verify the rules in each of the policies.
+The policy check will occur immediately after a plan is successfully executed in the run. If the plan fails, the policy check will not be performed. The policy check uses the generated tfplan file, [simulated apply object](./import/tfplan.html#resource-applied-field), state and configuration to verify the rules in each of the policies.
 
 Enforcement level details can be found in the [Managing Policies](./manage-policies.html) documentation.
 


### PR DESCRIPTION
One of the links broken because the content was migrated. This updates the link to the new location.