### PR TITLE
Fix tar to change into config directory

### DIFF
--- a/content/source/docs/enterprise/workspaces/run-api.html.md
+++ b/content/source/docs/enterprise/workspaces/run-api.html.md
@@ -53,6 +53,8 @@ WORKSPACE_NAME="$(cut -d'/' -f2 <<<"$2")"
 
 The [configuration version API](../api/configuration-versions.html) expects a tar.gz file to be uploaded, so the configuration directory must be packaged into a tar.gz.
 
+~> **Important:** The configuration directory must be the root of the tar file, with no intermediate directories. In other words, when the tar file is extracted the result must be paths like `./main.tf` rather than `./terraform-appserver/main.tf`.
+
 ```bash
 UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
 tar cvzf $UPLOAD_FILE_NAME -C $CONTENT_DIRECTORY .

--- a/content/source/docs/enterprise/workspaces/run-api.html.md
+++ b/content/source/docs/enterprise/workspaces/run-api.html.md
@@ -55,7 +55,7 @@ The [configuration version API](../api/configuration-versions.html) expects a ta
 
 ```bash
 UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
-tar -zcvf $UPLOAD_FILE_NAME $CONTENT_DIRECTORY
+tar cvzf $UPLOAD_FILE_NAME -C $CONTENT_DIRECTORY .
 ```
 
 ### 3. Look Up the Workspace ID


### PR DESCRIPTION
The generated archive must not package the config directory but rather the files inside the config directory. The output of `tar tvzf my-configuration.tar.gz` should be something like this:

```
drwxr-xr-x  0 dan    staff       0  5 Feb 16:50 ./
-rw-r--r--  0 dan    staff      76 29 Jan 21:12 ./.gitignore
-rw-r--r--  0 dan    staff   16725 29 Jan 21:12 ./LICENSE
-rw-r--r--  0 dan    staff      32 30 Jan 08:35 ./main.tf
-rw-r--r--  0 dan    staff      98 30 Jan 09:59 ./outputs.tf
-rw-r--r--  0 dan    staff      12 29 Jan 21:12 ./README.md
-rw-r--r--  0 dan    staff       1 30 Jan 09:03 ./variables.tf
```

not this:

```
drwxr-xr-x  0 dan    staff       0  5 Feb 16:50 my-configuration/
-rw-r--r--  0 dan    staff      76 29 Jan 21:12 my-configuration/.gitignore
-rw-r--r--  0 dan    staff   16725 29 Jan 21:12 my-configuration/LICENSE
-rw-r--r--  0 dan    staff      32 30 Jan 08:35 my-configuration/main.tf
-rw-r--r--  0 dan    staff      98 30 Jan 09:59 my-configuration/outputs.tf
-rw-r--r--  0 dan    staff      12 29 Jan 21:12 my-configuration/README.md
-rw-r--r--  0 dan    staff       1 30 Jan 09:03 my-configuration/variables.tf
```

Thanks,
Dan
 