### PR TITLE
Updating GH and GHE pages about private forks

### DIFF
--- a/content/source/docs/enterprise/vcs/github-enterprise.html.md
+++ b/content/source/docs/enterprise/vcs/github-enterprise.html.md
@@ -96,7 +96,7 @@ The rest of this page explains the GitHub Enterprise versions of these steps.
 
     This takes you to a page on github.com, asking whether you want to authorize the app.
 
-2. The authorization page lists any GitHub organizations this account belongs to. If there is a "Request" button next to the organization that owns your Terraform code repositories, click it now.
+2. The authorization page lists any GitHub organizations this account belongs to. If there is a "Request" button next to the organization that owns your Terraform code repositories, click it now. Note that you need to do this even if you are only connecting workspaces to private forks of repositories in those organizations since those forks are subject to the organization's access restrictions.  See [About OAuth App access restrictions](https://help.github.com/articles/about-oauth-app-access-restrictions).
 
     ![GitHub screenshot: the authorization screen](./images/gh-authorize.png)
 

--- a/content/source/docs/enterprise/vcs/github.html.md
+++ b/content/source/docs/enterprise/vcs/github.html.md
@@ -89,7 +89,7 @@ The rest of this page explains the GitHub versions of these steps.
 
     This takes you to a page on github.com, asking whether you want to authorize the app.
 
-2. The authorization page lists any GitHub organizations this account belongs to. If there is a "Request" button next to the organization that owns your Terraform code repositories, click it now.
+2. The authorization page lists any GitHub organizations this account belongs to. If there is a "Request" button next to the organization that owns your Terraform code repositories, click it now. Note that you need to do this even if you are only connecting workspaces to private forks of repositories in those organizations since those forks are subject to the organization's access restrictions.  See [About OAuth App access restrictions](https://help.github.com/articles/about-oauth-app-access-restrictions).
 
     ![GitHub screenshot: the authorization screen](./images/gh-authorize.png)
 


### PR DESCRIPTION
I learned today while helping a customer that an OAuth app in Github needs access to the parent organization of a private fork of a repository in that organization.  I also found a Github page that explains why: https://help.github.com/articles/about-oauth-app-access-restrictions.

So, I added comment to the Github.com and GHE VCS pages indicating that users need to request access to the parent orgs when using private forks and included a link to that URL.

My customer could not create a workspace in his org until he re-created the OAuth client and requested and received access from the parent org of the private fork he had created in a separate org.