### PR TITLE
Update TFE SaaS hostname to app.terraform.io

### DIFF
--- a/content/source/docs/enterprise/api/configuration-versions.html.md
+++ b/content/source/docs/enterprise/api/configuration-versions.html.md
@@ -38,7 +38,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/workspaces/ws-2Qhk7LHgbMrm3grF/configuration-versions
+  https://app.terraform.io/api/v2/workspaces/ws-2Qhk7LHgbMrm3grF/configuration-versions
 ```
 
 ### Sample Response

--- a/content/source/docs/enterprise/api/modules.html.md
+++ b/content/source/docs/enterprise/api/modules.html.md
@@ -40,7 +40,7 @@ The same request for the same module and provider on the TFE module registry for
 ```shell
 $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
-  https://atlas.hashicorp.com/api/registry/v1/modules/my-tfe-org/consul/aws/versions
+  https://app.terraform.io/api/registry/v1/modules/my-tfe-org/consul/aws/versions
 ```
 
 
@@ -80,7 +80,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/registry-modules
+  https://app.terraform.io/api/v2/registry-modules
 ```
 
 ### Sample Response
@@ -142,5 +142,5 @@ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  https://atlas.hashicorp.com/api/v2/registry-modules/actions/delete/skierkowski-v2/instance
+  https://app.terraform.io/api/v2/registry-modules/actions/delete/skierkowski-v2/instance
 ```

--- a/content/source/docs/enterprise/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise/api/oauth-tokens.html.md
@@ -27,7 +27,7 @@ List all the OAuth Tokens for a given organization
 ```shell
 curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/oauth-tokens
+  https://app.terraform.io/api/v2/organizations/my-organization/oauth-tokens
 ```
 
 ### Sample Response

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -27,7 +27,7 @@ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/authentication-token
+  https://app.terraform.io/api/v2/organizations/my-organization/authentication-token
 ```
 
 ### Sample Response
@@ -72,5 +72,5 @@ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/authentication-token
+  https://app.terraform.io/api/v2/organizations/my-organization/authentication-token
 ```

--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -53,7 +53,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/policies
+  https://app.terraform.io/api/v2/organizations/my-organization/policies
 ```
 
 ### Sample Response
@@ -110,7 +110,7 @@ curl \
   --header "Content-Type: application/octet-stream" \
   --request PUT \
   --data-binary @payload.sentinel \
-  https://atlas.hashicorp.com/api/v2/policy/pol-u3S5p2Uwk21keu1s/upload
+  https://app.terraform.io/api/v2/policy/pol-u3S5p2Uwk21keu1s/upload
 ```
 
 
@@ -153,7 +153,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/policy/pol-u3S5p2Uwk21keu1s
+  https://app.terraform.io/api/v2/policy/pol-u3S5p2Uwk21keu1s
 ```
 
 ### Sample Response
@@ -199,7 +199,7 @@ List all the policies for a given organization
 ```shell
 curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/policies
+  https://app.terraform.io/api/v2/organizations/my-organization/policies
 ```
 
 ### Sample Response
@@ -246,6 +246,6 @@ curl \
 curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --request DELETE \
-  https://atlas.hashicorp.com/api/v2/policies/pl-u3S5p2Uwk21keu1s
+  https://app.terraform.io/api/v2/policies/pl-u3S5p2Uwk21keu1s
 ```
 

--- a/content/source/docs/enterprise/api/policy-checks.html.md
+++ b/content/source/docs/enterprise/api/policy-checks.html.md
@@ -25,7 +25,7 @@ This endpoint lists the policy checks in a run.
 ```shell
 curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
-  https://atlas.hashicorp.com/api/v2/runs/run-CZcmD7eagjhyXavN/policy-checks
+  https://app.terraform.io/api/v2/runs/run-CZcmD7eagjhyXavN/policy-checks
 ```
 
 ### Sample Response
@@ -117,7 +117,7 @@ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  https://atlas.hashicorp.com/api/v2/policy-checks/polchk-EasPB4Srx5NAiWAU/actions/override
+  https://app.terraform.io/api/v2/policy-checks/polchk-EasPB4Srx5NAiWAU/actions/override
 ```
 
 ### Sample Response

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -67,7 +67,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/runs
+  https://app.terraform.io/api/v2/runs
 ```
 
 ### Sample Response
@@ -152,7 +152,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/runs/run-DQGdmrWMX8z9yWQB/actions/apply
+  https://app.terraform.io/api/v2/runs/run-DQGdmrWMX8z9yWQB/actions/apply
 ```
 
 
@@ -174,7 +174,7 @@ This endpoint lists the runs in a workspace
 curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-  https://atlas.hashicorp.com/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs
+  https://app.terraform.io/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs
 ```
 
 ### Sample Response

--- a/content/source/docs/enterprise/api/team-access.html.md
+++ b/content/source/docs/enterprise/api/team-access.html.md
@@ -27,7 +27,7 @@ $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request GET \
-  https://atlas.hashicorp.com/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-5vBKrazjYR36gcYX
+  https://app.terraform.io/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-5vBKrazjYR36gcYX
 ```
 
 ### Sample Response
@@ -116,7 +116,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/team-workspaces
+  https://app.terraform.io/api/v2/team-workspaces
 ```
 
 ### Sample Response
@@ -173,7 +173,7 @@ $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request GET \
-  https://atlas.hashicorp.com/api/v2/team-workspaces/257525
+  https://app.terraform.io/api/v2/team-workspaces/257525
 ```
 
 ### Sample Response
@@ -205,6 +205,6 @@ $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://atlas.hashicorp.com/api/v2/team-workspaces/257525
+  https://app.terraform.io/api/v2/team-workspaces/257525
 ```
 

--- a/content/source/docs/enterprise/api/team-members.html.md
+++ b/content/source/docs/enterprise/api/team-members.html.md
@@ -41,7 +41,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/teams/257525/relationships/users
+  https://app.terraform.io/api/v2/teams/257525/relationships/users
 ```
 
 
@@ -76,5 +76,5 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/teams/257525/relationships/users
+  https://app.terraform.io/api/v2/teams/257525/relationships/users
 ```

--- a/content/source/docs/enterprise/api/team-tokens.html.md
+++ b/content/source/docs/enterprise/api/team-tokens.html.md
@@ -27,7 +27,7 @@ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  https://atlas.hashicorp.com/api/v2/teams/team-BUHBEM97xboT8TVz/authentication-token
+  https://app.terraform.io/api/v2/teams/team-BUHBEM97xboT8TVz/authentication-token
 ```
 
 ### Sample Response
@@ -72,5 +72,5 @@ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://atlas.hashicorp.com/api/v2/teams/team-BUHBEM97xboT8TVz/authentication-token
+  https://app.terraform.io/api/v2/teams/team-BUHBEM97xboT8TVz/authentication-token
 ```

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -42,7 +42,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/teams
+  https://app.terraform.io/api/v2/organizations/my-organization/teams
 ```
 
 
@@ -86,5 +86,5 @@ $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://atlas.hashicorp.com/api/v2/teams/257529
+  https://app.terraform.io/api/v2/teams/257529
 ```

--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -60,7 +60,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/vars
+  https://app.terraform.io/api/v2/vars
 ```
 
 ### Sample Response
@@ -112,7 +112,7 @@ curl \
 $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-https://atlas.hashicorp.com/api/v2/vars?filter%5Borganization%5D%5Busername%5D=my-organization&filter%5Bworkspace%5D%5Bname%5D=my-workspace
+https://app.terraform.io/api/v2/vars?filter%5Borganization%5D%5Busername%5D=my-organization&filter%5Bworkspace%5D%5Bname%5D=my-workspace
 # ?filter[organization][username]=my-organization&filter[workspace][name]=demo01
 ```
 
@@ -185,7 +185,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/vars/var-yRmifb4PJj7cLkMG
+  https://app.terraform.io/api/v2/vars/var-yRmifb4PJj7cLkMG
 ```
 
 ### Sample Response

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -63,7 +63,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/compound-workspaces
+  https://app.terraform.io/api/v2/compound-workspaces
 ```
 
 ### Sample Response
@@ -155,7 +155,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/workspaces
+  https://app.terraform.io/api/v2/organizations/my-organization/workspaces
 ```
 
 ### Sample Response
@@ -248,7 +248,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
-  https://atlas.hashicorp.com/api/v2/compound-workspaces/ws-erEAnPmgtm5mJr77
+  https://app.terraform.io/api/v2/compound-workspaces/ws-erEAnPmgtm5mJr77
 ```
 
 ### Sample Response
@@ -313,7 +313,7 @@ This endpoint lists workspaces in the organization.
 $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/workspaces
+  https://app.terraform.io/api/v2/organizations/my-organization/workspaces
 ```
 
 ### Sample Response
@@ -420,5 +420,5 @@ $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://atlas.hashicorp.com/api/v2/organizations/my-organization/workspaces/my-workspace
+  https://app.terraform.io/api/v2/organizations/my-organization/workspaces/my-workspace
 ```

--- a/content/source/docs/enterprise/getting-started/access.html.md
+++ b/content/source/docs/enterprise/getting-started/access.html.md
@@ -25,7 +25,7 @@ If you don't already have a TFE account, you must create one. You can use the sa
 
 In your web browser, go to:
 
-- [atlas.hashicorp.com](https://atlas.hashicorp.com) if you've registered for the SaaS version of TFE.
+- [app.terraform.io](https://app.terraform.io) if you've registered for the SaaS version of TFE.
 - The hostname of your private instance if you're using private Terraform Enterprise.
 
 ## Creating an Organization

--- a/content/source/docs/enterprise/registry/using.html.md
+++ b/content/source/docs/enterprise/registry/using.html.md
@@ -11,7 +11,7 @@ sidebar_current: "docs-enterprise2-registry-using"
 By design, Terraform Enterprise (TFE)'s private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already familiar with the public registry, here are the main differences:
 
 - Use TFE's web UI to browse and search for modules.
-- Module `source` strings are slightly different. The public registry uses a three-part `<NAMESPACE>/<MODULE NAME>/<PROVIDER>` format, and private modules use a four-part `<TFE HOSTNAME>/<TFE ORGANIZATION>/<MODULE NAME>/<PROVIDER>` format. (Also, see [Note About Hostnames below](#note-about-hostnames).) For example, to load a module from the `example_corp` organization on the SaaS version of TFE:
+- Module `source` strings are slightly different. The public registry uses a three-part `<NAMESPACE>/<MODULE NAME>/<PROVIDER>` format, and private modules use a four-part `<TFE HOSTNAME>/<TFE ORGANIZATION>/<MODULE NAME>/<PROVIDER>` format. For example, to load a module from the `example_corp` organization on the SaaS version of TFE:
 
     ```hcl
     module "vpc" {
@@ -59,12 +59,6 @@ If you're using the SaaS version of TFE, the hostname is `app.terraform.io`; pri
 
 For more details on using modules in Terraform configurations, see ["Using Modules" in the Terraform docs.](/docs/modules/usage.html)
 
-### Note About Hostnames
-
-`app.terraform.io` is the future hostname for the SaaS version of Terraform Enterprise, and `atlas.hashicorp.com` is the current hostname. Right now, **you can safely use either hostname** for private modules, since `app.terraform.io` is already forwarding API calls and `atlas.hashicorp.com` will redirect API calls for a long time after we complete the hostname change.
-
-Since changing the hostname across all your Terraform configurations would be annoying, we recommend using `app.terraform.io` for private modules immediately, even though the hostname change isn't complete yet. It will make your configurations more confusing for a little while, but will save you effort in the long run.
-
 ### Usage Examples and the Configuration Designer
 
 Each registry page for a module version includes a usage example, which you can copy and paste to get started.
@@ -91,7 +85,7 @@ credentials "app.terraform.io" {
 }
 ```
 
-The block label for the `credentials` block must be TFE's hostname (`app.terraform.io`, `atlas.hashicorp.com`, or the hostname of your private install), and the block body must contain a `token` attribute whose value is a TFE authentication token. You can generate a personal API token from your user settings page in TFE.
+The block label for the `credentials` block must be TFE's hostname (`app.terraform.io` or the hostname of your private install), and the block body must contain a `token` attribute whose value is a TFE authentication token. You can generate a personal API token from your user settings page in TFE.
 
 Make sure the hostname matches the hostname you use in module sources — if the same TFE server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, you can add two `credentials` blocks with the same `token`.
 

--- a/content/source/docs/enterprise/users-teams-organizations/organizations.html.md
+++ b/content/source/docs/enterprise/users-teams-organizations/organizations.html.md
@@ -13,5 +13,5 @@ which workspaces.
 If you navigate to TFE before you're a member of any organizations, you'll be asked to create one. You can also create a new organization at any time by going to an existing organization's settings, then clicking the "Create new organization" button in the sidebar navigation.
 
 Invite users to join an organization by sending them the
-[signup link](https://atlas.hashicorp.com/account/new) and then adding them to a
+[signup link](https://app.terraform.io/account/new) and then adding them to a
 [team](./teams.html).

--- a/content/source/docs/enterprise/users-teams-organizations/users.html.md
+++ b/content/source/docs/enterprise/users-teams-organizations/users.html.md
@@ -6,7 +6,7 @@ sidebar_current: "docs-enterprise2-users-teams-organizations-users"
 
 # Users
 
-Users are individual members of an organization. Users must first [create an account](https://atlas.hashicorp.com/account/new) in Terraform Enterprise before
+Users are individual members of an organization. Users must first [create an account](https://app.terraform.io/account/new) in Terraform Enterprise before
 they can be added to an organization.
 
 ## Team and Organization Membership

--- a/content/source/docs/enterprise/vcs/bitbucket-cloud.html.md
+++ b/content/source/docs/enterprise/vcs/bitbucket-cloud.html.md
@@ -46,7 +46,7 @@ The rest of this page explains the Bitbucket Cloud-specific versions of these st
     Name             | Terraform Enterprise (`<YOUR ORGANIZATION NAME>`)
     Description      | Any description of your choice.
     Callback URL     | `https://example.com/replace-this-later` (or any placeholder; the correct URI doesn't exist until the next step.)
-    URL              | `https://atlas.hashicorp.com` (or the URL of your private TFE install)
+    URL              | `https://app.terraform.io` (or the URL of your private TFE install)
 
     Ensure that the "This is a private consumer" option is checked. Then, activate the following permissions checkboxes:
 

--- a/content/source/docs/enterprise/vcs/bitbucket-server.html.md
+++ b/content/source/docs/enterprise/vcs/bitbucket-server.html.md
@@ -55,9 +55,9 @@ Leave the page open in a browser tab, and remain logged in as an admin user.
 
     ![Bitbucket Server screenshot: The application links page](./images/bitbucket-server-application-links.png)
 
-2. Enter TFE's URL in the text field (`https://atlas.hashicorp.com`, or the hostname of your private TFE instance) and click the "Create new link" button.
+2. Enter TFE's URL in the text field (`https://app.terraform.io`, or the hostname of your private TFE instance) and click the "Create new link" button.
 
-    ~> **Note:** If you're connecting multiple TFE organizations to the same Bitbucket Server instance, you can only use TFE's main URL once. For subsequent organizations, you can enter the organization URL instead. Organization URLs look like `https://atlas.hashicorp.com/app/<ORG NAME>` or `https://<TFE HOSTNAME>/app/<ORG NAME>` — it's the page TFE's "Workspaces" button takes you to.
+    ~> **Note:** If you're connecting multiple TFE organizations to the same Bitbucket Server instance, you can only use TFE's main URL once. For subsequent organizations, you can enter the organization URL instead. Organization URLs look like `https://app.terraform.io/app/<ORG NAME>` or `https://<TFE HOSTNAME>/app/<ORG NAME>` — it's the page TFE's "Workspaces" button takes you to.
 
 3. In the "Configure application URL" dialog, confirm that you wish to use the URL exactly as you entered it. If you used TFE's main URL, click "Continue;" if you used an organization URL, click the "Use this URL" checkbox and then click "Continue."
 

--- a/content/source/docs/enterprise/vcs/github-enterprise.html.md
+++ b/content/source/docs/enterprise/vcs/github-enterprise.html.md
@@ -42,7 +42,7 @@ The rest of this page explains the GitHub Enterprise versions of these steps.
     Field name                 | Value
     ---------------------------|--------------------------------------------------
     Application Name           | Terraform Enterprise (`<YOUR ORGANIZATION NAME>`)
-    Homepage URL               | `https://atlas.hashicorp.com` (or the URL of your private TFE install)
+    Homepage URL               | `https://app.terraform.io` (or the URL of your private TFE install)
     Application Description    | Any description of your choice.
     Authorization callback URL | `https://example.com/replace-this-later` (or any placeholder; the correct URI doesn't exist until the next step.)
 

--- a/content/source/docs/enterprise/vcs/github.html.md
+++ b/content/source/docs/enterprise/vcs/github.html.md
@@ -42,7 +42,7 @@ The rest of this page explains the GitHub versions of these steps.
     Field name                 | Value
     ---------------------------|--------------------------------------------------
     Application Name           | Terraform Enterprise (`<YOUR ORGANIZATION NAME>`)
-    Homepage URL               | `https://atlas.hashicorp.com` (or the URL of your private TFE install)
+    Homepage URL               | `https://app.terraform.io` (or the URL of your private TFE install)
     Application Description    | Any description of your choice.
     Authorization callback URL | `https://example.com/replace-this-later` (or any placeholder; the correct URI doesn't exist until the next step.)
 

--- a/content/source/docs/enterprise/workspaces/run-api.html.md
+++ b/content/source/docs/enterprise/workspaces/run-api.html.md
@@ -66,7 +66,7 @@ The first step identified the organization name and the workspace name; however,
 WORKSPACE_ID=($(curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-  https://atlas.hashicorp.com/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME \
+  https://app.terraform.io/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME \
   | jq -r '.data.id'))
 ```
 
@@ -82,7 +82,7 @@ UPLOAD_URL=($(curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @create_config_version.json \
-  https://atlas.hashicorp.com/api/v2/workspaces/$WORKSPACE_ID/configuration-versions \
+  https://app.terraform.io/api/v2/workspaces/$WORKSPACE_ID/configuration-versions \
   | jq -r '.data.attributes."upload-url"'))
 ```
 
@@ -137,7 +137,7 @@ tar -zcvf $UPLOAD_FILE_NAME $CONTENT_DIRECTORY
 WORKSPACE_ID=($(curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-  https://atlas.hashicorp.com/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME \
+  https://app.terraform.io/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME \
   | jq -r '.data.id'))
 echo '{"data":{"type":"configuration-version"}}' > ./create_config_version.json
 
@@ -146,7 +146,7 @@ UPLOAD_URL=($(curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @create_config_version.json \
-  https://atlas.hashicorp.com/api/v2/workspaces/$WORKSPACE_ID/configuration-versions \
+  https://app.terraform.io/api/v2/workspaces/$WORKSPACE_ID/configuration-versions \
   | jq -r '.data.attributes."upload-url"'))
 curl \
   --request PUT \


### PR DESCRIPTION
This commit also deletes a longer note about hostnames; now that the new
hostname is visible and official, we don't need any extra explanation of why to
use it for private modules. Hopefully anyone who used private modules in the
intervening weeks is good to go, and new users won't be tempted to use the old
name.