### PR TITLE
Update API documentation for new structure of possible actions

### DIFF
--- a/content/source/docs/enterprise/api/policy-checks.html.md
+++ b/content/source/docs/enterprise/api/policy-checks.html.md
@@ -88,7 +88,12 @@ curl \
           "queued-at": "2017-11-29T20:02:17+00:00",
           "soft-failed-at": "2017-11-29T20:02:20+00:00"
         },
-        "may-override": false
+        "actions": {
+          "is-overridable": true
+        },
+        "permissions": {
+          "can-override": false
+        }
       },
       "links": {
         "output": "/api/v2/policy-checks/polchk-9VYRc9bpfJEsnwum/output"
@@ -180,7 +185,12 @@ curl \
         "soft-failed-at": "2017-11-29T20:13:40+00:00",
         "overridden-at": "2017-11-29T20:14:11+00:00"
       },
-      "may-override": false
+      "actions": {
+        "is-overridable": true
+      },
+      "permissions": {
+        "can-override": false
+      }
     },
     "links": {
       "output": "/api/v2/policy-checks/polchk-EasPB4Srx5NAiWAU/output"

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -88,10 +88,12 @@ curl \
       "status-timestamps": {},
       "terraform-version": "0.10.8",
       "created-at": "2017-11-29T19:56:15.205Z",
-      "may-canceled": true,
-      "may-confirm": false,
-      "may-discarded": false,
       "has-changes": false,
+      "actions": {
+        "is-cancelable": true,
+        "is-confirmable": false,
+        "is-discardable": false,
+      },
       "permissions": {
         "can-apply": true,
         "can-cancel": true,
@@ -198,10 +200,12 @@ curl \
         },
         "terraform-version": "0.11.0",
         "created-at": "2017-11-28T22:52:46.711Z",
-        "may-canceled": false,
-        "may-confirm": true,
-        "may-discarded": true,
         "has-changes": true,
+        "actions": {
+          "is-cancelable": false,
+          "is-confirmable": true,
+          "is-discardable": true,
+        },
         "permissions": {
           "can-apply": true,
           "can-cancel": true,


### PR DESCRIPTION
We're changing the way how possibly actions on a Run or Policy Check are returned from the API, so this documentation keeps us in line with a change that's incoming today.