### PR TITLE
TFE API workspace SSH key association/dissociation

### DIFF
--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -1,0 +1,217 @@
+---
+layout: enterprise2
+page_title: "SSH Keys - API Docs - Terraform Enterprise"
+sidebar_current: "docs-enterprise2-api-ssh-keys"
+---
+
+# SSH Keys
+
+-> **Note**: These API endpoints are in beta and are subject to change.
+
+The `ssh-key` object represents an SSH key which includes a name and the SSH private key. This object is used to clone Terraform modules at the organization level, and allows multiple keys to be added for the organization. You can also easily use them in any [workspace](./workspaces.html#assign-an-ssh-key-to-a-workspace) that clones modules from a Git server.
+
+## List SSH Keys
+
+List all the SSH Keys for a given organization
+
+| Method | Path           |
+| :----- | :------------- |
+| GET | /organizations/:organization_name/ssh-keys |
+
+### Parameters
+
+- `:organization_name` (`string: <required>`) - specifies the organization name where the SSH Keys are defined
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  https://app.terraform.io/api/v2/organizations/my-organization/ssh-keys
+```
+
+### Sample Response
+
+```json
+{
+  "data": [
+    {
+      "attributes": {
+        "name": "SSH Key"
+      },
+      "id": "sshkey-GxrePWre1Ezug7aM",
+      "links": {
+        "self": "/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM"
+      },
+      "type": "ssh-keys"
+    }
+  ]
+}
+```
+
+
+## Get an SSH Key
+
+Get an SSH Key
+
+| Method | Path           |
+| :----- | :------------- |
+| GET | /ssh-keys/:ssh_key_id |
+
+### Parameters
+
+- `:ssh_key_id` (`string: <required>`) - specifies the SSH key ID to get
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  https://app.terraform.io/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "name": "SSH Key"
+    },
+    "id": "sshkey-GxrePWre1Ezug7aM",
+    "links": {
+      "self": "/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM"
+    },
+    "type": "ssh-keys"
+  }
+}
+```
+
+## Create an SSH Key
+
+Create an SSH Key
+
+| Method | Path           |
+| :----- | :------------- |
+| POST | /organizations/:organization_name/ssh-keys |
+
+### Parameters
+
+- `:organization_name` (`string: <required>`) - specifies the organization name where the SSH keys are defined
+- `name` (`string: <required>`) - specifies the name of the SSH key
+- `value` (`string: <required>`) - specifies the text of the SSH private key
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "attributes": {
+      "name": "SSH Key",
+      "value": "..."
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/organizations/my-organization/ssh-keys
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "name": "SSH Key"
+    },
+    "id": "sshkey-GxrePWre1Ezug7aM",
+    "links": {
+      "self": "/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM"
+    },
+    "type": "ssh-keys"
+  }
+}
+```
+
+
+## Update an SSH Key
+
+Update an SSH Key
+
+| Method | Path           |
+| :----- | :------------- |
+| PATCH | /ssh-keys/:ssh_key_id |
+
+### Parameters
+
+- `:ssh_key_id` (`string: <required>`) - specifies the SSH key ID to update
+- `name` (`string: <required>`) - specifies the name of the SSH key
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "attributes": {
+      "name": "SSH Key for GitHub"
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --request PATCH \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "name": "SSH Key for GitHub"
+    },
+    "id": "sshkey-GxrePWre1Ezug7aM",
+    "links": {
+      "self": "/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM"
+    },
+    "type": "ssh-keys"
+  }
+}
+```
+
+
+## Delete an SSH Key
+
+Delete an SSH Key
+
+| Method | Path           |
+| :----- | :------------- |
+| DELETE | /ssh-keys/:ssh_key_id |
+
+### Parameters
+
+- `:ssh_key_id` (`string: <required>`) - specifies the SSH key ID to delete
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --request DELETE \
+  https://app.terraform.io/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM
+```

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -553,3 +553,172 @@ $ curl \
   }
 }
 ```
+
+
+## Associate an SSH key to a workspace
+
+This endpoint associates an SSH key to a workspace.
+
+| Method | Path           |
+| :----- | :------------- |
+| PATCH | /workspaces/:workspace_id/relationships/ssh-key |
+
+### Parameters
+
+* `:workspace_id` (`string: <required>`) - Specifies the workspace ID to associate the SSH key to.
+* `id` (`string: <required>`) - Specifies the SSH key ID to associate.
+
+#### Sample Payload
+
+```json
+{
+  "data":
+  {
+    "attributes": {
+      "id":"sshkey-GxrePWre1Ezug7aM"
+    },
+    "type":"workspaces"
+  }
+}
+```
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/workspaces/ws-erEAnPmgtm5mJr77/relationships/ssh-key
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "auto-apply": false,
+      "can-queue-destroy-plan": false,
+      "created-at": "2017-11-02T23:24:05.997Z",
+      "environment": "default",
+      "ingress-trigger-attributes": {
+        "branch": "",
+        "default-branch": true,
+        "ingress-submodules": false
+      },
+      "locked": false,
+      "name": "my-workspace-2",
+      "terraform-version": "0.10.8",
+      "working-directory": ""
+    },
+    "id": "ws-erEAnPmgtm5mJr77",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/ws-erEAnPmgtm5mJr77"
+    },
+    "relationships": {
+      "latest-run": {
+        "data": null
+      },
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "ssh-key": {
+        "data": {
+          "id": "sshkey-GxrePWre1Ezug7aM",
+          "type": "ssh-keys"
+        },
+        "links": {
+          "related": "/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM"
+        }
+      }
+    },
+    "type": "workspaces"
+  }
+}
+```
+
+
+## Dissociate an SSH key from a workspace
+
+This endpoint dissociates the currently associated SSH key from a workspace.
+
+| Method | Path           |
+| :----- | :------------- |
+| PATCH | /workspaces/:workspace_id/relationships/ssh-key |
+
+### Parameters
+
+* `:workspace_id` (`string: <required>`) - Specifies the workspace ID to dissociate the currently associated SSH key from.
+
+#### Sample Payload
+
+```json
+{
+  "data":
+  {
+    "attributes": {
+      "id":null
+    },
+    "type":"workspaces"
+  }
+}
+```
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/workspaces/ws-erEAnPmgtm5mJr77/relationships/ssh-key
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "auto-apply": false,
+      "can-queue-destroy-plan": false,
+      "created-at": "2017-11-02T23:24:05.997Z",
+      "environment": "default",
+      "ingress-trigger-attributes": {
+        "branch": "",
+        "default-branch": true,
+        "ingress-submodules": false
+      },
+      "locked": false,
+      "name": "my-workspace-2",
+      "terraform-version": "0.10.8",
+      "working-directory": ""
+    },
+    "id": "ws-erEAnPmgtm5mJr77",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/ws-erEAnPmgtm5mJr77"
+    },
+    "relationships": {
+      "latest-run": {
+        "data": null
+      },
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "ssh-key": {
+        "data": null
+      }
+    },
+    "type": "workspaces"
+  }
+}
+```

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -555,9 +555,9 @@ $ curl \
 ```
 
 
-## Associate an SSH key to a workspace
+## Assign an SSH key to a workspace
 
-This endpoint associates an SSH key to a workspace.
+This endpoint assigns an SSH key to a workspace.
 
 | Method | Path           |
 | :----- | :------------- |
@@ -565,8 +565,8 @@ This endpoint associates an SSH key to a workspace.
 
 ### Parameters
 
-* `:workspace_id` (`string: <required>`) - Specifies the workspace ID to associate the SSH key to.
-* `id` (`string: <required>`) - Specifies the SSH key ID to associate.
+* `:workspace_id` (`string: <required>`) - Specifies the workspace ID to assign the SSH key to.
+* `id` (`string: <required>`) - Specifies the SSH key ID to assign. This ID can be obtained from the [ssh-keys](./ssh-keys.html) endpoint.
 
 #### Sample Payload
 
@@ -643,9 +643,9 @@ $ curl \
 ```
 
 
-## Dissociate an SSH key from a workspace
+## Unassign an SSH key from a workspace
 
-This endpoint dissociates the currently associated SSH key from a workspace.
+This endpoint unassigns the currently assigned SSH key from a workspace.
 
 | Method | Path           |
 | :----- | :------------- |
@@ -653,7 +653,7 @@ This endpoint dissociates the currently associated SSH key from a workspace.
 
 ### Parameters
 
-* `:workspace_id` (`string: <required>`) - Specifies the workspace ID to dissociate the currently associated SSH key from.
+* `:workspace_id` (`string: <required>`) - Specifies the workspace ID to unassign the currently assigned SSH key from.
 
 #### Sample Payload
 

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -245,6 +245,9 @@
           <li<%= sidebar_current("docs-enterprise2-api-run") %>>
             <a href="/docs/enterprise/api/run.html">Runs</a>
           </li>
+          <li<%= sidebar_current("docs-enterprise2-api-ssh-keys") %>>
+            <a href="/docs/enterprise/api/ssh-keys.html">SSH Keys</a>
+          </li>
           <li<%= sidebar_current("docs-enterprise2-api-team-access") %>>
             <a href="/docs/enterprise/api/team-access.html">Team Access</a>
           </li>


### PR DESCRIPTION
A simple update to document an endpoint that allows you to associate and dissociate an SSH key to and from a workspace.

I used `an SSH key` as per documented elsewhere. I also included the difference responses for when you associate and dissociate an SSH key. It'd be great to draw attention to the parts of the response that matter, but unsure how best to do that.