### PR TITLE
TFE API delete variable

### DIFF
--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -219,3 +219,23 @@ $ curl \
   }
 }
 ```
+
+## Delete Variables
+
+| Method | Path           |
+| :----- | :------------- |
+| DELETE | /vars/:variable_id |
+
+### Parameters
+
+- `:variable_id` (`string: <required>`) - specifies the ID of the variable to be deleted. Specified in the request path.
+
+### Sample Request
+
+```bash
+$ curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request DELETE \
+  https://app.terraform.io/api/v2/vars/var-yRmifb4PJj7cLkMG
+```


### PR DESCRIPTION
An undocumented part of the variables API.

@nfagerlund I noticed that the structure and wording is different to the workspaces page. For instance under `Delete Variables` there is no further text. The title itself is different, not `Delete a <resource>`.

Is there a preference for either way? I'd be happy to update at least this page to match if it would be preferable to follow the workspaces page.