### PR TITLE
Fix description of repo ID formats

### DIFF
--- a/content/source/docs/enterprise/api/modules.html.md
+++ b/content/source/docs/enterprise/api/modules.html.md
@@ -54,7 +54,7 @@ This endpoint can be used to publish a new module to the registry. The publishin
 
 ### Parameters
 
-- `vcs-repo.identifier` (`string: <required>`) - Specifies the repository to be used to ingress the configuration. For GitHub and Bitbucket, the format is `<PROJECT_KEY>/<REPO>`.
+- `vcs-repo.identifier` (`string: <required>`) - Specifies the repository from which to ingress the configuration. For most VCS providers, the format is `<ORGANIZATION>/<REPO>`; for Bitbucket Server, the format is `<PROJECT_KEY>/<REPO>`.
 - `vcs-repo.oauth-token-id` (`string: <required>`) - Specifies the VCS Connection (OAuth Conection + Token) to use as identified. This ID can be obtained from the [oauth-tokens](./oauth-tokens.html) endpoint.
 
 


### PR DESCRIPTION
"project key" is an atlassian-ism, only applicable to Bitbucket Server. (Even Bitbucket Cloud uses org names instead.)