### PR TITLE
Proposal for formatting API parameters

### DIFF
--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -1,0 +1,130 @@
+Follow this template to format each API method. There are usually multiple sections like this on a given API endpoint page.
+
+## Create a Something
+
+<!-- "Verb a Noun" or "Verb Nouns." -->
+
+`POST /organizations/:organization_name/somethings`
+
+<!-- ^ The method and path are styled as a single code span, with global prefix (`/api/v2`) omitted and the method capitalized. -->
+
+Parameter            | Description
+---------------------|------------
+`:organization_name` | The name of the organization to create the something in. The organization must already exist in the system, and the user must have permissions to create new somethings.
+
+<!-- ^ The list of URL path parameters goes directly below the method and path, without a header of its own. They're simpler than other parameters because they're always strings and they're always mandatory, so this table only has two columns. Prefix URL path parameter names with a colon.
+
+If further explanation of this method is needed beyond its title, write it here, after the parameter list. -->
+
+### Query Parameters
+
+[These are standard URL query parameters](./index.html.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+<!-- ^ Query parameters get their own header and boilerplate. Omit the whole section if this method takes no query parameters; we only use them for certain GET requests. -->
+
+Parameter               | Description
+------------------------|------------
+`filter[workspace][id]` | **Required.** The workspace ID where this action will happen.
+
+<!-- ^ This table is flexible. If we somehow end up with a case where there's a long list of parameters, in a mix of optional and required, you could add a "Required?" or "Default" column or something; likewise if there are multiple data types in play. But in the usual minimal case, keep the table minimal and style important information as strong emphasis.
+
+Do not prefix query parameter names with a question mark. -->
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+<!-- ^ Payload parameters go under this header and boilerplate. -->
+
+Key path                    | Type   | Default | Description
+----------------------------|--------|---------|------------
+`data.type`                 | string |         | Must be `"somethings"`.
+`data.attributes.category`  | string |         | Whether this is a blue or red something. Valid values are `"blue"` or `"red"`.
+`data.attributes.sensitive` | bool   | `false` | Whether the value is sensitive. If true then the something is written once and not visible thereafter.
+`filter.workspace.name`     | string |         | The name of the workspace that owns the something.
+`filter.organization.name`  | string |         | The name of the organization that owns the workspace.
+
+<!--
+- Name the paths to these object properties with dot notation, starting from the
+  root of the JSON object. So, `data.attributes.category` instead of just
+  `category`. Since our API format uses deeply nested structures and is finicky
+  about the details, err on the side of being very explicit about where the user
+  puts everything.
+- Style key paths as code spans.
+- Style data types as plain text.
+- Style string values as code spans with interior double-quotes, to distinguish
+them from unquoted values like booleans and nulls.
+- If a limited number of values are valid, list them in the description.
+- In the rare case where a parameter is optional but has no default, you can
+  list something like "(nothing)" as the default and explain in the description.
+-->
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type":"somethings",
+    "attributes": {
+      "category":"red",
+      "sensitive":true
+    }
+  },
+  "filter": {
+    "organization": {
+      "name":"my-organization"
+    },
+    "workspace": {
+      "name":"my-workspace"
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/somethings
+```
+
+<!-- In curl examples, you can use the `$ATLAS_TOKEN` environment variable. If it's a GET request with query parameters, you can use double-quotes to have curl handle the URL encoding for you.
+
+Make sure to test a query that's very nearly the same as the example, to avoid errors. -->
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id":"som-EavQ1LztoRTQHSNT",
+    "type":"somethings",
+    "attributes": {
+      "sensitive":true,
+      "category":"red",
+    },
+    "relationships": {
+      "configurable": {
+        "data": {
+          "id":"ws-4j8p6jX1w33MiDC7",
+          "type":"workspaces"
+        },
+        "links": {
+          "related":"/api/v2/organizations/my-organization/workspaces/my-workspace"
+        }
+      }
+    },
+    "links": {
+      "self":"/api/v2/somethings/som-EavQ1LztoRTQHSNT"
+    }
+  }
+}
+```
+
+<!-- Make sure to mangle any real IDs this might expose. -->

--- a/content/source/docs/enterprise/api/team-access.html.md
+++ b/content/source/docs/enterprise/api/team-access.html.md
@@ -12,13 +12,15 @@ The team access APIs are used to associate a team to permissions on a workspace.
 
 ## List Team Access to Workspaces
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /team-workspaces |
+`GET /team-workspaces`
 
-### Parameters
+### Query Parameters
 
-- `filter[workspace][id]` (`string: <required>`) - The workspace ID for which to list the teams with access
+[These are standard URL query parameters](./index.html.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+Parameter               | Description
+------------------------|------------
+`filter[workspace][id]` | **Required.** The workspace ID for which to list the teams with access.
 
 ### Sample Request
 
@@ -69,17 +71,24 @@ $ curl \
 }
 ```
 
-## Add Team access to a Workspace
+## Add Team Access to a Workspace
 
-| Method | Path           |
-| :----- | :------------- |
-| POST | /team-workspaces |
+`POST /team-workspaces`
 
-### Parameters
+### Request Body
 
-- `access` (`string: <required>`) - `read`, `write`, or `admin`
-- `team` (`string: <required>`) - The ID of the team to add to the workspace.
-- `workspace` (`string: <required>`) - The workspace ID to which the team is to be added.
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+Key path                                 | Type   | Default | Description
+-----------------------------------------|--------|---------|------------
+`data.type`                              | string |         | Must be `"team-workspaces"`.
+`data.attributes.access`                 | string |         | The type of access to grant. Valid values are `read`, `write`, or `admin`.
+`data.relationships.workspace.data.type` | string |         | Must be `workspaces`.
+`data.relationships.workspace.data.id`   | string |         | The workspace ID to which the team is to be added.
+`data.relationships.team.data.type`      | string |         | Must be `teams`.
+`data.relationships.team.data.id`        | string |         | The ID of the team to add to the workspace.
 
 ### Sample Payload
 
@@ -158,13 +167,11 @@ $ curl \
 
 ## Show Team Access to a Workspace
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /team-workspaces/:id |
+`GET /team-workspaces/:id``
 
-### Parameters
-
-- `id` (`string: <required>`) - The ID of the team/workspace relationship.
+Parameter | Description
+----------|------------
+`:id`     | The ID of the team/workspace relationship. Obtain this from the [list team access action](#list-team-access-to-workspaces) described above.
 
 ### Sample Request
 
@@ -190,13 +197,11 @@ $ curl \
 
 ## Remove Team Access to a Workspace
 
-| Method | Path           |
-| :----- | :------------- |
-| DELETE | /team-workspaces/:id |
+`DELETE /team-workspaces/:id`
 
-### Parameters
-
-- `id` (`string: <required>`) - The ID of the team/workspace relationship.
+Parameter | Description
+----------|------------
+`:id`     | The ID of the team/workspace relationship. Obtain this from the [list team access action](#list-team-access-to-workspaces) described above.
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -12,14 +12,22 @@ The Teams API is used to create and destroy teams. The [Team Membership API](./t
 
 ## Create a Team
 
-| Method | Path           |
-| :----- | :------------- |
-| POST | /organizations/:organization_name/teams |
+`POST /organizations/:organization_name/teams`
 
-### Parameters
+Parameter            | Description
+---------------------|------------
+`:organization_name` | The name of the organization to create the team in. The organization must already exist in the system, and the user must have permissions to create new teams.
 
-- `name` (`string: <required>`) - Specifies the name of the workspace, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.
-- `:organization_name` (`string: <required>`) - Specifies the organization name under which to create the team. The organization must already exist in the system, and the user must have permissions to create new teams. This parameter is specified in the URL path.
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+Key path               | Type   | Default | Description
+-----------------------|--------|---------|------------
+`data.type`            | string |         | Must be `"teams"`.
+`data.attributes.name` | string |         | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.
 
 ### Sample Payload
 
@@ -70,13 +78,11 @@ $ curl \
 
 # Delete a Team
 
-| Method | Path           |
-| :----- | :------------- |
-| DELETE | /teams/:team_id |
+`DELETE /teams/:team_id`
 
-### Parameters
-
-- `:team_id` (`string: <required>`) - The team ID to be deleted. This parameter is specified in the URL.
+Parameter   | Description
+------------|------------
+`:team_id`  | The team ID to be deleted.
 
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -13,19 +13,26 @@ This set of APIs covers create, update, list and delete operations on variables.
 
 ## Create a Variable
 
-| Method | Path           |
-| :----- | :------------- |
-| POST | /vars |
+`POST /vars`
 
-### Parameters
+### Request Body
 
-- `key` (`string: <required>`) - specifies the name of the variable which will be passed into the plan/apply.
-- `value` (`string: <required>`) - specifies the value of the variable which will be passed into the plan/apply.
-- `category` (`string: "terraform"|"env"`) - specifies whether this should be parsed as a Terraform variable (with support for HCL) or as an environment variable. This governs how it is accessible in the Terraform configuration.
-- `hcl` (`bool: false`) - use HCL when setting the value of the string.
-- `sensitive` (`bool: false`) - marks the variable as sensitive. If true then the variable is written once and not visible thereafter.
-- `filter[workspace][name]` (`string: required`) - variables must be associated with a workspace. Specify the workspace's name with the `filter` query parameter.
-- `filter[organization][name]` (`string: required`) - workspaces must be owned by an organization. Specify which organization owns the workspace with the `filter` query parameter.
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+
+Key path                    | Type   | Default | Description
+----------------------------|--------|---------|------------
+`data.type`                 | string |         | Must be `"vars"`.
+`data.attributes.key`       | string |         | The name of the variable.
+`data.attributes.value`     | string |         | The value of the variable.
+`data.attributes.category`  | string |         | Whether this is a Terraform or environment variable. Valid values are `"terraform"` or `"env"`.
+`data.attributes.hcl`       | bool   | `false` | Whether to evaluate the value of the variable as a string of HCL code. Has no effect for environment variables.
+`data.attributes.sensitive` | bool   | `false` | Whether the value is sensitive. If true then the variable is written once and not visible thereafter.
+`filter.workspace.name`     | string |         | The name of the workspace that owns the variable.
+`filter.organization.name`  | string |         | The name of the organization that owns the workspace.
+
 
 ### Sample Payload
 
@@ -97,14 +104,18 @@ curl \
 
 ## List Variables
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /vars |
+`GET /vars`
 
-### Parameters
+### Query Parameters
 
-- `filter[organization][name]` (`optional`) - Optionally filter the list to an organization given the organization name. If this parameter is provided, `filter[workspace][name]` must also be provided.
-- `filter[workspace][name]` (`optional`) - Optionally filter the list to a workspace given the workspace name. If this parameter is provided, `filter[organization][name]` must also be provided.
+[These are standard URL query parameters](./index.html.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+Parameter                    | Description
+-----------------------------|------------
+`filter[workspace][name]`    | **Optional.** The name of one workspace to list variables for. If included, you must also include the organization name filter.
+`filter[organization][name]` | The name of the organization that owns the desired workspace. Must be combined with the workspace name filter.
+
+These two parameters are optional but linked; if you include one, you must include both. Without a filter, this method lists variables for all workspaces you can access.
 
 ### Sample Request
 
@@ -151,13 +162,23 @@ $ curl \
 
 ## Update Variables
 
-| Method | Path           |
-| :----- | :------------- |
-| PATCH | /vars/:variable_id |
+`PATCH /vars/:variable_id`
 
-### Parameters
+Parameter      | Description
+---------------|------------
+`:variable_id` | The ID of the variable to be updated.
 
-- `:variable_id` (`string: <required>`) - specifies the ID of the variable to be updated. Specified in the request path.
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+Key path          | Type   | Default | Description
+------------------|--------|---------|------------
+`data.type`       | string |         | Must be `"vars"`.
+`data.id`         | string |         | The ID of the variable to update.
+`data.attributes` | object |         | New attributes for the variable. This object can include `key`, `value`, `category`, `hcl`, and `sensitive` properties, which are described above under [create a variable](#create-a-variable). All of these properties are optional; if omitted, a property will be left unchanged.
 
 ### Sample Payload
 
@@ -222,13 +243,11 @@ $ curl \
 
 ## Delete Variables
 
-| Method | Path           |
-| :----- | :------------- |
-| DELETE | /vars/:variable_id |
+`DELETE /vars/:variable_id`
 
-### Parameters
-
-- `:variable_id` (`string: <required>`) - specifies the ID of the variable to be deleted. Specified in the request path.
+Parameter      | Description
+---------------|------------
+`:variable_id` | The ID of the variable to be deleted.
 
 ### Sample Request
 


### PR DESCRIPTION
As a reader/user, I've found it difficult to distinguish between the three types
of parameters we use in our APIs. I think we can make these docs a lot more
useful by doing two things:

- Explicitly separate the types of parameters (URL segments, URL query
parameters, and attributes that appear in a JSON API post document) into
different lists. This makes the steps of assembling a valid query clearer.
- Use a combination of list nesting and dot-notation to show the structure of
the JSON API document. This helps keep track of where you are while constructing
the payload, and makes the API's underlying format more visible to users who
aren't old hands at JSON API.

I'm also adding in some missing attributes that seem to only appear in the
examples (like `type`).

Dylan and I are leaning toward the following guidelines for nesting vs. dot-notation:

- Three levels of nesting should be the maximum just for the sake of
readability, so if any items within the `data.attributes` object have sub-items,
they should be listed with dot-notation.
- If a property has only one sub-item, it should probably be listed with
dot-notation.