### PR TITLE
[WIP] Switch web analytics to segment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 		--volume "$(shell pwd)/content:/website" \
 		--volume "$(shell pwd)/content/build:/website/build" \
 		hashicorp/middleman-hashicorp:${VERSION} \
-		bundle exec middleman build --verbose --clean
+		ENV=production bundle exec middleman build --verbose --clean
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/content/Gemfile
+++ b/content/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.29"
+gem "middleman-hashicorp", "0.3.32"

--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (7.2.5)
+    autoprefixer-rails (8.1.0.1)
       execjs
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.29)
+    middleman-hashicorp (0.3.32)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -153,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.29)
+  middleman-hashicorp (= 0.3.32)
 
 BUNDLED WITH
    1.15.1

--- a/content/config.rb
+++ b/content/config.rb
@@ -10,6 +10,16 @@ ignore "ext/**/*"
 config[:file_watcher_ignore] += [/^(\/website\/)?ext\//]
 
 helpers do
+  # Returns a segment tracking ID such that local development is not
+  # tracked to production systems.
+  def segmentId()
+    if (ENV['ENV'] == 'production')
+      'EnEETDWhfxp1rp09jVvJr66LdvwI6KVP'
+    else
+      '0EXTgkNx0Ydje2PGXVbRhpKKoe5wtzcE'
+    end
+  end
+
   # Returns the FQDN of the image URL.
   #
   # @param [String] path

--- a/content/source/assets/javascripts/analytics.js
+++ b/content/source/assets/javascripts/analytics.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  track('.downloads .download a', el => {
+    return {
+      event: 'Download',
+      category: 'Button',
+      label: `Terraform | v${el.href.match(/\/(\d+\.\d+\.\d+)\//)[1]}`
+    }
+  })
+})

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -3,3 +3,6 @@
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
+//= require hashicorp/analytics
+
+//= require analytics

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -119,14 +119,16 @@
     </div>
 
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-53231375-1', 'terraform.io');
-      ga('require', 'linkid');
-      ga('send', 'pageview', location.pathname);
+      // ga async load
+      window['GoogleAnalyticsObject'] = 'ga';
+      window['ga'] = window['ga'] || function() {
+        (window['ga'].q = window['ga'].q || []).push(arguments)
+      };
+      // analytics.js
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
+      analytics.load("<%= segmentId %>");
+      analytics.page();
+      }}();
     </script>
 
     <script type="application/ld+json">


### PR DESCRIPTION
⚠️ Do not merge yet! ⚠️

We're going through a process of switching over to using segment for our analytics. Segment will still send data to google analytics, so it should behave the same as before for those relying on the GA interface, but segment has the ability also to send the data elsewhere, so we can integrate cleanly with other analytics tooling as well.

This PR switches over from pure GA to segment. In production, data will be logged to the same GA property as before, and in development it won't be logged to GA at all, to prevent pollution. I added a "production" environment flag to the make build command to adjust for this. Let me know if there's a better way to accomplish this!