### PR TITLE
Fix issues related to `?` and note that both filters are required if one is provided

### DIFF
--- a/content/source/docs/enterprise/api/team-access.html.md
+++ b/content/source/docs/enterprise/api/team-access.html.md
@@ -18,7 +18,7 @@ The team access APIs are used to associate a team to permissions on a workspace.
 
 ### Parameters
 
-- `?filter[workspace][id]` (`string: <required>`) - The workspace ID for which to list the teams with access
+- `filter[workspace][id]` (`string: <required>`) - The workspace ID for which to list the teams with access
 
 ### Sample Request
 
@@ -27,7 +27,7 @@ $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request GET \
-  https://app.terraform.io/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-5vBKrazjYR36gcYX
+  "https://app.terraform.io/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-5vBKrazjYR36gcYX"
 ```
 
 ### Sample Response
@@ -207,4 +207,3 @@ $ curl \
   --request DELETE \
   https://app.terraform.io/api/v2/team-workspaces/257525
 ```
-

--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -103,8 +103,8 @@ curl \
 
 ### Parameters
 
-- `?filter[organization][name]` (`optional`) - Optionally filter the list to an organization given the organization name. If this parameter is provided, `filter[workspace][name]` must also be provided.
-- `?filter[workspace][name]` (`optional`) - Optionally filter the list to a workspace given the workspace name. If this parameter is provided, `filter[organization][name]` must also be provided.
+- `filter[organization][name]` (`optional`) - Optionally filter the list to an organization given the organization name. If this parameter is provided, `filter[workspace][name]` must also be provided.
+- `filter[workspace][name]` (`optional`) - Optionally filter the list to a workspace given the workspace name. If this parameter is provided, `filter[organization][name]` must also be provided.
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -24,8 +24,8 @@ This set of APIs covers create, update, list and delete operations on variables.
 - `category` (`string: "terraform"|"env"`) - specifies whether this should be parsed as a Terraform variable (with support for HCL) or as an environment variable. This governs how it is accessible in the Terraform configuration.
 - `hcl` (`bool: false`) - use HCL when setting the value of the string.
 - `sensitive` (`bool: false`) - marks the variable as sensitive. If true then the variable is written once and not visible thereafter.
-- `?filter[workspace][name]` (`string: required`) - variables must be associated with a workspace. Specify the workspace's name with the `filter` query parameter.
-- `?filter[organization][name]` (`string: required`) - workspaces must be owned by an organization. Specify which organization owns the workspace with the `filter` query parameter.
+- `filter[workspace][name]` (`string: required`) - variables must be associated with a workspace. Specify the workspace's name with the `filter` query parameter.
+- `filter[organization][name]` (`string: required`) - workspaces must be owned by an organization. Specify which organization owns the workspace with the `filter` query parameter.
 
 ### Sample Payload
 
@@ -103,8 +103,8 @@ curl \
 
 ### Parameters
 
-- `?filter[organization][name]` (`optional`) - Optionally filter the list to an organization given the organization name
-- `?filter[workspace][name]` (`optional`) - Optionally filter the list to a workspace given the workspace name
+- `?filter[organization][name]` (`optional`) - Optionally filter the list to an organization given the organization name. If this parameter is provided, `filter[workspace][name]` must also be provided.
+- `?filter[workspace][name]` (`optional`) - Optionally filter the list to a workspace given the workspace name. If this parameter is provided, `filter[organization][name]` must also be provided.
 
 ### Sample Request
 
@@ -112,7 +112,7 @@ curl \
 $ curl \
   --header "Authorization: Bearer $ATLAS_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-https://app.terraform.io/api/v2/vars?filter%5Borganization%5D%5Bname%5D=my-organization&filter%5Bworkspace%5D%5Bname%5D=my-workspace
+"https://app.terraform.io/api/v2/vars?filter%5Borganization%5D%5Bname%5D=my-organization&filter%5Bworkspace%5D%5Bname%5D=my-workspace"
 # ?filter[organization][name]=my-organization&filter[workspace][name]=demo01
 ```
 


### PR DESCRIPTION
When URLs contain query params, most shells have a bad time. Let's quote 'em.