### PR TITLE
TFE API run action discard

### DIFF
--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -234,3 +234,37 @@ curl \
   ]
 }
 ```
+
+# Discard
+
+The `discard` endpoint represents an action as opposed to a resource. As such, the endpoint does not return any object in the response body. This endpoint queues the request to perform a discard; the discard might not happen immediately.
+
+| Method | Path           |
+| :----- | :------------- |
+| POST | /runs/:run_id/actions/discard |
+
+### Parameters
+
+- `run_id` (`string: <required>`) - specifies the run ID to run
+- `comment` (`string: <optional>`) - Optional comment to add on the discard
+
+### Sample Payload
+
+This payload is optional, so the `curl` command will work without the `--data @payload.json` option too.
+
+```json
+{
+  "comment": "This run was discarded"
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/runs/run-DQGdmrWMX8z9yWQB/actions/discard
+```


### PR DESCRIPTION
This is a copy-and-paste from the `apply` action documentation. `cancel` and `force_execute` are still undocumented, but have very similar traits, should I tack them on here?

Also I put `Discard` at the bottom, but should it just sit under `Apply` before `List Runs`?

> As such, the endpoint does not return any object in the response body.

Across the documentation are we always only talking about successful responses within the documented sections? Don't want people to see error handling under a request and not expect others to follow.