### PR TITLE
Update Automating the Installer Formatting Docs

### DIFF
--- a/content/source/docs/enterprise/private/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/private/automating-the-installer.html.md
@@ -25,7 +25,7 @@ This file contains the values you would normally provide in the settings screen,
 
 ### Format
 
-The settings file is JSON formatted.  The example below is suitable for a demo installation:
+The settings file is JSON formatted. All values must be strings.  The example below is suitable for a demo installation:
 
 ```json
 {
@@ -36,7 +36,7 @@ The settings file is JSON formatted.  The example below is suitable for a demo i
         "value": "poc"
     },
     "capacity_concurrency": {
-        "value": 5
+        "value": "5"
     }
 }
 ```


### PR DESCRIPTION
Updates documentation example for `capacity_concurrency` and specify that all automated installer config values must be strings. 

[Asana](https://app.asana.com/0/153076180902462/590164057438803/f) 
[ZenDesk](https://hashicorp.zendesk.com/agent/tickets/7100)