### PR TITLE
Add RHEL Install Guide to the sidebar

### DIFF
--- a/content/source/docs/enterprise/private/rhel-install-guide.html.md
+++ b/content/source/docs/enterprise/private/rhel-install-guide.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "enterprise2"
 page_title: "Private Terraform Enterprise Installation (Installer Beta) - RHEL Install Guide"
-sidebar_current: "docs-enterprise2-private-installer"
+sidebar_current: "docs-enterprise2-private-rhel"
 ---
 
 # Private Terraform Enterprise Installation (Installer Beta) - RHEL Install Guide

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -202,6 +202,9 @@
           <li<%= sidebar_current("docs-enterprise2-private-installer") %>>
             <a href="/docs/enterprise/private/install-installer.html">Installation (Installer Beta)</a>
             <ul class="nav">
+              <li<%= sidebar_current("docs-enterprise2-private-rhel") %>>
+                <a href="/docs/enterprise/private/rhel-istall-guide.html">RedHat Enterprise Install Guide</a>
+              </li>
               <li<%= sidebar_current("docs-enterprise2-private-installer-automating") %>>
                 <a href="/docs/enterprise/private/automating-the-installer.html">Automated Installation</a>
               </li>


### PR DESCRIPTION
This was missed when the RHEL install guide was added.