### PR TITLE
Remove restriction on using RHEL docker versions

### DIFF
--- a/content/source/docs/enterprise/private/rhel-install-guide.html.md
+++ b/content/source/docs/enterprise/private/rhel-install-guide.html.md
@@ -11,20 +11,27 @@ This install guide is specifically for users of Private Terraform Enterprise ins
 ## Install Recommendations
 
 * RedHat Enterprise Linux version 7.3 or 7.4
-* Docker CE or EE version 17.06 or later. These versions are not available in the standard RHEL yum repositories.
+* Docker 1.13.1 (available in RHEL extras) or Docker CE or EE version 17.06 or later. The later versions are not available in the standard RHEL yum repositories.
    * For Docker CE, you can use the official CentOS docker repository. Instructions are available here: https://docs.docker.com/install/linux/docker-ce/centos/#install-from-a-package.
    * For Docker EE, there are explicit RHEL instructions to follow: https://docs.docker.com/install/linux/docker-ee/rhel/ 
 * A properly configured docker storage backend, either:
    * Devicemapper configured for production usage, according to the Docker documentation: https://docs.docker.com/storage/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-for-production. This configuration requires a second block device available to the system to be used as a thin-pool for Docker. You may need to configure this block device before the host system is booted, depending on the hosting platform.
    * A system capable of using overlay2. The requires at least kernel version 3.10.0-693 and, if XFS is being used, the flag ftype=1. The full documentation on this configuration is at: https://docs.docker.com/storage/storagedriver/overlayfs-driver/
 
+## Mandatory Configuration
+
+If you opt to use Docker from RHEL extras, then you must make a change to it's default configuration to avoid hitting an out of memory bug.
+
+1. Open `/usr/lib/systemd/system/docker.service`
+1. Remove the line that contains `--authorization-plugin=rhel-push-plugin`
+1. Run `systemctl daemon-reload && systemctl restart docker`
+1. Run `docker info 2> /dev/null | grep Authorization` to verify that there are no authorization plugins active.
+   If nothing is printed, your installation is properly configured. If anything is printed, please
+   contact support for further assistance.
 
 ## FAQ:
 ### Can I use the Docker version in rpm-extras?
-We do not recommend doing so. Customers have experienced many issues with the Docker versions in rpm-extras (1.12 and 1.13), primarily memory issues resulting in failed airgap installations. We’ve found that newer Docker versions do not have these problems, and thus we request that version 17.06 or later be used.
-
-### I can only use the versions of Docker available in rpm-extras. What can I do?
-If you must use the versions in rpm-extras, you need to be able to support those versions yourself. Be warned, as indicated above, those versions have significant issues running airgapped installation due to memory exhaustion bugs. If you are unable to install the product properly on these versions, we highly suggest you use newer Docker versions.
+Sure! Just be sure to have at least 1.13.1 and authorization plugins disabled.
 
 ### When I run the installer, it allows me to download and install Docker CE on RedHat. Can I use that?
 Yes, Docker CE is compatible with the current installer; however it is not directly supported by RedHat. You still need to be sure that the storage backend is configured properly as by default, Docker will be using devicemapper in loopback, an entirely unsupported mode.

--- a/content/source/docs/enterprise/private/rhel-install-guide.html.md
+++ b/content/source/docs/enterprise/private/rhel-install-guide.html.md
@@ -11,7 +11,7 @@ This install guide is specifically for users of Private Terraform Enterprise ins
 ## Install Recommendations
 
 * RedHat Enterprise Linux version 7.3 or 7.4
-* Docker 1.13.1 (available in RHEL extras) or Docker CE or EE version 17.06 or later. The later versions are not available in the standard RHEL yum repositories.
+* Docker 1.13.1 (available in RHEL extras), or Docker CE or EE version 17.06 or later. The later versions are not available in the standard RHEL yum repositories.
    * For Docker CE, you can use the official CentOS docker repository. Instructions are available here: https://docs.docker.com/install/linux/docker-ce/centos/#install-from-a-package.
    * For Docker EE, there are explicit RHEL instructions to follow: https://docs.docker.com/install/linux/docker-ee/rhel/ 
 * A properly configured docker storage backend, either:
@@ -20,7 +20,7 @@ This install guide is specifically for users of Private Terraform Enterprise ins
 
 ## Mandatory Configuration
 
-If you opt to use Docker from RHEL extras, then you must make a change to it's default configuration to avoid hitting an out of memory bug.
+If you opt to use Docker from RHEL extras, then you must make a change to its default configuration to avoid hitting an out of memory bug.
 
 1. Open `/usr/lib/systemd/system/docker.service`
 1. Remove the line that contains `--authorization-plugin=rhel-push-plugin`


### PR DESCRIPTION
After much debugging and gnashing of teeth, fruit was borne:

```
      flat  flat%   sum%        cum   cum%
    1.23GB 99.06% 99.06%     1.23GB 99.06%  github.com/docker/docker/pkg/authorization.(*responseModifier).Write
```

Turns out that docker's authorization plugins system is super busted, in that it buffers **100%** of anything that flows through it: https://github.com/moby/moby/blob/master/pkg/authorization/response.go#L118-L126

The reason this appeared only on RHEL and not other platforms is RHEL ships with an authorization plugin on by default! https://github.com/projectatomic/rhel-push-plugin

This doc change tells user to just turn that shit off, then everything is 💯 

![image uploaded from ios 1](https://user-images.githubusercontent.com/7/37811543-2f8e297a-2e18-11e8-8d2d-0526ef5d962e.jpg)
