### PR TITLE
Add deprecation to all Atlas & TFE Legacy pages

### DIFF
--- a/content/source/docs/enterprise-legacy/api/configurations.html.md
+++ b/content/source/docs/enterprise-legacy/api/configurations.html.md
@@ -9,6 +9,8 @@ description: |-
 
 # Configuration API
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 A configuration version represents versions of Terraform configuration. Each set
 of changes to Terraform HCL files or the scripts used in the files should have
 an associated configuration version.

--- a/content/source/docs/enterprise-legacy/api/environments.html.md
+++ b/content/source/docs/enterprise-legacy/api/environments.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Environments API
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Environments represent running infrastructure managed by Terraform.
 
 Environments can also be connected to Consul clusters. This documentation covers

--- a/content/source/docs/enterprise-legacy/api/index.html.md
+++ b/content/source/docs/enterprise-legacy/api/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Terraform Enterprise API Documentation
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise provides an API for a **subset of features** available. For
 questions or requests for new API features please email
 [support@hashicorp.com](mailto:support@hashicorp.com).

--- a/content/source/docs/enterprise-legacy/api/runs.html.md
+++ b/content/source/docs/enterprise-legacy/api/runs.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Runs API
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Runs in Terraform Enterprise represents a two step Terraform plan and a
 subsequent apply.
 

--- a/content/source/docs/enterprise-legacy/api/states.html.md
+++ b/content/source/docs/enterprise-legacy/api/states.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # State API
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 State represents the status of your infrastructure at the last time Terraform
 was run. States can be pushed to Terraform Enterprise from Terraform's CLI after
 an apply is done locally, or state is automatically stored if the apply is done

--- a/content/source/docs/enterprise-legacy/api/users.html.md
+++ b/content/source/docs/enterprise-legacy/api/users.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Users API
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Users are both users and organizations in Terraform Enterprise. They are the
 parent resource of all resources.
 

--- a/content/source/docs/enterprise-legacy/artifacts/artifact-provider.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/artifact-provider.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Artifact Provider
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Terraform has a [provider](https://terraform.io/docs/providers/index.html) for managing Terraform Enterprise artifacts called `atlas_artifact`.
 

--- a/content/source/docs/enterprise-legacy/artifacts/creating-amis.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/creating-amis.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # Creating AMI Artifacts with Packer and Terraform Enterprise
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Currently, the best way to create AWS AMI artifacts is with Packer.
 

--- a/content/source/docs/enterprise-legacy/artifacts/index.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/index.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # About Terraform Artifacts
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Terraform Enterprise can be used to store artifacts for use by Terraform.
 Typically, artifacts are [stored with Packer](https://packer.io/docs).

--- a/content/source/docs/enterprise-legacy/artifacts/managing-versions.html.md
+++ b/content/source/docs/enterprise-legacy/artifacts/managing-versions.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Managing Artifact Versions
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Artifacts stored in Terraform Enterprise are versioned and assigned a version
 number. Versions are useful to roll back, audit and deploy images specific

--- a/content/source/docs/enterprise-legacy/faq/index.html.md
+++ b/content/source/docs/enterprise-legacy/faq/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Frequently Asked Questions
 
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 [Monolithic Artifacts](/docs/enterprise-legacy/faq/monolithic-artifacts.html) - *How do I build multiple applications into one artifact?*
 
 [Rolling Deployments](/docs/enterprise-legacy/faq/rolling-deployments.html) - *How do I configure rolling deployments?*

--- a/content/source/docs/enterprise-legacy/faq/monolithic-artifacts.html.md
+++ b/content/source/docs/enterprise-legacy/faq/monolithic-artifacts.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Monolithic Artifacts
 
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 *How do I build multiple applications into one artifact?*
 
 Create your new Applications in Terraform Enterprise using the application

--- a/content/source/docs/enterprise-legacy/faq/rolling-deployments.html.md
+++ b/content/source/docs/enterprise-legacy/faq/rolling-deployments.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Rolling Deployments
 
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 *How do I configure rolling deployments?*
 
 User are able to quickly change out an Artifact version that is being utilized

--- a/content/source/docs/enterprise-legacy/glossary/index.html.md
+++ b/content/source/docs/enterprise-legacy/glossary/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Glossary
 
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 Terraform Enterprise, and this documentation, covers a large set of terminology
 adopted from tools, industry standards and the community. This glossary seeks to
 define as many of those terms as possible to help increase understanding in

--- a/content/source/docs/enterprise-legacy/index.html.md
+++ b/content/source/docs/enterprise-legacy/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Terraform Enterprise Features
 
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+
 [Terraform Enterprise](https://www.hashicorp.com/products/terraform/) is a tool for safely and
 efficiently changing infrastructure across providers.
 

--- a/content/source/docs/enterprise-legacy/organizations/authentication-policy.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/authentication-policy.html.md
@@ -9,6 +9,8 @@ description: |-
 
 # Set an Organization Authentication Policy
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Because organization membership affords members access to potentially sensitive
 resources, owners can set organization-wide authentication policy in Terraform
 Enterprise.

--- a/content/source/docs/enterprise-legacy/organizations/create.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/create.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Create an Organization Account
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 To create an organization:
 
 1. Create a personal account. You'll use this to create and administrate the

--- a/content/source/docs/enterprise-legacy/organizations/credit-card.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/credit-card.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Add credit card details to an organization
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 To setup automated billing for your Terraform usage, you must add a credit card
 to your organization's account. To do so, go into your account settings, then go
 to the proper organization settings in the left navigation. Select billing in

--- a/content/source/docs/enterprise-legacy/organizations/index.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/index.html.md
@@ -6,7 +6,9 @@ description: |-
   Organizations are a group of users in Terraform Enterprise that have access and ownership over shared resources.
 ---
 
-## Organizations in Terraform Enterprise
+# Organizations in Terraform Enterprise
+
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
 
 Organizations are a group of users in Terraform Enterprise that have access and
 ownership over shared resources. When operating within a team, we recommend

--- a/content/source/docs/enterprise-legacy/organizations/membership.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/membership.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Membership
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise allows collaboration in organizations. However, there are several membership levels within organizations.
 
 ### Admin

--- a/content/source/docs/enterprise-legacy/organizations/migrate.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/migrate.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Migrate Organization
 
+ !> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 To migrate an existing user account to an organization:
 
 1. Create or retrieve the username of a new personal account. You'll add this

--- a/content/source/docs/enterprise-legacy/organizations/trials.html.md
+++ b/content/source/docs/enterprise-legacy/organizations/trials.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Start a trial
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise offers organizations 30-day trials for [Terraform Enterprise](https://www.hashicorp.com/products/terraform/), [Consul Enterprise](https://www.hashicorp.com/consul.html), and Vagrant Enterprise. Note that trials are available for organizations, not users.
 
 [Request a trial](https://www.hashicorp.com/products/terraform/) for your organization.

--- a/content/source/docs/enterprise-legacy/packer/artifacts/creating-amis.html.md
+++ b/content/source/docs/enterprise-legacy/packer/artifacts/creating-amis.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Creating AMI Artifacts with Terraform Enterprise
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
 
 In an immutable infrastructure workflow, it's important to version and store
 full images (artifacts) to be deployed. This section covers storing [AWS

--- a/content/source/docs/enterprise-legacy/packer/artifacts/creating-vagrant-boxes.html.md
+++ b/content/source/docs/enterprise-legacy/packer/artifacts/creating-vagrant-boxes.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Creating Vagrant Boxes with Packer
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
 
 We recommend using Packer to create boxes, as is it is fully repeatable and
 keeps a strong history of changes within Terraform Enterprise.

--- a/content/source/docs/enterprise-legacy/packer/artifacts/index.html.md
+++ b/content/source/docs/enterprise-legacy/packer/artifacts/index.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # About Packer and Artifacts
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
 
 Packer creates and uploads artifacts to Terraform Enterprise. This is done
 with the [post-processor](https://packer.io/docs/post-processors/atlas.html).

--- a/content/source/docs/enterprise-legacy/packer/builds/build-environment.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/build-environment.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Packer Build Environment
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 This page outlines the environment that Packer runs in within Terraform
 Enterprise.

--- a/content/source/docs/enterprise-legacy/packer/builds/how-builds-run.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/how-builds-run.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # How Packer Builds Run in Terraform Enterprise
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 This briefly covers the internal process of running builds in Terraform
 Enterprise. It's not necessary to know this information, but may be valuable to

--- a/content/source/docs/enterprise-legacy/packer/builds/index.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/index.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # About Builds
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Builds are instances of `packer build` being run within Terraform Enterprise.
 Every build belongs to a build configuration.

--- a/content/source/docs/enterprise-legacy/packer/builds/installing-software.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/installing-software.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Installing Software
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Please review the [Packer Build Environment](/docs/enterprise-legacy/packer/builds/build-environment.html)
 specification for important information on isolation, security, and hardware

--- a/content/source/docs/enterprise-legacy/packer/builds/managing-packer-versions.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/managing-packer-versions.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Managing Packer Versions
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Terraform Enterprise does not automatically upgrade the version of Packer used
 to run builds or compiles. This is intentional, as occasionally there can be

--- a/content/source/docs/enterprise-legacy/packer/builds/notifications.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/notifications.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # About Packer Build Notifications
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Terraform Enterprise can send build notifications to your organization for the
 following events:

--- a/content/source/docs/enterprise-legacy/packer/builds/rebuilding.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/rebuilding.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Rebuilding Builds
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Sometimes builds fail due to temporary or remotely controlled conditions.
 

--- a/content/source/docs/enterprise-legacy/packer/builds/scheduling-builds.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/scheduling-builds.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Schedule Periodic Builds in Terraform Enterprise
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Terraform Enterprise can automatically run a Packer build and
 create artifacts on a specified schedule. This option is disabled by default and can be enabled by an

--- a/content/source/docs/enterprise-legacy/packer/builds/starting.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/starting.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Starting Packer Builds in Terraform Enterprise
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Packer builds can be started in in two ways: `packer push` to upload the
 template and directory or via a GitHub connection that retrieves the contents of

--- a/content/source/docs/enterprise-legacy/packer/builds/troubleshooting.html.md
+++ b/content/source/docs/enterprise-legacy/packer/builds/troubleshooting.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Troubleshooting Failing Builds
 
--> **Deprecation warning**:  The Packer and Artifact Registry features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Friday, March 30, 2018. Please see our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing these features yourself.
+!> **Deprecation warning**: The Packer, Artifact Registry and Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise and our [guide on building immutable infrastructure with Packer on CI/CD](https://www.packer.io/guides/packer-on-cicd/) for ideas on implementing the Packer and Artifact features yourself.
 
 Packer builds can fail in Terraform Enterprise for a number of reasons –
 improper configuration, transient networking errors, and hardware constraints

--- a/content/source/docs/enterprise-legacy/runs/automatic-applies.html.md
+++ b/content/source/docs/enterprise-legacy/runs/automatic-applies.html.md
@@ -8,9 +8,7 @@ description: |-
 
 # Automatic Terraform Applies
 
--> This is an unreleased beta feature. Please
-<a href="mailto:support@hashicorp.com">contact support</a> if you are interested
-in helping us test this feature.
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
 
 You can automatically apply successful Terraform plans to your
 infrastructure. This option is disabled by default and can be enabled by an

--- a/content/source/docs/enterprise-legacy/runs/how-runs-execute.html.md
+++ b/content/source/docs/enterprise-legacy/runs/how-runs-execute.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # How Terraform Runs Execute
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 This briefly covers the internal process of running Terraform plan and applies.
 It is not necessary to know this information, but may be valuable to help
 understand implications of running or debugging failed runs.

--- a/content/source/docs/enterprise-legacy/runs/index.html.md
+++ b/content/source/docs/enterprise-legacy/runs/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # About Terraform Enterprise Runs
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 A "run" represents the logical grouping of two Terraform steps - a "plan" and an
 "apply". The distinction between these two phases of a Terraform run are
 documented below.

--- a/content/source/docs/enterprise-legacy/runs/installing-software.html.md
+++ b/content/source/docs/enterprise-legacy/runs/installing-software.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Installing Custom Software
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 The machines that run Terraform exist in an isolated environment and are
 destroyed on each use. In some cases, it may be necessary to install certain
 software on the Terraform worker, such as a configuration management tool like

--- a/content/source/docs/enterprise-legacy/runs/managing-terraform-versions.html.md
+++ b/content/source/docs/enterprise-legacy/runs/managing-terraform-versions.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Managing Terraform Versions
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise does not automatically upgrade the version of Terraform
 used to execute plans and applies. This is intentional, as occasionally there
 can be backwards incompatible changes made to Terraform that cause state and

--- a/content/source/docs/enterprise-legacy/runs/multifactor-authentication.html.md
+++ b/content/source/docs/enterprise-legacy/runs/multifactor-authentication.html.md
@@ -8,11 +8,13 @@ description: |-
 
 # AWS Multi-Factor Authentication for Terraform Runs in Terraform Enterprise
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 You can optionally configure Terraform plans and applies to use multi-factor authentication using [AWS Secure Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html).
 
 This option is disabled by default and can be enabled by an organization owner.
 
-!> This is an advanced feature that enables changes to active infrastructure
+-> This is an advanced feature that enables changes to active infrastructure
 without user confirmation. Please understand the implications to your
 infrastructure before enabling.
 

--- a/content/source/docs/enterprise-legacy/runs/notifications.html.md
+++ b/content/source/docs/enterprise-legacy/runs/notifications.html.md
@@ -9,6 +9,8 @@ description: |-
 
 # Terraform Run Notifications
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise can send run notifications, the following events are
 configurable:
 

--- a/content/source/docs/enterprise-legacy/runs/scheduling-runs.html.md
+++ b/content/source/docs/enterprise-legacy/runs/scheduling-runs.html.md
@@ -9,9 +9,7 @@ description: |-
 
 # Schedule Periodic Plan Runs
 
--> This is an unreleased beta feature. Please
-<a href="mailto:support@hashicorp.com">contact support</a> if you are interested
-in helping us test this feature.
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
 
 Terraform can automatically run a plan against your infrastructure on a
 specified schedule. This option is disabled by default and can be enabled by an

--- a/content/source/docs/enterprise-legacy/runs/starting.html.md
+++ b/content/source/docs/enterprise-legacy/runs/starting.html.md
@@ -9,6 +9,8 @@ description: |-
 
 # Starting Terraform Runs
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 There are a variety of ways to queue a Terraform run in Terraform Enterprise. In addition to
 `terraform push`, you can connect your environment
 to GitHub and runs based on new commits. You can

--- a/content/source/docs/enterprise-legacy/runs/variables-and-configuration.html.md
+++ b/content/source/docs/enterprise-legacy/runs/variables-and-configuration.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Terraform Variables and Configuration
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 There are several ways to configure Terraform runs:
 
 1. Terraform variables

--- a/content/source/docs/enterprise-legacy/state/collaborating.html.md
+++ b/content/source/docs/enterprise-legacy/state/collaborating.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Collaborating on Terraform Remote State
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise is one of a few options to store [remote state](/docs/state/remote.html).
 
 Remote state gives you the ability to version and collaborate on Terraform

--- a/content/source/docs/enterprise-legacy/state/index.html.md
+++ b/content/source/docs/enterprise-legacy/state/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # State
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise stores the state of your managed infrastructure from the
 last time Terraform was run. The state is stored remotely, which works better in a
 team environment, allowing you to store, version and collaborate on state.

--- a/content/source/docs/enterprise-legacy/state/pushing.html.md
+++ b/content/source/docs/enterprise-legacy/state/pushing.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Pushing Terraform Remote State to Terraform Enterprise
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise is one of a few options to store [remote state](/docs/enterprise-legacy/state).
 
 Remote state gives you the ability to version and collaborate on Terraform

--- a/content/source/docs/enterprise-legacy/state/resolving-conflicts.html.md
+++ b/content/source/docs/enterprise-legacy/state/resolving-conflicts.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Resolving Conflicts in Remote States
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Resolving state conflicts can be time consuming and error prone, so it's
 important to approach it carefully.
 

--- a/content/source/docs/enterprise-legacy/user-accounts/access.html.md
+++ b/content/source/docs/enterprise-legacy/user-accounts/access.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Access
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise allows collaboration on resources, with several access levels available for users.
 
 ### Read

--- a/content/source/docs/enterprise-legacy/user-accounts/authentication.html.md
+++ b/content/source/docs/enterprise-legacy/user-accounts/authentication.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Authentication
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise requires a username and password to sign up and login.
 However, there are several ways to authenticate with your account.
 

--- a/content/source/docs/enterprise-legacy/user-accounts/index.html.md
+++ b/content/source/docs/enterprise-legacy/user-accounts/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # User Accounts
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Users are the main identity system in Terraform Enterprise. A user can be a
 member of multiple [organizations](/docs/enterprise-legacy/organizations/index.html),
 as well as individually collaborate on various resources.

--- a/content/source/docs/enterprise-legacy/user-accounts/recovery.html.md
+++ b/content/source/docs/enterprise-legacy/user-accounts/recovery.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Account Recovery
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 If you have lost access to your Terraform Enterprise account, use the reset
 password form on the login page to send yourself a link to reset your password.
 

--- a/content/source/docs/enterprise-legacy/vcs/bitbucket.html.md
+++ b/content/source/docs/enterprise-legacy/vcs/bitbucket.html.md
@@ -7,6 +7,8 @@ description: |-
 ---
 # Bitbucket Cloud
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Bitbucket Cloud can be used to import Terraform configuration, automatically
 queuing runs when changes are merged into a repository's default branch.
 Additionally, plans are run when a pull request is created or updated. Terraform

--- a/content/source/docs/enterprise-legacy/vcs/git.html.md
+++ b/content/source/docs/enterprise-legacy/vcs/git.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Git Integration
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Git repositories can be integrated with Terraform Enterprise by using
 [`terraform push`](/docs/commands/push.html) to import Terraform configuration
 when changes are committed. When Terraform configuration is imported using

--- a/content/source/docs/enterprise-legacy/vcs/github.html.md
+++ b/content/source/docs/enterprise-legacy/vcs/github.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # GitHub Integration
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 GitHub can be used to import Terraform configuration, automatically queuing runs
 when changes are merged into a repository's default branch. Additionally, plans
 are run when a pull request is created or updated. Terraform Enterprise will

--- a/content/source/docs/enterprise-legacy/vcs/gitlab.html.md
+++ b/content/source/docs/enterprise-legacy/vcs/gitlab.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # GitLab.com, GitLab Community, & GitLab Enterprise
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 GitLab can be used to import Terraform configuration, automatically
 queuing runs when changes are merged into a repository's default branch.
 Additionally, plans are run when a pull request is created or updated. Terraform

--- a/content/source/docs/enterprise-legacy/vcs/index.html.md
+++ b/content/source/docs/enterprise-legacy/vcs/index.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # Integration with Version Control Software
 
+!> **Deprecation warning**: Terraform Enterprise (Legacy) features of Atlas will no longer be actively developed or maintained and will be fully decommissioned on Thursday, May 31, 2018. Please see our [Upgrading From Terraform Enterprise (Legacy)](https://www.terraform.io/docs/enterprise/upgrade/index.html) guide to migrate to the new Terraform Enterprise.
+
 Terraform Enterprise can integrate with your version control software to
 automatically execute Terraform with your latest Terraform configuration as you
 commit changes to source control.


### PR DESCRIPTION
The documentation only included deprecation warnings for Packer and Artifact Registry before. This update adds deprecation warnings to Terraform Enterprise (Legacy) pages with a link to the upgrade guide.