### PR TITLE
Add `include` to API docs

### DIFF
--- a/content/source/docs/enterprise/api/configuration-versions.html.md
+++ b/content/source/docs/enterprise/api/configuration-versions.html.md
@@ -8,6 +8,102 @@ sidebar_current: "docs-enterprise2-api-configuration-versions"
 
 -> **Note**: These API endpoints are in beta and are subject to change.
 
+## List Configuration Versions
+
+| Method | Path           |
+| :----- | :------------- |
+| GET | /workspaces/:workspace_id/configuration-versions |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/workspaces/ws-2Qhk7LHgbMrm3grF/configuration-versions
+```
+
+### Sample Response
+
+```json
+{
+    "data": [
+        {
+            "id": "cv-ntv3HbhJqvFzamy7",
+            "type": "configuration-versions",
+            "attributes": {
+                "error": null,
+                "source": "gitlab",
+                "status": "uploaded",
+                "status-timestamps": {}
+            },
+            "relationships": {
+                "ingress-attributes": {
+                    "data": {
+                        "id": "ia-i4MrTxmQXYxH2nYD",
+                        "type": "ingress-attributes"
+                    },
+                    "links": {
+                        "related": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/ingress-attributes"
+                    }
+                }
+            },
+            "links": {
+                "self": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7"
+            }
+        }
+    ]
+}
+```
+
+## Show a Configuration Version
+
+| Method | Path           |
+| :----- | :------------- |
+| GET | /configuration-versions/:configuration-id |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7
+```
+
+### Sample Response
+
+```json
+{
+    "data": {
+        "id": "cv-ntv3HbhJqvFzamy7",
+        "type": "configuration-versions",
+        "attributes": {
+            "error": null,
+            "source": "gitlab",
+            "status": "uploaded",
+            "status-timestamps": {}
+        },
+        "relationships": {
+            "ingress-attributes": {
+                "data": {
+                    "id": "ia-i4MrTxmQXYxH2nYD",
+                    "type": "ingress-attributes"
+                },
+                "links": {
+                    "related": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/ingress-attributes"
+                }
+            }
+        },
+        "links": {
+            "self": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7"
+        }
+    }
+}
+```
+
 ## Create a Configuration Version
 
 A configuration version (`configuration-version`) is a resource used to reference the uploaded configuration files. It is associated with the run to use the uploaded configuration files for performing the plan and apply.

--- a/content/source/docs/enterprise/api/configuration-versions.html.md
+++ b/content/source/docs/enterprise/api/configuration-versions.html.md
@@ -10,9 +10,11 @@ sidebar_current: "docs-enterprise2-api-configuration-versions"
 
 ## List Configuration Versions
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /workspaces/:workspace_id/configuration-versions |
+`GET /workspaces/:workspace_id/configuration-versions`
+
+Parameter            | Description
+---------------------|------------
+`:workspace_id` | The id of the workspace to list configurations from.
 
 ### Sample Request
 
@@ -28,40 +30,42 @@ curl \
 
 ```json
 {
-    "data": [
-        {
-            "id": "cv-ntv3HbhJqvFzamy7",
-            "type": "configuration-versions",
-            "attributes": {
-                "error": null,
-                "source": "gitlab",
-                "status": "uploaded",
-                "status-timestamps": {}
-            },
-            "relationships": {
-                "ingress-attributes": {
-                    "data": {
-                        "id": "ia-i4MrTxmQXYxH2nYD",
-                        "type": "ingress-attributes"
-                    },
-                    "links": {
-                        "related": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/ingress-attributes"
-                    }
-                }
-            },
-            "links": {
-                "self": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7"
-            }
+  "data": [
+    {
+      "id": "cv-ntv3HbhJqvFzamy7",
+      "type": "configuration-versions",
+      "attributes": {
+        "error": null,
+        "source": "gitlab",
+        "status": "uploaded",
+        "status-timestamps": {}
+      },
+      "relationships": {
+        "ingress-attributes": {
+          "data": {
+            "id": "ia-i4MrTxmQXYxH2nYD",
+            "type": "ingress-attributes"
+          },
+          "links": {
+            "related": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/ingress-attributes"
+          }
         }
-    ]
+      },
+      "links": {
+        "self": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7"
+      }
+    }
+  ]
 }
 ```
 
 ## Show a Configuration Version
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /configuration-versions/:configuration-id |
+`GET /configuration-versions/:configuration-id`
+
+Parameter            | Description
+---------------------|------------
+`:configuration-id` | The id of the configuration to show.
 
 ### Sample Request
 
@@ -77,30 +81,30 @@ curl \
 
 ```json
 {
-    "data": {
-        "id": "cv-ntv3HbhJqvFzamy7",
-        "type": "configuration-versions",
-        "attributes": {
-            "error": null,
-            "source": "gitlab",
-            "status": "uploaded",
-            "status-timestamps": {}
-        },
-        "relationships": {
-            "ingress-attributes": {
-                "data": {
-                    "id": "ia-i4MrTxmQXYxH2nYD",
-                    "type": "ingress-attributes"
-                },
-                "links": {
-                    "related": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/ingress-attributes"
-                }
-            }
+  "data": {
+    "id": "cv-ntv3HbhJqvFzamy7",
+    "type": "configuration-versions",
+    "attributes": {
+      "error": null,
+      "source": "gitlab",
+      "status": "uploaded",
+      "status-timestamps": {}
+    },
+    "relationships": {
+      "ingress-attributes": {
+        "data": {
+          "id": "ia-i4MrTxmQXYxH2nYD",
+          "type": "ingress-attributes"
         },
         "links": {
-            "self": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7"
+          "related": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/ingress-attributes"
         }
+      }
+    },
+    "links": {
+      "self": "/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7"
     }
+  }
 }
 ```
 
@@ -172,3 +176,9 @@ $ curl \
     -F 'data=@config.tar.gz' \
     http://127.0.0.1:7675/v1/object/4c44d964-eba7-4dd5-ad29-1ece7b99e8da
 ```
+
+## Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
+
+- `ingress_attributes` - The commit information used in the configuration

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -108,6 +108,59 @@ Since these parameters were originally designed as part of a JSON object, they s
 
 For more about URI structure and query strings, see [the specification (RFC 3986)](https://tools.ietf.org/html/rfc3986) or [the Wikipedia page on URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
 
+### Inclusion of Related Resources
+
+Some of the API's GET endpoints can return additional information about nested resources by adding an `include` query parameter, whose value is a comma-separated list of resource types.
+
+The related resource options are listed in each endpoint's documentation where available.
+
+The related resources will appear in an `included` section of the response.
+
+Example:
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/teams/team-n8UQ6wfhyym25sMe?include=users
+```
+
+```json
+{
+  "data": {
+    "id": "team-n8UQ6wfhyym25sMe",
+    "type": "teams",
+    "attributes": {
+      "name": "owners",
+      "users-count": 1
+      ...
+    },
+    "relationships": {
+      "users": {
+        "data": [
+          {
+              "id": "hashibot",
+              "type": "users"
+          }
+        ]
+      } ...
+    }
+    ...
+  },
+  "included": [
+    {
+      "id": "hashibot",
+      "type": "users",
+      "attributes": {
+        "username": "hashibot"
+        ...
+      } ...
+    }
+  ]
+}
+```
+
 ## Community client libraries and tools
 
 The community client libraries and tools listed below have been built by the community of Terraform Enterprise users and vendors. These client libraries and tools are not tested nor officially maintained by HashiCorp, and are listed here in order to help users find them easily.

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -268,3 +268,13 @@ curl \
   --data @payload.json \
   https://app.terraform.io/api/v2/runs/run-DQGdmrWMX8z9yWQB/actions/discard
 ```
+
+## Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
+
+- `plan` - Additional information about plans.
+- `apply` - Additional information about applies.
+- `created_by` - Full user records of the users responsible for creating the runs.
+- `configuration_version` - The configuration record used in the run.
+- `configuration_version.ingress_attributes` - The commit information used in the run.

--- a/content/source/docs/enterprise/api/team-members.html.md
+++ b/content/source/docs/enterprise/api/team-members.html.md
@@ -59,7 +59,7 @@ curl \
   https://app.terraform.io/api/v2/teams/257525/relationships/users
 ```
 
-# Delete a User from Team
+## Delete a User from Team
 
 This method removes multiple users from a team. Both users and teams must already exist. This DOES NOT delete the user; it only removes them from this team.
 

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -10,6 +10,61 @@ sidebar_current: "docs-enterprise2-api-teams"
 
 The Teams API is used to create and destroy teams. The [Team Membership API](./team-members.html) is used to add or remove users from a team. To give a team access to a workspace use the [Team Access API](./team-access.html) to associate a team with privileges on a workspace.
 
+## List teams
+
+`GET organizations/:organization_name/teams`
+
+Parameter            | Description
+---------------------|------------
+`:organization_name` | The name of the organization to list teams from.
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/organizations/my-organization/teams
+```
+
+### Sample Response
+
+```json
+{
+  "data": [
+    {
+      "id": "257529",
+      "type": "teams",
+      "attributes": {
+        "name": "owners",
+        "users-count": 1,
+        "permissions": {
+          "can-update-membership": false,
+          "can-destroy": false
+        }
+      },
+      "relationships": {
+        "users": {
+          "data": [
+            {
+              "id": "hashibot",
+              "type": "users"
+            }
+          ]
+        },
+        "authentication-token": {
+          "meta": {}
+        }
+      },
+      "links": {
+        "self": "/api/v2/teams/team-n8UQ6wfhyym25sMe"
+      }
+    }
+  ]
+}
+```
+
 ## Create a Team
 
 `POST /organizations/:organization_name/teams`
@@ -75,8 +130,59 @@ $ curl \
 }
 ```
 
+## Show Team Information
 
-# Delete a Team
+`GET /teams/:team_id`
+
+Parameter   | Description
+------------|------------
+`:team_id`  | The team ID to be shown.
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $ATLAS_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/teams/257529
+```
+
+### Sample Response
+```json
+{
+  "data": {
+    "id": "257529",
+    "type": "teams",
+    "attributes": {
+      "name": "owners",
+      "users-count": 1,
+      "permissions": {
+        "can-update-membership": false,
+        "can-destroy": false
+      }
+    },
+    "relationships": {
+      "users": {
+        "data": [
+          {
+            "id": "hashibot",
+            "type": "users"
+          }
+        ]
+      },
+      "authentication-token": {
+        "meta": {}
+      }
+    },
+    "links": {
+      "self": "/api/v2/teams/257529"
+    }
+  }
+}
+```
+
+## Delete a Team
 
 `DELETE /teams/:team_id`
 
@@ -94,3 +200,9 @@ $ curl \
   --request DELETE \
   https://app.terraform.io/api/v2/teams/257529
 ```
+
+## Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
+
+- `users` (`string`) - Returns the full user record for every member of a team.

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -895,3 +895,18 @@ $ curl \
   }
 }
 ```
+
+
+## Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
+
+- `organization` - The full organization record.
+- `latest_run` - Additional information about the last run.
+- `latest_run.plan ` - The plan used in the last run.
+- `latest_run.configuration_version` - The configuration used in the last run.
+- `latest_run.configuration_version.ingress_attributes` - The commit information used in the last run.
+- `current_run` - Additional information about the current run.
+- `current_run.plan` - The plan used in the current run.
+- `current_run.configuration_version` - The configuration used in the current run.
+- `current_run.configuration_version.ingress_attributes` - The commit information used in the current run.


### PR DESCRIPTION
My attempt at adding documentation for the `include` parameter. It allows related resources to be included in a query and additional information to be returned.

**All writing feedback will be accepted without sass. Please critique**

http://jsonapi.org/format/#fetching-includes