### PR TITLE
Adds a section on community client libraries and tools

### DIFF
--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -107,3 +107,12 @@ Although most of our API endpoints use the POST method and receive their paramet
 Since these parameters were originally designed as part of a JSON object, they sometimes have characters that must be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding) in a query parameter. For example, `[` becomes `%5B` and `]` becomes `%5D`.
 
 For more about URI structure and query strings, see [the specification (RFC 3986)](https://tools.ietf.org/html/rfc3986) or [the Wikipedia page on URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
+
+## Community client libraries and tools
+
+The community client libraries and tools listed below have been built by the community of Terraform Enterprise users and vendors. These client libraries and tools are not tested nor officially maintained by HashiCorp, and are listed here in order to help users find them easily.
+
+If you have built a client library and would like to add it to this community list, please [contribute](https://github.com/hashicorp/terraform-website#contributions-welcome) to [this page](https://github.com/hashicorp/terraform-website/blob/master/content/source/docs/enterprise/api/index.html.md).
+
+- [tf_api_gateway](https://github.com/PlethoraOfHate/tf_api_gateway): Python API library and console app
+- [terraform-enterprise-client](https://github.com/skierkowski/terraform-enterprise-client): Ruby API library and console app


### PR DESCRIPTION
This adds the "Community client libraries and tools" section to the bottom of the Terraform Enterprise API documentation. 