### PR TITLE
provide more clarity on initial runs and plan-only runs

### DIFF
--- a/content/source/docs/enterprise/workspaces/creating.html.md
+++ b/content/source/docs/enterprise/workspaces/creating.html.md
@@ -40,10 +40,12 @@ There are also several optional fields, which you can reveal by clicking the "Mo
 
 When you create a new workspace, a few things happen:
 
-- TFE _doesn't_ immediately queue a plan for the workspace. Instead, it presents a dialog with shortcut links to either queue a plan or edit variables.
-- TFE automatically registers a webhook with your VCS service. The next time new commits appear in the selected branch of that repo, TFE will automatically queue a Terraform plan for the workspace.
+- TFE _doesn't_ immediately queue a plan for the workspace. Instead, it presents a dialog with shortcut links to either queue a plan or edit variables. If you don't need to edit variables, manually queuing a plan confirms to TFE that the workspace is ready to run.
+- TFE automatically registers a webhook with your VCS service. The next time new commits appear in the selected branch of that repo or a PR is opened to that branch, TFE will automatically queue a Terraform plan for the workspace. More at [VCS Connection webhooks](../vcs/index.html#webhooks).
 
-Most of the time, you'll want do do some of the following after creating a workspace:
+A workspace with no runs will not accept new runs via VCS webhook; at least one run must be manually queued to confirm that the workspace is ready for further runs.
+
+Most of the time, you'll want to do one or more of the following after creating a workspace:
 
 - [Edit variables](./variables.html)
 - [Edit workspace settings](./settings.html)

--- a/content/source/docs/enterprise/workspaces/run-ui.html.md
+++ b/content/source/docs/enterprise/workspaces/run-ui.html.md
@@ -15,13 +15,15 @@ Terraform Enterprise (TFE) has two workflows for managing Terraform runs.
 
 In the UI and VCS workflow, every workspace is associated with a specific branch of a VCS repo of Terraform configurations. TFE registers webhooks with your VCS provider when you create a workspace, then automatically queues a Terraform run whenever new commits are merged to the workspace's branch.
 
+By default, TFE also performs a plan-only run when a pull request is opened against that branch. As described at [VCS Connection webhooks](../vcs/index.html#webhooks), plan-only runs can't be applied, although their details can be viewed in TFE via a link in the VCS status check.
+
 The Terraform code for a run always comes from version control, and is always associated with a specific commit.
 
 ## Starting Runs
 
 Most of the time, you start a run automatically by committing changes to version control.
 
-If the code in version control hasn't changed but you've modified some variables in TFE, you can also manually queue a plan from the UI. Each workspace has a "Queue Plan" button, and the form for editing variables also includes a "Save & Plan" button.
+When you initially set up the workspace and add variables, or if the code in version control hasn't changed but you've modified some variables in TFE, you can manually queue a plan from the UI. Each workspace has a "Queue Plan" button, and the form for editing variables also includes a "Save & Plan" button.
 
 Manually queueing a plan requires write or admin access.
 


### PR DESCRIPTION
Customers tend to be a bit confused sometimes by having to manually queue an initial run, and how plan-only runs behave, so I wanted to add a few more notes on that.