### PR TITLE
Increase header levels on some Private TFE pages to generate page-internal links

### DIFF
--- a/content/source/docs/enterprise/private/diagnostics.html.md
+++ b/content/source/docs/enterprise/private/diagnostics.html.md
@@ -9,7 +9,7 @@ sidebar_current: "docs-enterprise2-diagnostics"
 This document contains information on how to provide HashiCorp with diagnostic information about a Private Terraform Enterprise (PTFE)
 installation that requires assistance from HashiCorp support.
 
-# AMI-based installs
+## AMI-based installs
 
 To generate a support bundle, connect to the instance via ssh and run `sudo hashicorp-support`. Below is a sample session:
 
@@ -67,11 +67,11 @@ hashicorp-support.tar.gz.enc                                                    
 
 Then, attach the bundle to your support ticket. If possible, use the SendSafely integration (as it allows for large file uploads).
 
-## Windows
+### Windows
 
 On Microsoft Windows, tools such as [PSCP](https://www.ssh.com/ssh/putty/putty-manuals/0.68/Chapter5.html) and [WinSCP](https://winscp.net/eng/index.php) can be used to transfer the file.
 
-# Installer-based Instances
+## Installer-based Instances
 
 Diagnostic information is available via in the Installer dashboard on port 8800 of your installation.
 
@@ -85,6 +85,6 @@ On the next page, click the _Download Support Bundle_ button which will download
 
 Then, attach the bundle to your support ticket. If possible, use the SendSafely integration (as it allows for large file uploads).
 
-# Pre-Sales uploads
+## Pre-Sales uploads
 
-Customers in the pre-sales phase can upload files directly at https://hashicorp.sendsafely.com/dropzone/private-tfe.
+Customers in the pre-sales phase can upload support bundle files directly at https://hashicorp.sendsafely.com/dropzone/private-tfe.

--- a/content/source/docs/enterprise/private/logging.html.md
+++ b/content/source/docs/enterprise/private/logging.html.md
@@ -8,7 +8,7 @@ sidebar_current: "docs-enterprise2-logging"
 
 This document contains information about interacting with Private Terraform Enterprise logs. There are two types of logs, application logs and audit logs. Application logs emit information about the services that comprise Terraform Enterprise. Audit logs emit information whenever any resource managed by Terraform Enterprise is changed.
 
-# Application Logs - AMI based installs
+## Application Logs - AMI based installs
 
 Private Terraform Enterprise's application-level services all log to CloudWatch logs, with one stream per service. The stream names take the format:
 
@@ -38,11 +38,11 @@ tfe.mycompany.io-terraform-state-parser
 
 CloudWatch logs can be searched, filtered, and read from either from the AWS Web Console or (recommended) the command line [`awslogs`](https://github.com/jorgebastida/awslogs) tool.
 
-## System-level Logs
+### System-level Logs
 
 All other system-level logs can be found in the standard locations for an Ubuntu 16.04 system.
 
-# Application Logs - Installer Beta
+## Application Logs - Installer Beta
 
 The installer-based version runs the application in a set of docker containers. As such, any tooling that can interact with docker logs
 can read the logs. This includes running the command `docker logs`, as well as access the [Docker API](https://docs.docker.com/engine/api/v1.36/#operation/ContainerLogs).
@@ -65,19 +65,19 @@ them to `logs.mycompany.com` over TCP on port 55555 using syslog over TLS.
    All other log drivers prevent the support bundle functionality from gathering logs, making it
    impossible to provide product support. **DO NOT** change the log driver of an installation to anything other than `json-file` or `journald`.
 
-# Audit Logs
+## Audit Logs
 
 Audit log entries are written to the application logs. To distinguish audit Log entries from other log entries, the JSON is prefixed with `[Audit Log]`.
 
-## AMI based installs
+### AMI based installs
 
 As of Private Terraform Enterprise release v201802-1, audit logging is available in Private Terraform Enterprise. These are written out to CloudWatch logs just like all other application-level logs.
 
-## Installer Beta
+### Installer Beta
 
 The audit logs have been available in the installer beta since beta4. They are emitted along with other logs by the `ptfe_atlas` container.
 
-## Log Contents
+### Log Contents
 
 The audit log will be updated when any resource managed by Terraform Enterprise is changed. Read requests will be logged for resources deemed sensitive. These include:
 
@@ -90,8 +90,7 @@ The audit log will be updated when any resource managed by Terraform Enterprise 
   * Users
   * Variables
 
-
-When requests occur, these are the pieces of information that will be logged:
+When requests occur, these pieces of information will be logged:
 
   1. The actor
     * Users (including IP address)
@@ -105,13 +104,13 @@ When requests occur, these are the pieces of information that will be logged:
     * Deletion of existing resources
     * Additional actions as defined in /actions/* namespaces
     * Webhook API calls
-  3. The target of the action (any resource exposed by APIv2)
+  3. The target of the action (any resource exposed by the V2 API)
   4. The time that the action occurred
   5. Where the action was taken (web/API request, background job, etc.)
 
-## Log Format
+### Log Format
 
-Log entries are in JSON, just like other terraform logs. Most audit log entries will be formatted like this: 
+Log entries are in JSON, just like other Terraform logs. Most audit log entries are formatted like this: 
 
 ``` json
 {


### PR DESCRIPTION
Page-internal links are only generated for H2 and below, so these pages didn't have them for the top-level sections, which was unfortunate for trying to direct customers to specific sections. :)