### PR TITLE
Move SAML to private TFE section of the sidebar nav

### DIFF
--- a/content/source/docs/enterprise/saml/attributes.html.md
+++ b/content/source/docs/enterprise/saml/attributes.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML User Attributes - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml-attributes"
+sidebar_current: "docs-enterprise2-private-saml-attributes"
 ---
 
 # Attributes

--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML Configuration - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml-configuration"
+sidebar_current: "docs-enterprise2-private-saml-configuration"
 ---
 
 # Configuration

--- a/content/source/docs/enterprise/saml/identity-provider-configuration-onelogin.html.md
+++ b/content/source/docs/enterprise/saml/identity-provider-configuration-onelogin.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML OneLogin Identity Provider Configuration - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml-identity-provider-configuration-onelogin"
+sidebar_current: "docs-enterprise2-private-saml-identity-provider-configuration-onelogin"
 ---
 
 # OneLogin Configuration

--- a/content/source/docs/enterprise/saml/identity-provider-configuration.html.md
+++ b/content/source/docs/enterprise/saml/identity-provider-configuration.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML Identity Provider Configuration - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml-identity-provider-configuration"
+sidebar_current: "docs-enterprise2-private-saml-identity-provider-configuration"
 ---
 
 # Identity Provider Configuration

--- a/content/source/docs/enterprise/saml/index.html.md
+++ b/content/source/docs/enterprise/saml/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml"
+sidebar_current: "docs-enterprise2-private-saml"
 ---
 
 # SAML Single Sign On

--- a/content/source/docs/enterprise/saml/login.html.md
+++ b/content/source/docs/enterprise/saml/login.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML Login - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml-login"
+sidebar_current: "docs-enterprise2-private-saml-login"
 ---
 
 # Login with SAML

--- a/content/source/docs/enterprise/saml/team-membership.html.md
+++ b/content/source/docs/enterprise/saml/team-membership.html.md
@@ -1,7 +1,7 @@
 ---
 layout: enterprise2
 page_title: "SAML Team Membership - Terraform Enterprise"
-sidebar_current: "docs-enterprise2-saml-team-membership"
+sidebar_current: "docs-enterprise2-private-saml-team-membership"
 ---
 
 # Team Membership Mapping

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -150,32 +150,6 @@
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-saml") %>>
-        <a href="/docs/enterprise/saml/index.html">SAML SSO</a>
-        <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-saml-configuration") %>>
-            <a href="/docs/enterprise/saml/configuration.html">Configuration</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-saml-team-membership") %>>
-            <a href="/docs/enterprise/saml/team-membership.html">Team Membership</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-saml-attributes") %>>
-            <a href="/docs/enterprise/saml/attributes.html">Attributes</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-saml-login") %>>
-            <a href="/docs/enterprise/saml/login.html">Login</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-saml-identity-provider-configuration") %>>
-            <a href="/docs/enterprise/saml/identity-provider-configuration.html">Identity Provider Configuration</a>
-            <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-saml-identity-provider-configuration-onelogin") %>>
-                <a href="/docs/enterprise/saml/identity-provider-configuration-onelogin.html">OneLogin</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </li>
-
       <li<%= sidebar_current("docs-enterprise2-sentinel") %>>
         <a href="/docs/enterprise/sentinel/index.html">Sentinel</a>
         <ul class="nav">
@@ -227,6 +201,32 @@
           <li<%= sidebar_current("docs-enterprise2-private-config") %>>
             <a href="/docs/enterprise/private/config.html">Configuration</a>
           </li>
+          <li<%= sidebar_current("docs-enterprise2-private-saml") %>>
+            <a href="/docs/enterprise/saml/index.html">SAML SSO</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-enterprise2-private-saml-configuration") %>>
+                <a href="/docs/enterprise/saml/configuration.html">Configuration</a>
+              </li>
+              <li<%= sidebar_current("docs-enterprise2-private-saml-team-membership") %>>
+                <a href="/docs/enterprise/saml/team-membership.html">Team Membership</a>
+              </li>
+              <li<%= sidebar_current("docs-enterprise2-private-saml-attributes") %>>
+                <a href="/docs/enterprise/saml/attributes.html">Attributes</a>
+              </li>
+              <li<%= sidebar_current("docs-enterprise2-private-saml-login") %>>
+                <a href="/docs/enterprise/saml/login.html">Login</a>
+              </li>
+              <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration") %>>
+                <a href="/docs/enterprise/saml/identity-provider-configuration.html">Identity Provider Configuration</a>
+                <ul class="nav">
+                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-onelogin") %>>
+                    <a href="/docs/enterprise/saml/identity-provider-configuration-onelogin.html">OneLogin</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+
           <li<%= sidebar_current("docs-enterprise2-private-vault") %>>
             <a href="/docs/enterprise/private/vault.html">External Vault (Installer)</a>
           </li>


### PR DESCRIPTION
SAML single sign on is only applicable to private TFE, so it should be in with
the private TFE administration and configuration docs. This commit only adjusts
the sidebar nav hierarchy; it doesn't move the saml/ directory, to avoid
breaking links. We can do that later and add redirects if we want, but it seems
unnecessary for now.