### PR TITLE
Sidebar: wrapping longer resource names

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -20,6 +20,7 @@
       a {
         color: $sidebar-link-color;
         font-size: $sidebar-font-size;
+        overflow-wrap: break-word;
         padding: 10px 0 10px 15px;
 
         &:before {


### PR DESCRIPTION
Currently resource names which are too long are truncated (technically hidden, I guess) by the main page body, as shown with `azurerm_sql_active_directory_administrator` here:

<img width="414" alt="screen shot 2018-04-09 at 08 17 01" src="https://user-images.githubusercontent.com/666005/38489203-f528aa72-3be5-11e8-9ae2-93e8bd3c1853.png">

.. instead this PR attempts to fix this by wrapping the resource name onto multiple lines; as shown here:

<img width="265" alt="screen shot 2018-04-09 at 08 16 47" src="https://user-images.githubusercontent.com/666005/38489224-03de27e0-3be6-11e8-95a1-f75ddc7822eb.png">

as shown in the image above this PR isn't flawless (IMO the `n` in `azurerm_postgresql_configuration` above shouldn't be on a separate line) - but it helps make longer resource names readable/differentiable.