### PR TITLE
Soft launch of "Extending Terraform" section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 VERSION?="0.3.32"
-EXTEND=${SHOW_EXTEND}
 
 build:
 	@echo "==> Starting build in Docker..."
 	@mkdir -p content/build
 	@docker run \
 		--interactive \
-    -e "SHOW_EXTEND=${EXTEND}" \
 		--rm \
 		--tty \
 		--volume "$(shell pwd)/ext:/ext" \
@@ -19,7 +17,6 @@ website:
 	@echo "==> Starting website in Docker..."
 	@docker run \
 		--interactive \
-    -e "SHOW_EXTEND=${EXTEND}" \
 		--rm \
 		--tty \
 		--publish "4567:4567" \

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -170,3 +170,4 @@
 /docs/enterprise/vcs/bitbucket.html                      /docs/enterprise/vcs/bitbucket-cloud.html
 /docs/enterprise/vcs/git.html                            /docs/enterprise-legacy/vcs/git.html
 /docs/enterprise/vcs/gitlab.html                         /docs/enterprise/vcs/gitlab-eece.html
+/guides/writing-custom-terraform-providers.html          /docs/extend/writing-custom-providers.html

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -76,18 +76,7 @@
                   <li><a href="/intro/index.html">Intro</a></li>
                   <li><a href="/docs/index.html">Docs</a></li>
                   <li><a href="/guides/index.html">Guides</a></li>
-                  <%
-                    ext=ENV['SHOW_EXTEND'] || ""
-                    if ext.empty?
-                  %>
-                     <li><a href="/community.html">Community</a></li>
-                  <%
-                    else
-                  %>
-                     <li><a href="/docs/extend/index.html">Extend</a></li>
-                  <%
-                    end
-                  %>
+                  <li><a href="/docs/extend/index.html">Extend</a></li>
                   <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
                   <li>
                     <a href="/downloads.html">


### PR DESCRIPTION
- Changes links
- remove `SHOW_EXTEND` env var that was used for testing
- add redirect from old writing plugins guide to new location