### PR TITLE
API template updates

### DIFF
--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -8,11 +8,6 @@ Follow this template to format each API method. There are usually multiple secti
 
 <!-- ^ The method and path are styled as a single code span, with global prefix (`/api/v2`) omitted and the method capitalized. -->
 
-- On success: HTTP 200 and a JSON API document (`type: "somethings"`).
-- On failure: HTTP 409 and a non-JSON error message.
-
-<!-- ^ Include status codes even if they're plain 200/404. If a JSON API document is returned, specify the `type`. -->
-
 Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to create the something in. The organization must already exist in the system, and the user must have permissions to create new somethings.
@@ -20,6 +15,13 @@ Parameter            | Description
 <!-- ^ The list of URL path parameters goes directly below the method and path, without a header of its own. They're simpler than other parameters because they're always strings and they're always mandatory, so this table only has two columns. Prefix URL path parameter names with a colon.
 
 If further explanation of this method is needed beyond its title, write it here, after the parameter list. -->
+
+Result  | Status and response
+--------|------------------------
+Success | HTTP 200 and a JSON API document (`type: "somethings"`).
+Failure | HTTP 409 and a non-JSON error message.
+
+<!-- ^ Include status codes even if they're plain 200/404. If a JSON API document is returned, specify the `type`. If there are multiple success or failure scenarios, put something descriptive in the "Result" column to distinguish them. -->
 
 ### Query Parameters
 

--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -41,6 +41,7 @@ Properties without a default value are required.
 Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
 `data.type`                 | string |         | Must be `"somethings"`.
+`data[].type`               | string |         | ... <!-- use data[].x when data is an array of objects. -->
 `data.attributes.category`  | string |         | Whether this is a blue or red something. Valid values are `"blue"` or `"red"`.
 `data.attributes.sensitive` | bool   | `false` | Whether the value is sensitive. If true then the something is written once and not visible thereafter.
 `filter.workspace.name`     | string |         | The name of the workspace that owns the something.
@@ -60,6 +61,19 @@ them from unquoted values like booleans and nulls.
 - In the rare case where a parameter is optional but has no default, you can
   list something like "(nothing)" as the default and explain in the description.
 -->
+
+### Available Related Resources
+
+<!-- Omit this subheader and section if it's not applicable. -->
+
+This GET endpoint can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
+
+Resource Name      | Description
+-------------------|------------
+`organization`     | The full organization record.
+`latest_run`       | Additional information about the last run.
+`latest_run.plan ` | The plan used in the last run.
+
 
 ### Sample Payload
 

--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -8,6 +8,11 @@ Follow this template to format each API method. There are usually multiple secti
 
 <!-- ^ The method and path are styled as a single code span, with global prefix (`/api/v2`) omitted and the method capitalized. -->
 
+- On success: HTTP 200 and a JSON API document (`type: "somethings"`).
+- On failure: HTTP 409 and a non-JSON error message.
+
+<!-- ^ Include status codes even if they're plain 200/404. If a JSON API document is returned, specify the `type`. -->
+
 Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to create the something in. The organization must already exist in the system, and the user must have permissions to create new somethings.


### PR DESCRIPTION
- Add status codes and return values.
- Add a spot for related resources.
- Add example of `data[].x`.

For @caseylang: I've associated the related resources with each endpoint here. Sacrificing brevity for clarity explicitness. y/n?

For @dylanegan: How you feelin' about that format for the status/return values? Tried to keep it basic and terse, even though the nature of a `vars` object, for example, is a little opaque at the moment... still thinking about how to handle that. 