### PR TITLE
make: Add website-provider target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,29 @@ website:
 		--volume "$(shell pwd)/content:/website" \
 		hashicorp/middleman-hashicorp:${VERSION}
 
+website-provider:
+ifeq ($(PROVIDER_PATH),)
+	@echo 'Please set PROVIDER_PATH'
+	exit 1
+endif
+ifeq ($(PROVIDER_NAME),)
+	@echo 'Please set PROVIDER_NAME'
+	exit 1
+endif
+	@echo "==> Starting $(PROVIDER_NAME) provider website in Docker..."
+	@docker run \
+		--interactive \
+		--rm \
+		--tty \
+		--publish "4567:4567" \
+		--publish "35729:35729" \
+		--volume "$(PROVIDER_PATH)/website:/website" \
+		--volume "$(PROVIDER_PATH)/website:/ext/providers/$(PROVIDER_NAME)/website" \
+		--volume "$(shell pwd)/content:/terraform-website" \
+		--volume "$(shell pwd)/content/source/assets:/website/docs/assets" \
+		--volume "$(shell pwd)/content/source/layouts:/website/docs/layouts" \
+		hashicorp/middleman-hashicorp:${VERSION}
+
 sync:
 	@echo "==> Syncing submodules for upstream changes"
 	@git submodule update --init --remote


### PR DESCRIPTION
This allows us to shorten/simplify the Makefile target in provider repositories, as proposed in https://github.com/terraform-providers/terraform-provider-aws/pull/4122#issuecomment-380159767

to something like

```make
website:
ifneq (,$(wildcard "$(GOPATH)/src/$WEBSITE_REPO"))
	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
	go get $WEBSITE_REPO
endif
	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=aws
```