### PR TITLE
make: Add website-test & website-provider-test (link checker)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ website:
 
 website-test:
 	@echo "==> Testing website in Docker..."
+	-@docker stop "tf-website-temp"
 	@docker run \
 		--detach \
 		--rm \
@@ -72,6 +73,7 @@ ifeq ($(PROVIDER_NAME),)
 	exit 1
 endif
 	@echo "==> Testing $(PROVIDER_NAME) provider website in Docker..."
+	-@docker stop "tf-website-temp"
 	@docker run \
 		--detach \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,19 @@ website:
 		--volume "$(shell pwd)/content:/website" \
 		hashicorp/middleman-hashicorp:${VERSION}
 
+website-test:
+	@echo "==> Testing website in Docker..."
+	@docker run \
+		--detach \
+		--rm \
+		--name "tf-website-temp" \
+		--publish "4567:4567" \
+		--volume "$(shell pwd)/ext:/ext" \
+		--volume "$(shell pwd)/content:/website" \
+		hashicorp/middleman-hashicorp:${VERSION}
+	$(MKFILE_PATH)/content/scripts/check-links.sh "http://127.0.0.1:4567" "/"
+	@docker stop "tf-website-temp"
+
 website-provider:
 ifeq ($(PROVIDER_PATH),)
 	@echo 'Please set PROVIDER_PATH'

--- a/content/scripts/check-links.sh
+++ b/content/scripts/check-links.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+URL=$1
+ACCEPT_PATH=$2
+
+wget \
+	--tries=120 \
+	--accept-regex "${URL}${ACCEPT_PATH}*" \
+	--delete-after \
+	--level inf \
+	--no-directories \
+	--no-host-directories \
+	--no-verbose \
+	--page-requisites \
+	--recursive \
+	--spider \
+	$URL


### PR DESCRIPTION
## In action

### AWS provider

```
$ make website-test # from aws provider repo
```
```
==> Testing aws provider website in Docker...
0c8928fd14784520a61fde9e411ff9485c70ae9eb0ae29a025aaf281edf5b3a2
/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-website
/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-website/content/scripts/check-links.sh "http://127.0.0.1:4567" "/docs/providers/aws/"
No data received.
No data received.
No data received.
No data received.
No data received.
2018-04-12 08:00:30 URL:http://127.0.0.1:4567/ [127788/127788] -> "index.html.tmp.tmp" [1]

...

Found no broken links.

FINISHED --2018-04-12 08:00:52--
Total wall clock time: 37s
Downloaded: 416 files, 44M in 0.2s (289 MB/s)
tf-website-aws-temp
```

### Whole website

```
$ make website-test
```
```
==> Testing website in Docker...
284121652caa90efcccc70430b46c96b7b4c01badf75b086644273c2a7bfac9c
/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-website/content/scripts/check-links.sh "http://127.0.0.1:4567" "/"
No data received.
No data received.
No data received.
No data received.
No data received.
2018-04-12 08:08:27 URL:http://127.0.0.1:4567/ [68692/68692] -> "index.html.tmp.tmp" [1]

...

Found no broken links.

FINISHED --2018-04-12 08:14:16--
Total wall clock time: 6m 8s
Downloaded: 1756 files, 89M in 2.1s (42.4 MB/s)
tf-website-temp
```