### PR TITLE
Reuse existing Gemfile+config for provider site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ endif
 		--volume "$(shell pwd)/content:/terraform-website" \
 		--volume "$(shell pwd)/content/source/assets:/website/docs/assets" \
 		--volume "$(shell pwd)/content/source/layouts:/website/docs/layouts" \
+		--workdir /terraform-website \
+		-e PROVIDER_NAME=$(PROVIDER_NAME) \
 		hashicorp/middleman-hashicorp:${VERSION}
 
 website-provider-test:
@@ -84,8 +86,9 @@ endif
 		--volume "$(shell pwd)/content:/terraform-website" \
 		--volume "$(shell pwd)/content/source/assets:/website/docs/assets" \
 		--volume "$(shell pwd)/content/source/layouts:/website/docs/layouts" \
+		--workdir /terraform-website \
 		hashicorp/middleman-hashicorp:${VERSION}
-	$(MKFILE_PATH)/content/scripts/check-links.sh "http://127.0.0.1:4567" "/docs/providers/$(PROVIDER_NAME)/"
+	$(MKFILE_PATH)/content/scripts/check-links.sh "http://127.0.0.1:4567/docs/providers/$(PROVIDER_NAME)/"
 	@docker stop "tf-website-$(PROVIDER_NAME)-temp"
 
 sync:

--- a/content/config.rb
+++ b/content/config.rb
@@ -11,3 +11,10 @@ config[:file_watcher_ignore] += [/^(\/website\/)?ext\//]
 
 require "middleman_helpers"
 helpers Helpers
+
+if ENV.include?('PROVIDER_NAME')
+  provider = ENV['PROVIDER_NAME']
+  logger.info("==")
+  logger.info("==> See #{provider} docs at http://localhost:4567/docs/providers/#{provider}")
+  logger.info("==")
+end


### PR DESCRIPTION
This allows us to reduce the amount of plumbing code we need to put into each provider codebase as discussed in https://github.com/terraform-providers/terraform-provider-aws/pull/4122 and with @bflad via Slack.
