### PR TITLE
Add default description to make for better unfurls

### DIFF
--- a/content/middleman_helpers.rb
+++ b/content/middleman_helpers.rb
@@ -27,7 +27,7 @@ module Helpers
   #
   # @return [String]
   def description_for(page)
-    description = (page.data.description || "")
+    description = (page.data.description || "Terraform by HashiCorp")
       .gsub('"', '')
       .gsub(/\n+/, ' ')
       .squeeze(' ')


### PR DESCRIPTION
My latest discovery in the Saga of Reasonable Unfurls is that
descriptions are crucial to getting a non-huge image printed.

Here, we set a default description to make it so that every page has at
least something there. Ideally we should be writing descriptions for all
our pages, but this will help as a stopgap unfurl improvement in the
meantime.