### PR TITLE
Provide redirects for aws_codecommit_* resource pages that were fixed for naming consistency

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -45,6 +45,8 @@
 /docs/providers/aws/r/alb_listener_rule.html      /docs/providers/aws/r/lb_listener_rule.html
 /docs/providers/aws/r/alb_target_group.html       /docs/providers/aws/r/lb_target_group.html
 /docs/providers/aws/r/alb_target_group_attachment.html    /docs/providers/aws/r/lb_target_group_attachment.html
+/docs/providers/aws/r/code_commit_repository.html /docs/providers/aws/r/codecommit_repository.html
+/docs/providers/aws/r/code_commit_trigger.html    /docs/providers/aws/r/codecommit_trigger.html
 /docs/providers/aws/d/alb.html                    /docs/providers/aws/d/lb.html
 /docs/providers/aws/d/alb_listener.html           /docs/providers/aws/d/lb_listener.html
 /docs/providers/aws/d/alb_target_group.html       /docs/providers/aws/d/lb_target_group.html


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/4330

The AWS provider change will go out tomorrow, 4/25, with the v1.16.0 release.