### PR TITLE
WIP: Add an FAQ section on disabling VCS webhook SSL config

### DIFF
--- a/content/source/docs/enterprise/private/faq.html.md
+++ b/content/source/docs/enterprise/private/faq.html.md
@@ -14,6 +14,7 @@ This page will provide answers to many common questions around Private Terraform
 4. [Upgrade Information](#migrating-from-a-legacy-terraform-enterprise-installation)
 5. [Migration from SaaS-based Terraform Enterprise](#migrating-from-terraform-enterprise-saas)
 6. [Required Network Access](#network-access)
+7. [Disabling VCS Webhook SSL verification](#disabling-vcs-webhook-ssl-verification)
 7. [Managing the Terraform State of the Install Process](#storing-terraform-enterprise-state)
 8. [Support](#support-for-private-terraform-enterprise)
 9. [Private Terraform Enterprise Architecture](#private-terraform-enterprise-architecture)
@@ -218,6 +219,16 @@ When displaying Terraform Runs, Private Terraform Enterprise has JavaScript that
 
 * Private Terraform Enterprise uses the configured SMTP endpoint for sending emails
 * Twilio can optionally be set up for for SMS-based 2FA (virtual TOTP support is available separately which does not make external API calls)
+
+---
+## Disabling VCS webhook SSL verification
+
+If running PTFE with a self-signed certificate (which is not recommended) or with a certificate that the connected VCS system does not trust, webhooks on the VCS must have SSL verification disabled in order to push data to PTFE. This configuration is _not recommended_ but is included here for reference.
+
+* **GitHub and GitHub Enterprise**: In the repository settings, select **Webhooks**, and then choose a webhook. Click the **Disable SSL verification** button above the event list, then confirm. See the [API Reference for this value](https://developer.github.com/v3/repos/hooks/#create-a-hook) for more information.
+* [GitLab.com and GitLab EE/CE](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#ssl-verification)
+* [Bitbucket Cloud](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-create_webhookCreatingwebhooks)
+* Bitbucket Server
 
 ---
 

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -24,8 +24,8 @@ Before you begin, you'll need to prepare data files and a Linux instance.
 * TLS private key and certificate
   * The installer allows for using a self-signed certificate but HashiCorp does
     _not_ recommended this. Your VCS provider will likely reject that certificate
-    when sending webhooks. If you do use the self-signed certificate, you must configure
-    each webhook to ignore SSL errors within your VCS provider.
+    when sending webhooks. If you do use the self-signed certificate, you must [configure
+    each webhook to ignore SSL errors](./faq.html#disabling-vcs-webhook-ssl-verification) within your VCS provider.
 * License key (provided by HashiCorp)
 
 ~> **Note:** If you use your own certificate and it is issued by a private Certificate


### PR DESCRIPTION
 ...linked to from the installer mention of self-signed certs.

@amy-hashi Do you know where to find the instructions for the web post hooks plugin we use with BBS? I couldn't see anything for it.