### PR TITLE
Update how we set the environment to production, for segment tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION?="0.3.35"
 MKFILE_PATH=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+DEPLOY_ENV?="development"
 
 build:
 	@echo "==> Starting build in Docker..."
@@ -11,7 +12,7 @@ build:
 		--volume "$(shell pwd)/ext:/ext" \
 		--volume "$(shell pwd)/content:/website" \
 		--volume "$(shell pwd)/content/build:/website/build" \
-		-e "ENV=production" \
+		-e "DEPLOY_ENV=${DEPLOY_ENV}" \
 		hashicorp/middleman-hashicorp:${VERSION} \
 		bundle exec middleman build --verbose --clean
 
@@ -23,6 +24,7 @@ website:
 		--tty \
 		--publish "4567:4567" \
 		--publish "35729:35729" \
+		-e "DEPLOY_ENV=${DEPLOY_ENV}" \
 		--volume "$(shell pwd)/ext:/ext" \
 		--volume "$(shell pwd)/content:/website" \
 		hashicorp/middleman-hashicorp:${VERSION}

--- a/content/middleman_helpers.rb
+++ b/content/middleman_helpers.rb
@@ -2,13 +2,13 @@ module Helpers
   # Returns a segment tracking ID such that local development is not
   # tracked to production systems.
   def segmentId()
-    if (ENV['ENV'] == 'production')
+    if (ENV['DEPLOY_ENV'] == 'production')
       'EnEETDWhfxp1rp09jVvJr66LdvwI6KVP'
     else
       '0EXTgkNx0Ydje2PGXVbRhpKKoe5wtzcE'
     end
   end
-  
+
   # Returns the FQDN of the image URL.
   #
   # @param [String] path

--- a/packer.json
+++ b/packer.json
@@ -24,7 +24,7 @@
         "AWS_ACCESS_KEY_ID={{ user `aws_access_key_id` }}",
         "AWS_SECRET_ACCESS_KEY={{ user `aws_secret_access_key` }}",
         "AWS_REGION={{ user `aws_region` }}",
-        "ENV={{ user `website_environment` }}",
+        "DEPLOY_ENV={{ user `website_environment` }}",
         "FASTLY_API_KEY={{ user `fastly_api_key` }}"
       ],
       "inline": [


### PR DESCRIPTION
Default to `development`, which should always use the dev key from middleman helpers. Any value for `DEPLOY_ENV` will have that affect too, but thought it good to be explicit. Only a value of `production` will result in the production key.

This fixes an issue we have right now, where the development key is being used and data is being sent and registered as Development traffic and not Production traffic. 