### PR TITLE
Clarify usage of self-signed certs behind an LB

### DIFF
--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -141,7 +141,7 @@ If a Classic or Application Load Balancer is used, SSL/TLS will be terminated th
 In this configuration, the PTFE instances should still be configured to listen
 for incoming SSL/TLS connections but can do so using a self-signed certificate.
 
-The load balancer, being configured to send traffic to port 443 on the instances
+Since the load balancer is configured to send traffic to port 443 on the instances
 as type `https`, will ignore the fact that it can't trust the self-signed certificate
 and operate correctly.
 

--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -137,6 +137,14 @@ clients and the PTFE application server. The certificate can be
 specified during the UI-based installation or the path to the
 certificate codified during an unattended installation.
 
+If a Classic or ALB Load Balancer is used, SSL/TLS will be terminated there.
+In this configuration, the PTFE instances should still be configured to listen
+for incoming SSL/TLS connections but can do so using a self-signed certificate.
+
+The Load Balancer, being configured to send traffic to port 443 on the instances
+as type `https` will ignore the fact that it can't trust the self-signed certificate
+and operate correctly.
+
 ## Infrastructure Diagram
 
 ![aws-infrastructure-diagram](./assets/aws-infrastructure-diagram.png)

--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -137,12 +137,12 @@ clients and the PTFE application server. The certificate can be
 specified during the UI-based installation or the path to the
 certificate codified during an unattended installation.
 
-If a Classic or ALB Load Balancer is used, SSL/TLS will be terminated there.
+If a Classic or Application Load Balancer is used, SSL/TLS will be terminated there.
 In this configuration, the PTFE instances should still be configured to listen
 for incoming SSL/TLS connections but can do so using a self-signed certificate.
 
-The Load Balancer, being configured to send traffic to port 443 on the instances
-as type `https` will ignore the fact that it can't trust the self-signed certificate
+The load balancer, being configured to send traffic to port 443 on the instances
+as type `https`, will ignore the fact that it can't trust the self-signed certificate
 and operate correctly.
 
 ## Infrastructure Diagram


### PR DESCRIPTION
The guide doesn't have much about using a non network load balancer, but at list this section will clarify how to use an internal self-signed cert in the case someone uses a Classic or ALB LB.