### PR TITLE
scripts: Allow rejecting paths in link checker

### DIFF
--- a/content/scripts/check-links.sh
+++ b/content/scripts/check-links.sh
@@ -3,10 +3,16 @@ set -e
 
 URL=$1
 ACCEPT_PATH=$2
+REJECT_PATH=$3
+
+if [ -n "$REJECT_PATH" ]; then
+	REJECT_REGEX_ARG="--reject-regex ${URL}${REJECT_PATH}"
+fi
 
 wget \
 	--tries=120 \
 	--accept-regex "${URL}${ACCEPT_PATH}*" \
+	$REJECT_REGEX_ARG \
 	--delete-after \
 	--level inf \
 	--no-directories \


### PR DESCRIPTION
This is to unblock https://github.com/hashicorp/terraform/pull/17982 and allow exclusion of paths when checking links.