### PR TITLE
Document cases where organization tokens don't work

### DIFF
--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -16,7 +16,7 @@ Parameter            | Description
 
 If further explanation of this method is needed beyond its title, write it here, after the parameter list. -->
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 <!-- ^ Include a note like the above if the endpoint CANNOT be used with a given token type. Most endpoints don't need this. -->
 

--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -25,7 +25,7 @@ Status  | Response                                     | Reason
 [200][] | [JSON API document][] (`type: "somethings"`) | Successfully created a team
 [400][] | [JSON API error object][]                    | Invalid `include` parameter
 [404][] | [JSON API error object][]                    | Organization not found, or user unauthorized to perform action
-[422][] | [JSON API error object][]                    | Validation errors
+[422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 [500][] | [JSON API error object][]                    | Failure during team creation
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -2,7 +2,7 @@ Follow this template to format each API method. There are usually multiple secti
 
 ## Create a Something
 
-<!-- "Verb a Noun" or "Verb Nouns." -->
+<!-- Header: "Verb a Noun" or "Verb Nouns." -->
 
 `POST /organizations/:organization_name/somethings`
 
@@ -15,6 +15,10 @@ Parameter            | Description
 <!-- ^ The list of URL path parameters goes directly below the method and path, without a header of its own. They're simpler than other parameters because they're always strings and they're always mandatory, so this table only has two columns. Prefix URL path parameter names with a colon.
 
 If further explanation of this method is needed beyond its title, write it here, after the parameter list. -->
+
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
+<!-- ^ Include a note like the above if the endpoint CANNOT be used with a given token type. Most endpoints don't need this. -->
 
 Status  | Response                                     | Reason
 --------|----------------------------------------------|----------

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -9,15 +9,22 @@ sidebar_current: "docs-enterprise2-api"
 
 -> **Note**: These API endpoints are in beta and are subject to change.
 
-Terraform Enterprise provides an API for a subset of its features. If you have any questions or want to request new API features, please email support@hashicorp.com.
+Terraform Enterprise (TFE) provides an API for a subset of its features. If you have any questions or want to request new API features, please email support@hashicorp.com.
 
 See the navigation sidebar for the list of available endpoints.
 
 ## Authentication
 
-All requests must be authenticated with a bearer token. Use the HTTP Header `Authorization` with the value `Bearer <token>`. This token can be generated or revoked on the account tokens page. Your token has access to all resources your account has access to.
+All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, TFE responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.
 
-For organization-level resources, we recommend creating a separate user account that can be added to the organization with the specific privilege level required.
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+
+There are three kinds of token available:
+
+- [User tokens](../users-teams-organizations/users.html#api-tokens) — each TFE user can have any number of API tokens, which can make requests on their behalf.
+- [Team tokens](../users-teams-organizations/service-accounts.html#team-service-accounts) — each team has an associated service account, which can have one API token at a time. This is intended for performing plans and applies via a CI/CD pipeline.
+- [Organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts) — each organization also has a service account, which can have one API token at a time. This is intended for automating the management of teams, team membership, and workspaces. The organization token cannot perform plans and applies.
 
 ## Response Codes
 

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -16,9 +16,9 @@ Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to generate a token for.
 
-Generates a new organization token and overrides existing token if one exists. This token can be used to act as [the organization service account](../users-teams-organizations/service-accounts.html).
+Generates a new organization token, replacing any existing token. This token can be used to act as [the organization service account](../users-teams-organizations/service-accounts.html).
 
-Only members of the owners team, the owners team service account, and the organization service account can use this endpoint.
+Only members of the owners team, the owners [team service account](../users-teams-organizations/service-accounts.html#team-service-accounts), and the [organization service account](../users-teams-organizations/service-accounts.html#organization-service-accounts) can use this endpoint.
 
 Status  | Response                                                | Reason
 --------|---------------------------------------------------------|-------

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -10,15 +10,25 @@ sidebar_current: "docs-enterprise2-api-organization-tokens"
 
 ## Generate a new organization token
 
-Generates a new organization token and overrides existing token if one exists.
+`POST /organizations/:organization_name/authentication-token`
 
-| Method | Path           |
-| :----- | :------------- |
-| POST | /organizations/:organization/authentication-token |
+Parameter            | Description
+---------------------|------------
+`:organization_name` | The name of the organization to generate a token for.
 
-### Parameters
+Generates a new organization token and overrides existing token if one exists. This token can be used to act as [the organization service account](../users-teams-organizations/service-accounts.html).
 
-- `:organization` (`string: <required>`) - specifies the organization for the organization token
+Only members of the owners team, the owners team service account, and the organization service account can use this endpoint.
+
+Status  | Response                                                | Reason
+--------|---------------------------------------------------------|-------
+[201][] | [JSON API document][] (`type: "authentication-tokens"`) | Success
+[404][] | [JSON API error object][]                               | User not authorized
+
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -57,13 +67,20 @@ curl \
 
 ## Delete the organization token
 
-| Method | Path           |
-| :----- | :------------- |
-| DELETE | /organizations/:organization/authentication-token |
+`DELETE /organizations/:organization/authentication-token`
 
-### Parameters
+Parameter            | Description
+---------------------|------------
+`:organization_name` | Which organization's token should be deleted.
 
-- `:organization` (`string: <required>`) - specifies the organization for the organization token
+Only members of the owners team, the owners team service account, and the organization service account can use this endpoint.
+
+Status  | Response                                             | Reason
+--------|------------------------------------------------------|-------
+[204][] | Nothing                                              | Success
+[404][] | [JSON API error object][]                            | User not authorized
+
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -138,7 +138,7 @@ Status  | Response                                        | Reason
 --------|-------------------------------------------------|----------
 [201][] | [JSON API document][] (`type: "organizations"`) | The organization was successfully created
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
-[422][] | [JSON API error object][]                       | Validation errors
+[422][] | [JSON API error object][]                       | Malformed request body (missing attributes, wrong types, etc.)
 
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
@@ -229,7 +229,7 @@ Status  | Response                                        | Reason
 --------|-------------------------------------------------|----------
 [200][] | [JSON API document][] (`type: "organizations"`) | The organization was successfully updated
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
-[422][] | [JSON API error object][]                       | Validation errors
+[422][] | [JSON API error object][]                       | Malformed request body (missing attributes, wrong types, etc.)
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
@@ -320,11 +320,9 @@ Status  | Response                                        | Reason
 --------|-------------------------------------------------|----------
 [204][] |                                                 | The organization was successfully destroyed
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
-[422][] | [JSON API error object][]                       | Validation errors
 
 [204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -43,7 +43,7 @@ Status  | Response                               | Reason
 [200][] | [JSON API document][] (`type: "runs"`) | Successfully created a run
 [401][] | [JSON API error object][]              | Tried to create run with organization token (use a user or team token instead)
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
-[422][] | [JSON API error object][]              | Validation errors
+[422][] | [JSON API error object][]              | Malformed request body (missing attributes, wrong types, etc.)
 
 [JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -23,7 +23,7 @@ Alternately, you can create a run with a pre-existing configuration version, eve
 
 A run performs a plan and apply, using a configuration version and the workspace’s current variables. You can specify a configuration version when creating a run; if you don’t provide one, the run defaults to the workspace’s most recently used version. (A configuration version is “used” when it is created or used for a run in this workspace.)
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 ### Request Body
 
@@ -158,7 +158,7 @@ This endpoint queues the request to perform an apply; the apply might not happen
 
 This endpoint represents an action as opposed to a resource. As such, the endpoint does not return any object in the response body.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 
 Status  | Response                  | Reason(s)
@@ -210,7 +210,7 @@ Parameter      | Description
 ---------------|------------
 `workspace_id` | The workspace ID to list runs for.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                                         | Reason
 --------|--------------------------------------------------|-------
@@ -305,7 +305,7 @@ This endpoint queues the request to perform a discard; the discard might not hap
 
 This endpoint represents an action as opposed to a resource. As such, it does not return any object in the response body.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
@@ -357,7 +357,7 @@ This endpoint queues the request to perform a cancel; the cancel might not happe
 
 This endpoint represents an action as opposed to a resource. As such, it does not return any object in the response body.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -41,9 +41,9 @@ Key path                    | Type   | Default | Description
 Status  | Response                               | Reason
 --------|----------------------------------------|-------
 [200][] | [JSON API document][] (`type: "runs"`) | Successfully created a run
+[401][] | [JSON API error object][]              | Tried to create run with organization token (use a user or team token instead)
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]              | Validation errors
-[401][] | [JSON API error object][]              | Tried to create run with organization token (use a user or team token instead)
 
 [JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
@@ -164,8 +164,8 @@ This endpoint represents an action as opposed to a resource. As such, the endpoi
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a discard request.
-[409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
 [401][] | [JSON API error object][] | Tried to apply run with organization token (use a user or team token instead)
+[409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
 
 [202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
 [409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
@@ -286,7 +286,7 @@ curl \
         "self": "/api/v2/runs/run-bWSq4YeYpfrW4mx7"
       }
     },
-    ...
+    {...}
   ]
 }
 ```
@@ -310,8 +310,8 @@ This endpoint represents an action as opposed to a resource. As such, it does no
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a discard request.
-[409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
 [401][] | [JSON API error object][] | Tried to discard run with organization token (use a user or team token instead)
+[409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
 
 ### Request Body
 
@@ -362,8 +362,8 @@ This endpoint represents an action as opposed to a resource. As such, it does no
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a cancel request.
-[409][] | [JSON API error object][] | Run was not planning or applying; cancel not allowed.
 [401][] | [JSON API error object][] | Tried to cancel run with organization token (use a user or team token instead)
+[409][] | [JSON API error object][] | Run was not planning or applying; cancel not allowed.
 
 ### Request Body
 

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -41,7 +41,6 @@ Key path                    | Type   | Default | Description
 Status  | Response                               | Reason
 --------|----------------------------------------|-------
 [200][] | [JSON API document][] (`type: "runs"`) | Successfully created a run
-[401][] | [JSON API error object][]              | Tried to create run with organization token (use a user or team token instead)
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]              | Malformed request body (missing attributes, wrong types, etc.)
 
@@ -49,7 +48,6 @@ Status  | Response                               | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 
 
 ### Sample Payload
@@ -164,7 +162,6 @@ This endpoint represents an action as opposed to a resource. As such, the endpoi
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a discard request.
-[401][] | [JSON API error object][] | Tried to apply run with organization token (use a user or team token instead)
 [409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
 
 [202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
@@ -210,12 +207,9 @@ Parameter      | Description
 ---------------|------------
 `workspace_id` | The workspace ID to list runs for.
 
--> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
-
 Status  | Response                                         | Reason
 --------|--------------------------------------------------|-------
 [200][] | Array of [JSON API document][]s (`type: "runs"`) | Successfully listed runs
-[401][] | [JSON API error object][]                        | Tried to list runs with organization token (use a user or team token instead)
 
 ### Query Parameters
 
@@ -310,7 +304,6 @@ This endpoint represents an action as opposed to a resource. As such, it does no
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a discard request.
-[401][] | [JSON API error object][] | Tried to discard run with organization token (use a user or team token instead)
 [409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
 
 ### Request Body
@@ -362,7 +355,6 @@ This endpoint represents an action as opposed to a resource. As such, it does no
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a cancel request.
-[401][] | [JSON API error object][] | Tried to cancel run with organization token (use a user or team token instead)
 [409][] | [JSON API error object][] | Run was not planning or applying; cancel not allowed.
 
 ### Request Body

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -23,6 +23,8 @@ Alternately, you can create a run with a pre-existing configuration version, eve
 
 A run performs a plan and apply, using a configuration version and the workspace’s current variables. You can specify a configuration version when creating a run; if you don’t provide one, the run defaults to the workspace’s most recently used version. (A configuration version is “used” when it is created or used for a run in this workspace.)
 
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
 ### Request Body
 
 This POST endpoint requires a JSON object with the following properties as a request payload.
@@ -41,11 +43,13 @@ Status  | Response                               | Reason
 [200][] | [JSON API document][] (`type: "runs"`) | Successfully created a run
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]              | Validation errors
+[401][] | [JSON API error object][]              | Tried to create run with organization token (use a user or team token instead)
 
 [JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 
 
 ### Sample Payload
@@ -154,10 +158,14 @@ This endpoint queues the request to perform an apply; the apply might not happen
 
 This endpoint represents an action as opposed to a resource. As such, the endpoint does not return any object in the response body.
 
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
+
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a discard request.
 [409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
+[401][] | [JSON API error object][] | Tried to apply run with organization token (use a user or team token instead)
 
 [202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
 [409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
@@ -201,6 +209,13 @@ curl \
 Parameter      | Description
 ---------------|------------
 `workspace_id` | The workspace ID to list runs for.
+
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
+Status  | Response                                         | Reason
+--------|--------------------------------------------------|-------
+[200][] | Array of [JSON API document][]s (`type: "runs"`) | Successfully listed runs
+[401][] | [JSON API error object][]                        | Tried to list runs with organization token (use a user or team token instead)
 
 ### Query Parameters
 
@@ -290,10 +305,13 @@ This endpoint queues the request to perform a discard; the discard might not hap
 
 This endpoint represents an action as opposed to a resource. As such, it does not return any object in the response body.
 
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a discard request.
 [409][] | [JSON API error object][] | Run was not paused for confirmation or priority; discard not allowed.
+[401][] | [JSON API error object][] | Tried to discard run with organization token (use a user or team token instead)
 
 ### Request Body
 
@@ -339,10 +357,13 @@ This endpoint queues the request to perform a cancel; the cancel might not happe
 
 This endpoint represents an action as opposed to a resource. As such, it does not return any object in the response body.
 
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a cancel request.
 [409][] | [JSON API error object][] | Run was not planning or applying; cancel not allowed.
+[401][] | [JSON API error object][] | Tried to cancel run with organization token (use a user or team token instead)
 
 ### Request Body
 

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -19,15 +19,23 @@ SSH keys can be used in two places:
 
 ## List SSH Keys
 
-List all the SSH Keys for a given organization.
+`GET /organizations/:organization_name/ssh-keys`
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /organizations/:organization_name/ssh-keys |
+Parameter            | Description
+---------------------|------------
+`:organization_name` | The name of the organization to list SSH keys for.
 
-### Parameters
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
-- `:organization_name` (`string: <required>`) - specifies the organization name where the SSH Keys are defined
+Status  | Response                                             | Reason
+--------|------------------------------------------------------|-------
+[200][] | Array of [JSON API document][]s (`type: "ssh-keys"`) | Success
+[404][] | [JSON API error object][]                            | Organization not found
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -59,15 +67,20 @@ curl \
 
 ## Get an SSH Key
 
-Get the name (and other metadata) associated with a given SSH key ID.
+`GET /ssh-keys/:ssh_key_id`
 
-| Method | Path           |
-| :----- | :------------- |
-| GET | /ssh-keys/:ssh_key_id |
+Parameter     | Description
+--------------|----------------------
+`:ssh_key_id` | The SSH key ID to get.
 
-### Parameters
+This endpoint is for looking up the name associated with an SSH key ID. It does not retrieve the key text.
 
-- `:ssh_key_id` (`string: <required>`) - specifies the SSH key ID to get
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
+Status  | Response                                   | Reason
+--------|--------------------------------------------|-------
+[200][] | [JSON API document][] (`type: "ssh-keys"`) | Success
+[404][] | [JSON API error object][]                  | SSH key not found or user not authorized
 
 ### Sample Request
 
@@ -96,26 +109,45 @@ curl \
 
 ## Create an SSH Key
 
-Create an SSH Key.
+`POST /organizations/:organization_name/ssh-keys`
 
-| Method | Path           |
-| :----- | :------------- |
-| POST | /organizations/:organization_name/ssh-keys |
+Parameter            | Description
+---------------------|------------
+`:organization_name` | The name of the organization to create an SSH key in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team.
 
-### Parameters
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
-- `:organization_name` (`string: <required>`) - specifies the organization name where the SSH keys are defined
-- `name` (`string: <required>`) - specifies the name of the SSH key
-- `value` (`string: <required>`) - specifies the text of the SSH private key
+Status  | Response                                   | Reason
+--------|--------------------------------------------|-------
+[201][] | [JSON API document][] (`type: "ssh-keys"`) | Success
+[422][] | [JSON API error object][]                  | Validation errors
+
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+Key path                    | Type   | Default | Description
+----------------------------|--------|---------|------------
+`data.type`                 | string |         | Must be `"ssh-keys"`.
+`data.attributes.name`      | string |         | A name to identify the SSH key.
+`data.attributes.value`     | string |         | The text of the SSH private key.
+
 
 ### Sample Payload
 
 ```json
 {
   "data": {
+    "type": "ssh-keys",
     "attributes": {
       "name": "SSH Key",
-      "value": "..."
+      "value": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAm6+JVgl..."
     }
   }
 }
@@ -151,16 +183,34 @@ curl \
 
 ## Update an SSH Key
 
-Update an SSH Key.
+`PATCH /ssh-keys/:ssh_key_id`
 
-| Method | Path           |
-| :----- | :------------- |
-| PATCH | /ssh-keys/:ssh_key_id |
+Parameter            | Description
+---------------------|------------
+`:ssh_key_id`        | The SSH key ID to update.
 
-### Parameters
+This endpoint lets you replace the name or value of an existing SSH key. Existing workspaces that use the key will be updated with the new name and/or key text.
 
-- `:ssh_key_id` (`string: <required>`) - specifies the SSH key ID to update
-- `name` (`string: <required>`) - specifies the name of the SSH key
+Only members of the owners team (or the owners team's service account) can edit SSH keys.
+
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
+Status  | Response                                   | Reason
+--------|--------------------------------------------|-------
+[200][] | [JSON API document][] (`type: "ssh-keys"`) | Success
+[404][] | [JSON API error object][]                  | SSH key not found or user not authorized
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+Key path                    | Type   | Default   | Description
+----------------------------|--------|-----------|------------
+`data.type`                 | string |           | Must be `"ssh-keys"`.
+`data.attributes.name`      | string | (nothing) | A name to identify the SSH key. If omitted, the existing name is preserved.
+`data.attributes.value`     | string | (nothing) | The text of the SSH private key. If omitted, the existing value is preserved.
 
 ### Sample Payload
 
@@ -204,15 +254,23 @@ curl \
 
 ## Delete an SSH Key
 
-Delete an SSH Key.
+`DELETE /ssh-keys/:ssh_key_id`
 
-| Method | Path           |
-| :----- | :------------- |
-| DELETE | /ssh-keys/:ssh_key_id |
+Parameter            | Description
+---------------------|------------
+`:ssh_key_id`        | The SSH key ID to delete.
 
-### Parameters
+Only members of the owners team (or the owners team's service account) can delete SSH keys.
 
-- `:ssh_key_id` (`string: <required>`) - specifies the SSH key ID to delete
+-> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+
+Status  | Response                                             | Reason
+--------|------------------------------------------------------|-------
+[204][] | Nothing                                              | Success
+[404][] | [JSON API error object][]                            | SSH key not found or user not authorized
+
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -30,7 +30,7 @@ Parameter            | Description
 Status  | Response                                             | Reason
 --------|------------------------------------------------------|-------
 [200][] | Array of [JSON API document][]s (`type: "ssh-keys"`) | Success
-[404][] | [JSON API error object][]                            | Organization not found
+[404][] | [JSON API error object][]                            | Organization not found or user not authorized
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
@@ -120,7 +120,8 @@ Parameter            | Description
 Status  | Response                                   | Reason
 --------|--------------------------------------------|-------
 [201][] | [JSON API document][] (`type: "ssh-keys"`) | Success
-[422][] | [JSON API error object][]                  | Validation errors
+[422][] | [JSON API error object][]                  | Malformed request body (missing attributes, wrong types, etc.)
+[404][] | [JSON API error object][]                  | User not authorized
 
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
@@ -191,7 +192,7 @@ Parameter            | Description
 
 This endpoint replaces the name and/or key text of an existing SSH key. Existing workspaces that use the key will be updated with the new values.
 
-Only members of the owners team (or the owners team's service account) can edit SSH keys.
+Only members of the owners team (or the owners team service account) can edit SSH keys.
 
 -> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
@@ -260,7 +261,7 @@ Parameter            | Description
 ---------------------|------------
 `:ssh_key_id`        | The SSH key ID to delete.
 
-Only members of the owners team (or the owners team's service account) can delete SSH keys.
+Only members of the owners team (or the owners team service account) can delete SSH keys.
 
 -> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -25,7 +25,7 @@ Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to list SSH keys for.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                                             | Reason
 --------|------------------------------------------------------|-------
@@ -75,7 +75,7 @@ Parameter     | Description
 
 This endpoint is for looking up the name associated with an SSH key ID. It does not retrieve the key text.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                                   | Reason
 --------|--------------------------------------------|-------
@@ -115,7 +115,7 @@ Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to create an SSH key in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                                   | Reason
 --------|--------------------------------------------|-------
@@ -189,11 +189,11 @@ Parameter            | Description
 ---------------------|------------
 `:ssh_key_id`        | The SSH key ID to update.
 
-This endpoint lets you replace the name or value of an existing SSH key. Existing workspaces that use the key will be updated with the new name and/or key text.
+This endpoint replaces the name and/or key text of an existing SSH key. Existing workspaces that use the key will be updated with the new values.
 
 Only members of the owners team (or the owners team's service account) can edit SSH keys.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                                   | Reason
 --------|--------------------------------------------|-------
@@ -262,7 +262,7 @@ Parameter            | Description
 
 Only members of the owners team (or the owners team's service account) can delete SSH keys.
 
--> **Note:** This endpoint is disabled for [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
+-> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 
 Status  | Response                                             | Reason
 --------|------------------------------------------------------|-------

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -78,7 +78,7 @@ Status  | Response                                | Reason
 [200][] | [JSON API document][] (`type: "teams"`) | Successfully created a team
 [400][] | [JSON API error object][]               | Invalid `include` parameter
 [404][] | [JSON API error object][]               | Organization not found, or user unauthorized to perform action
-[422][] | [JSON API error object][]               | Validation errors
+[422][] | [JSON API error object][]               | Malformed request body (missing attributes, wrong types, etc.)
 [500][] | [JSON API error object][]               | Failure during team creation
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -18,6 +18,10 @@ Parameter            | Description
 -------------------- | ------------
 `:organization_name` | The name of the organization to create the workspace in. The organization must already exist in the system, and the user must have permissions to create new workspaces.
 
+-> **Note:** Workspace creation is restricted to members of the owners team, the owners team [service account](../users-teams-organizations/service-accounts.html#team-service-accounts), and the [organization service account](../users-teams-organizations/service-accounts.html#organization-service-accounts).
+
+-> **Note:** Migrating legacy workspaces (with the `migration-environment` attribute) can only be done with a [user token](../users-teams-organizations/users.html#api-tokens). The user must be a member of the owners team in both the legacy organization and the new organization.
+
 ### Request Body
 
 This POST endpoint requires a JSON object with the following properties as a request payload.


### PR DESCRIPTION
- Adds some boilerplate to the template
- Adds org token notes to the SSH keys, workspaces, and runs API pages. 
- Investigated and updated a bunch of behavior
- Modernized some API pages while I was in there. 