### PR TITLE
Configurable link check delay for provider sites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ endif
 ifeq ($(PROVIDER_SLUG),)
 	$(eval PROVIDER_SLUG := $(PROVIDER_NAME))
 endif
-ifeq ($(LINKCHECK_DELAY,)
+ifeq ($(LINKCHECK_DELAY),)
 	$(eval LINKCHECK_DELAY := 15)
 endif
 	@echo "==> Testing $(PROVIDER_NAME) provider website in Docker..."

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ endif
 ifeq ($(PROVIDER_SLUG),)
 	$(eval PROVIDER_SLUG := $(PROVIDER_NAME))
 endif
-ifeq ($(MIDDLEMAN_STARTUP_DELAY),)
-	$(eval MIDDLEMAN_STARTUP_DELAY := 15)
+ifeq ($(LINKCHECK_DELAY,)
+	$(eval LINKCHECK_DELAY := 15)
 endif
 	@echo "==> Testing $(PROVIDER_NAME) provider website in Docker..."
 	-@docker stop "tf-website-$(PROVIDER_NAME)-temp"
@@ -100,8 +100,8 @@ endif
 		--volume "$(shell pwd)/content/source/layouts:/website/docs/layouts" \
 		--workdir /terraform-website \
 		hashicorp/middleman-hashicorp:${VERSION}
-	@echo "==> Waiting $(MIDDLEMAN_STARTUP_DELAY)s for middleman"
-	@sleep $(MIDDLEMAN_STARTUP_DELAY)
+	@echo "==> Waiting $(LINKCHECK_DELAY)s for website before linkchecking"
+	@sleep $(LINKCHECK_DELAY)
 	$(MKFILE_PATH)/content/scripts/check-links.sh "http://127.0.0.1:4567/docs/providers/$(PROVIDER_SLUG)/"
 	@docker stop "tf-website-$(PROVIDER_NAME)-temp"
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ endif
 ifeq ($(PROVIDER_SLUG),)
 	$(eval PROVIDER_SLUG := $(PROVIDER_NAME))
 endif
+ifeq ($(MIDDLEMAN_STARTUP_DELAY),)
+	$(eval MIDDLEMAN_STARTUP_DELAY := 15)
+endif
 	@echo "==> Testing $(PROVIDER_NAME) provider website in Docker..."
 	-@docker stop "tf-website-$(PROVIDER_NAME)-temp"
 	@docker run \
@@ -97,6 +100,8 @@ endif
 		--volume "$(shell pwd)/content/source/layouts:/website/docs/layouts" \
 		--workdir /terraform-website \
 		hashicorp/middleman-hashicorp:${VERSION}
+	@echo "==> Waiting $(MIDDLEMAN_STARTUP_DELAY)s for middleman"
+	@sleep $(MIDDLEMAN_STARTUP_DELAY)
 	$(MKFILE_PATH)/content/scripts/check-links.sh "http://127.0.0.1:4567/docs/providers/$(PROVIDER_SLUG)/"
 	@docker stop "tf-website-$(PROVIDER_NAME)-temp"
 


### PR DESCRIPTION
add startup delay to provider site linkchecks, my local tests showed 15 seconds was enough to not receive any `No data received` or `Connection reset by peer` messages from wget. Open to having the environment variable be named something friendlier