### PR TITLE
Configure wget to back-off up to 2 minutes before failing

### DIFF
--- a/content/scripts/check-links.sh
+++ b/content/scripts/check-links.sh
@@ -21,4 +21,5 @@ wget \
 	--page-requisites \
 	--recursive \
 	--spider \
+	--waitretry=120 \
 	$URL


### PR DESCRIPTION
This is an alternative to solving the failing CI, you will still see early `Connection reset by peer` or `No data received` messages but the max retry interval should now be more than enough for the website to startup. The advantage being there is zero config across providers as long as this number is large enough and it will not degrade performance for small providers that don't need a lot of time for middleman to startup.