### PR TITLE
Set s3cmd to remove the 'connection' header when setting svg mime-type

### DIFF
--- a/content/scripts/deploy.sh
+++ b/content/scripts/deploy.sh
@@ -114,6 +114,7 @@ if [ -z "$NO_UPLOAD" ]; then
   s3cmd \
     --mime-type="image/svg+xml" \
     --add-header="Cache-Control: max-age=31536000" \
+    --remove-header="Connection" \
     --exclude "*" \
     --include "*.svg" \
     --recursive \


### PR DESCRIPTION
Our deploys are failing when overriding the mime-type for SVGs. [Radek's PR to s3cmd](https://github.com/s3tools/s3cmd/pull/970) is said to fix this upstream, but rather than update `s3cmd` from `1.6.1` to `2.x.x` right away, let's try this, which I believe has the same effect 