### PR TITLE
docs/extending terraform read func

### DIFF
--- a/content/source/docs/extend/how-terraform-works.html.md
+++ b/content/source/docs/extend/how-terraform-works.html.md
@@ -64,7 +64,7 @@ their type.
 - Executing commands or scripts on the designated Resource after creation, or on
 destruction. 
 
-## Discovery 
+## Discovery
 
 ~> **Advanced topic:** This section describes Terraform's plugin discovery
 behavior at the level of detail a plugin developer might need. For instructions

--- a/content/source/docs/extend/writing-custom-providers.html.md
+++ b/content/source/docs/extend/writing-custom-providers.html.md
@@ -891,7 +891,6 @@ func flattenServiceMounts(in []mount.Mount) *schema.Set {
 }
 ```
 
-
 ## Next Steps
 
 This guide covers the schema and structure for implementing a Terraform provider


### PR DESCRIPTION
As requested by @catsby in https://github.com/terraform-providers/terraform-provider-docker/pull/40#issuecomment-389593699

- adds `resourceServerRead` at the end of the `create` and `update` function because this is the desired structure
- adds an example of a more complex example for `resourceServerRead` with a `flattener` and nested structures such as maps and sets.