### PR TITLE
Layouts: Make the mobile primary nav match the desktop one

### DIFF
--- a/content/source/layouts/_sidebar.erb
+++ b/content/source/layouts/_sidebar.erb
@@ -8,10 +8,9 @@
   <ul class="nav sidebar-nav">
     <li><a href="/intro/index.html">Intro</a></li>
     <li><a href="/docs/index.html">Docs</a></li>
+    <li><a href="/guides/index.html">Guides</a></li>
     <li><a href="/docs/extend/index.html">Extend</a></li>
     <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
-    <li><a href="/security.html">Security</a></li>
-    <li><a href="/assets/files/press-kit.zip">Press Kit</a></li>
   </ul>
 
   <div class="divider"></div>


### PR DESCRIPTION
This commit adds the missing "Guides" link to the mobile main nav, and removes
"Press Kit" and "Security" (which are linked at the bottom of the page on
both mobile and desktop widths).