### PR TITLE
Call out an issue with org rename and modules

### DIFF
--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -221,6 +221,8 @@ curl \
 
 `PATCH /organizations/:organization_name`
 
+-> **Note**: Renaming an organization is not recommended if the organization has modules in the Private Module Registry. To rename an organization with private modules, first, delete the modules from the Private Module Registry. Then make the name change. After the change is complete, reload the modules into the Private Module Registry.
+
 Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to update


### PR DESCRIPTION
It's not currently possible to rename an org which has modules, as those modules use the org name as their namespace. Discussion has begun on future resolutions to this issue. For now, a call out of the issue is sufficient.

Relates to https://app.asana.com/0/157256879238414/683075579461559/f