### PR TITLE
Swap order of installer and AMI support bundle docs

### DIFF
--- a/content/source/docs/enterprise/private/diagnostics.html.md
+++ b/content/source/docs/enterprise/private/diagnostics.html.md
@@ -9,6 +9,21 @@ sidebar_current: "docs-enterprise2-private-diagnostics"
 This document contains information on how to provide HashiCorp with diagnostic information about a Private Terraform Enterprise (PTFE)
 installation that requires assistance from HashiCorp support.
 
+## Installer-based Instances
+
+Diagnostic information is available via in the Installer dashboard on port 8800 of your installation.
+
+On the dashboard, click on the Support tab:
+
+![PTFE Dashboard Top](./assets/ptfe-dashboard.png)
+
+On the next page, click the _Download Support Bundle_ button which will download the support bundle directly to your web browser.
+
+![PTFE Support](./assets/ptfe-support.png)
+
+Then, attach the bundle to your support ticket. If possible, use the SendSafely integration (as it allows for large file uploads).
+
+
 ## AMI-based installs
 
 To generate a support bundle, connect to the instance via ssh and run `sudo hashicorp-support`. Below is a sample session:
@@ -70,20 +85,6 @@ Then, attach the bundle to your support ticket. If possible, use the SendSafely 
 ### Windows
 
 On Microsoft Windows, tools such as [PSCP](https://www.ssh.com/ssh/putty/putty-manuals/0.68/Chapter5.html) and [WinSCP](https://winscp.net/eng/index.php) can be used to transfer the file.
-
-## Installer-based Instances
-
-Diagnostic information is available via in the Installer dashboard on port 8800 of your installation.
-
-On the dashboard, click on the Support tab:
-
-![PTFE Dashboard Top](./assets/ptfe-dashboard.png)
-
-On the next page, click the _Download Support Bundle_ button which will download the support bundle directly to your web browser.
-
-![PTFE Support](./assets/ptfe-support.png)
-
-Then, attach the bundle to your support ticket. If possible, use the SendSafely integration (as it allows for large file uploads).
 
 ## Pre-Sales uploads
 


### PR DESCRIPTION
[Asana](https://app.asana.com/0/527290736177977/703199820895663/f) 

as we are getting ready to bid adieu to the AMI based ptfe, we want to start pushing up the visibility of the installer and its tools. 