### PR TITLE
mention install mode choice is final in installation doc

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -146,7 +146,8 @@ Terraform Enterprise can store its state in a few different ways and you'll
 need to decide which works best for your installation. Each option has a
 different approach to
 [recovering from failures](./reliability-availability.html#recovery-from-failures-1)
-and should be selected based on your organization's preferences.
+and should be selected based on your organization's preferences. The operational mode is selected
+at install time and cannot be changed once the install is running.
 
 1. **Production - External Services** - This mode stores the majority of the
    stateful data used by the instance in an external PostgreSQL database as


### PR DESCRIPTION
I added the same sentence in this main doc as mentioned in [Reliability and availability](https://www.terraform.io/docs/enterprise/private/reliability-availability.html#installer-architecture), because this is where the customer chooses and it's useful to know (and I had a hard time tracking it down in the other doc).