### PR TITLE
mention SAML enablement in re token perms as well

### DIFF
--- a/content/source/docs/enterprise/saml/login.html.md
+++ b/content/source/docs/enterprise/saml/login.html.md
@@ -12,6 +12,6 @@ They can follow the link to complete the SAML login process with the identity pr
 
 ## API token expiration
 
-When a user's SAML-authenticated web session expires, their API tokens are also temporarily disabled until they reauthenticate at `https://<YOUR_TERRAFORM_ENTERPRISE_DOMAIN>/session`. This is because Terraform Enterprise relies on your identity provider for [team membership mapping](./team-membership.html), and a user might have been added to or removed from some teams since their session expired. This restriction only affects user tokens, not [team or organization tokens](../users-teams-organizations/service-accounts.html).
+When SAML is initially enabled, or when a user's SAML-authenticated web session expires, existing user API tokens are also temporarily disabled until they reauthenticate at `https://<YOUR_TERRAFORM_ENTERPRISE_DOMAIN>/session`. This is because Terraform Enterprise relies on your identity provider for [team membership mapping](./team-membership.html), and a user might have been added to or removed from some teams since their session expired. This restriction only affects user tokens, not [team or organization tokens](../users-teams-organizations/service-accounts.html).
 
-The API token session timeout is a site-wide setting that is configurable in the admin settings.
+The API token session timeout is a site-wide setting that is configurable in the admin settings at `https://<YOUR_TERRAFORM_ENTERPRISE_DOMAIN>/admin/settings/saml`.


### PR DESCRIPTION
We've had a few customers lately ask about permissions with their admin user tokens after enabling SAML, so I added a note here about enabling having the same expiry effect.