### PR TITLE
remove extra word from page title in sidebar

### DIFF
--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -206,7 +206,7 @@
                 <a href="/docs/enterprise/private/install-installer.html">Installation</a>
               </li>
               <li<%= sidebar_current("docs-enterprise2-private-installer-migration") %>>
-                <a href="/docs/enterprise/private/migrate.html">Migrate from AMI</a>Installation
+                <a href="/docs/enterprise/private/migrate.html">Migrate from AMI</a>
               </li>
               <li<%= sidebar_current("docs-enterprise2-private-installer-rhel") %>>
                 <a href="/docs/enterprise/private/rhel-install-guide.html">RedHat Enterprise Linux Install Guide</a>


### PR DESCRIPTION
It was making this sadness:

<img width="226" alt="private_terraform_enterprise_installation__installer__-_terraform_by_hashicorp" src="https://user-images.githubusercontent.com/1274037/41626209-5f50fbe4-73d0-11e8-8cb9-069886449e4a.png">
