### PR TITLE
Remove mention of self-signed certificates from PTFE docs

### DIFF
--- a/content/source/docs/enterprise/private/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/private/automating-the-installer.html.md
@@ -173,7 +173,7 @@ For Azure:
 
 ## Online
 
-The following is an example `/etc/replicated.conf` suitable for an automated online install using a self-signed certificate.  `ImportSettingsFrom` must be the full path to the application settings file.  You also need to provide the full path to your license file in `LicenseFileLocation`.
+The following is an example `/etc/replicated.conf` suitable for an automated online install using a publicly trusted certificate.  `ImportSettingsFrom` must be the full path to the application settings file.  You also need to provide the full path to your license file in `LicenseFileLocation`.
 
 See the full set of configuration parameters in the [Replicated documentation](https://help.replicated.com/docs/kb/developer-resources/automate-install/#configure-replicated-automatically).
 
@@ -181,7 +181,10 @@ See the full set of configuration parameters in the [Replicated documentation](h
 {
     "DaemonAuthenticationType":     "password",
     "DaemonAuthenticationPassword": "your-password-here",
-    "TlsBootstrapType":             "self-signed",
+    "TlsBootstrapType":             "server-path",
+    "TlsBootstrapHostname":         "server.company.com",
+    "TlsBootstrapCert":             "/etc/server.crt",
+    "TlsBootstrapKey":              "/etc/server.key",
     "BypassPreflightChecks":        true,
     "ImportSettingsFrom":           "/path/to/application-settings.json",
     "LicenseFileLocation":          "/path/to/license.rli"
@@ -209,7 +212,10 @@ The following is an example `/etc/replicated.conf` suitable for an automated air
 {
     "DaemonAuthenticationType":          "password",
     "DaemonAuthenticationPassword":      "your-password-here",
-    "TlsBootstrapType":                  "self-signed",
+    "TlsBootstrapType":                  "server-path",
+    "TlsBootstrapHostname":              "server.company.com",
+    "TlsBootstrapCert":                  "/etc/server.crt",
+    "TlsBootstrapKey":                   "/etc/server.key",
     "BypassPreflightChecks":             true,
     "ImportSettingsFrom":                "/path/to/application-settings.json",
     "LicenseFileLocation":               "/path/to/license.rli",

--- a/content/source/docs/enterprise/private/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/private/automating-the-installer.html.md
@@ -173,7 +173,7 @@ For Azure:
 
 ## Online
 
-The following is an example `/etc/replicated.conf` suitable for an automated online install using a publicly trusted certificate.  `ImportSettingsFrom` must be the full path to the application settings file.  You also need to provide the full path to your license file in `LicenseFileLocation`.
+The following is an example `/etc/replicated.conf` suitable for an automated online install using a certificate trusted by a public or private CA.  `ImportSettingsFrom` must be the full path to the application settings file.  You also need to provide the full path to your license file in `LicenseFileLocation`.
 
 See the full set of configuration parameters in the [Replicated documentation](https://help.replicated.com/docs/kb/developer-resources/automate-install/#configure-replicated-automatically).
 

--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -139,11 +139,11 @@ certificate codified during an unattended installation.
 
 If a Classic or Application Load Balancer is used, SSL/TLS will be terminated there.
 In this configuration, the PTFE instances should still be configured to listen
-for incoming SSL/TLS connections but can do so using a self-signed certificate.
+for incoming SSL/TLS connections.
 
 Since the load balancer is configured to send traffic to port 443 on the instances
-as type `https`, will ignore the fact that it can't trust the self-signed certificate
-and operate correctly.
+as type `https`, it will ignore the fact that it can't trust self-signed certificates
+and operate correctly. HashiCorp does not recommend the use of self-signed certificates.
 
 ## Infrastructure Diagram
 

--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -132,7 +132,7 @@ of this guide.
 
 #### SSL/TLS
 
-An SSL/TLS certificate is required for secure communication between
+An SSL/TLS certificate signed by a public or private CA is required for secure communication between
 clients and the PTFE application server. The certificate can be
 specified during the UI-based installation or the path to the
 certificate codified during an unattended installation.
@@ -141,9 +141,7 @@ If a Classic or Application Load Balancer is used, SSL/TLS will be terminated th
 In this configuration, the PTFE instances should still be configured to listen
 for incoming SSL/TLS connections.
 
-Since the load balancer is configured to send traffic to port 443 on the instances
-as type `https`, it will ignore the fact that it can't trust self-signed certificates
-and operate correctly. HashiCorp does not recommend the use of self-signed certificates.
+HashiCorp does not recommend the use of self-signed certificates.
 
 ## Infrastructure Diagram
 

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -27,13 +27,10 @@ Before you begin, you'll need to prepare data files and a Linux instance.
 ### Data Files
 
 * TLS private key and certificate
-  * The installer allows for using a self-signed certificate but HashiCorp does
-    _not_ recommended this. Your VCS provider will likely reject that certificate
-    when sending webhooks. If you do use the self-signed certificate, you must configure
-    each webhook to ignore SSL errors within your VCS provider.
+  * The installer allows for using a publicly trusted certificate. If you do not use a publicly trusted certificate, your VCS provider will likely reject that certificate when sending webhooks. 
 * License key (provided by HashiCorp)
 
-~> **Note:** If you use your own certificate and it is issued by a private Certificate
+~> **Note:** If you use a certificate issued by a private Certificate
    Authority, you must provide the certificate for that CA in the
    `Certificate Authority (CA) Bundle` section of the installation. This allows services
    running within PTFE to access each other properly.

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -27,7 +27,7 @@ Before you begin, you'll need to prepare data files and a Linux instance.
 ### Data Files
 
 * TLS private key and certificate
-  * The installer allows for using a publicly trusted certificate. If you do not use a publicly trusted certificate, your VCS provider will likely reject that certificate when sending webhooks. 
+  * The installer allows for using a certificate signed by a public or private CA. If you do not use a trusted certificate, your VCS provider will likely reject that certificate when sending webhooks. 
 * License key (provided by HashiCorp)
 
 ~> **Note:** If you use a certificate issued by a private Certificate

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -16,10 +16,7 @@ Before you begin, you'll need to prepare data files and a Linux instance.
 ### Data Files
 
 * TLS private key and certificate
-  * The installer allows for using a self-signed certificate but HashiCorp does
-    _not_ recommend this. Your VCS provider will likely reject that certificate
-    when sending webhooks. If you do use the self-signed certificate, you must configure
-    each webhook to ignore SSL errors within your VCS provider.
+  * HashiCorp does _not_ recommend the use of a self-signed certificate.
 * License key (provided by HashiCorp)
 
 ~> **Note:** If you use your own certificate issued by a private or internal Certificate


### PR DESCRIPTION
[Asana](https://app.asana.com/0/527290736177977/711294447593490/f)

self-signed certificates can lead to connectivity issues between services in PTFE and are difficult to set up correctly. For these reasons, we do not recommend their use. This PR removes mention of self-signed certs from the docs and updates examples to show how to configure PTFE with a publicly trusted certificate. 