### PR TITLE
Upgrade the GitLab API from v3 to use v4

### DIFF
--- a/content/source/docs/enterprise-legacy/vcs/gitlab.html.md
+++ b/content/source/docs/enterprise-legacy/vcs/gitlab.html.md
@@ -38,7 +38,7 @@ Scroll down to the **Add OAuthClient** pane and fill out the form with the follo
 - **Oauth client**: Your GitLab installation type (e.g. GitLab.com, GitLab Community Edition, or GitLab Enterprise)
 - **Application key**: Application Id (from GitLab in the previous section)
 - **Base url**: https://gitlab.com (for GitLab.com; If you are using GitLab Community Edition or GitLab Enterprise your URL will be different)
-- **Api url**: https://gitlab.com/api/v3 (for GitLab.com; If you are using GitLab Community Edition or GitLab Enterprise your URL will be different)
+- **Api url**: https://gitlab.com/api/v4 (for GitLab.com; If you are using GitLab Community Edition or GitLab Enterprise your URL will be different)
 - **Application secret**: Secret (from GitLab in the previous section)
 
 Once you have created your client, you will be redirected back to the **Configuration** page for your chosen Organization. On that page, find the **OAuth Clients** pane and copy the **Callback url** for GitLab. Leave this tab open in your browser as you will need to return to it in a moment.

--- a/content/source/docs/enterprise/vcs/github-enterprise.html.md
+++ b/content/source/docs/enterprise/vcs/github-enterprise.html.md
@@ -72,7 +72,7 @@ The rest of this page explains the GitHub Enterprise versions of these steps.
     Field         | Value
     --------------|--------------------------------------------
     HTTP URL      | `https://<GITHUB INSTANCE HOSTNAME>`
-    API URL       | `https://<GITHUB INSTANCE HOSTNAME>/api/v3`
+    API URL       | `https://<GITHUB INSTANCE HOSTNAME>/api/v4`
     Client ID     | (paste value from previous step)
     Client Secret | (paste value from previous step)
 

--- a/content/source/docs/enterprise/vcs/gitlab-eece.html.md
+++ b/content/source/docs/enterprise/vcs/gitlab-eece.html.md
@@ -70,7 +70,7 @@ The rest of this page explains the on-premise GitLab versions of these steps.
     Field          | Value
     ---------------|--------------------------------------------
     HTTP URL       | `https://<GITLAB INSTANCE HOSTNAME>`
-    API URL        | `https://<GITLAB INSTANCE HOSTNAME>/api/v3`
+    API URL        | `https://<GITLAB INSTANCE HOSTNAME>/api/v4`
     Application ID | (paste value from previous step)
     Secret         | (paste value from previous step)
 


### PR DESCRIPTION
GitLab API `v3` has been deprecated and causes errors when using TFE. Using the newer `v4` API works as expected. This change updates our examples to match TFE's settings.