### PR TITLE
clarify database user requirements

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -264,7 +264,7 @@ When Terraform Enterprise uses an external PostgreSQL database, the
 following must be present on it:
 
 * PostgreSQL version 9.4 or greater
-* User with full access to the schemas created and the ability to run "CREATE EXTENSION" on the database
+* User with all privileges granted on the schemas created and the ability to run "CREATE EXTENSION" on the database
 * The following PostgreSQL schemas must be installed into the database: `rails`, `vault`, `registry`
 
 To create schemas in PostgreSQL, the `CREATE SCHEMA` command is used. So to

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -264,7 +264,7 @@ When Terraform Enterprise uses an external PostgreSQL database, the
 following must be present on it:
 
 * PostgreSQL version 9.4 or greater
-* User with access to ownership semantics on the referenced database
+* User with full access to the schemas created and the ability to run "CREATE EXTENSION" on the database
 * The following PostgreSQL schemas must be installed into the database: `rails`, `vault`, `registry`
 
 To create schemas in PostgreSQL, the `CREATE SCHEMA` command is used. So to
@@ -281,7 +281,7 @@ When specifying which PostgreSQL database to use, the value specified must
 be a valid Database URL, as [specified in the libpq documentation](https://www.postgresql.org/docs/9.3/static/libpq-connect.html#AEN39514).
 
 Additionally, the URL must include the `sslmode` parameter indicating if SSL
-should be used to connect to the database. There is no assumed SSL mode, the
+should be used to connect to the database. There is no assumed SSL mode; the
 parameter must be specified.
 
 ### Finish Bootstrapping


### PR DESCRIPTION
A customer had a lot of trouble setting up PTFE because he hadn't created a user with the right role - as a non-DBA, he found "User with access to ownership semantics" to be opaque (as did I).

I discussed the best way to express this in a way that's general but clear with @koikonom, and we landed on this, but I'm open to changing it up as long as it's something that a technical user who isn't a database expert can act on.

Also fix a stray comma.