### PR TITLE
Update PTFE Admin Settings API Docs

### DIFF
--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -12,6 +12,103 @@ sidebar_current: "docs-enterprise2-api-admin-settings"
 
 -> **Pre-release**: These API endpoints are not yet available in the current Private Terraform Enterprise release.
 
+## List General Settings
+`GET /api/v2/admin/general-settings`
+
+Status  | Response                                         | Reason
+--------|--------------------------------------------------|-------
+[200][] | [JSON API document][] (`type: "general-settings"`) | Successfully listed General settings
+[404][] | [JSON API error object][]                    | User unauthorized to perform action
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/admin/general-settings
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "general",
+    "type": "general-settings",
+    "attributes": {
+      "limit-user-organization-creation": true
+    }
+  }
+}
+```
+
+## Update General Settings
+`PATCH /api/v2/admin/general-settings`
+
+Status  | Response                                     | Reason
+--------|----------------------------------------------|----------
+[200][] | [JSON API document][] (`type: "general-settings"`) | Successfully updated the General settings
+[404][] | [JSON API error object][]                    | User unauthorized to perform action
+[422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
+### Request Body
+
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
+
+Key path                    | Type   | Default | Description
+----------------------------|--------|---------|------------
+`data.attributes.limit-user-organization-creation`| bool     | `true` | When set to `true`, limits the ability to create organizations to users with the `site-admin` permission only.
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "attributes": {
+      "limit-user-organization-creation": true
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PATCH \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/admin/general-settings
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id":"general",
+    "type":"general-settings",
+    "attributes": {
+      "limit-user-organization-creation": true
+    }
+  }
+}
+```
+
 ## List SAML Settings
 `GET /api/v2/admin/saml-settings`
 

--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -141,6 +141,7 @@ curl \
     "type": "saml-settings",
     "attributes": {
       "enabled": true,
+      "debug": false,
       "idp-cert": "SAMPLE-CERTIFICATE",
       "slo-endpoint-url": "https://example.com/slo",
       "sso-endpoint-url": "https://example.com/sso",
@@ -179,6 +180,7 @@ If `data.attributes.enabled` is set to `true`, all remaining attributes must hav
 Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
 `data.attributes.enabled`    | bool   | `false` | Allows SAML to be used. If true, all remaining attributes are required.
+`data.attributes.debug`    | bool   | `false` | Enables a SAML debug dialog that allows an admin to see the SAMLResponse XML and processed values during login.
 `data.attributes.idp-cert`   | string |         | Identity Provider Certificate specifies the PEM encoded X.509 Certificate as provided by the IdP configuration.
 `data.attributes.slo-endpoint-url` | string |         | Single Log Out URL specifies the HTTPS endpoint on your IdP for single logout requests. This value is provided by the IdP configuration.
 `data.attributes.sso-endpoint-url` | string |         | Single Sign On URL specifies the HTTPS endpoint on your IdP for single sign-on requests. This value is provided by the IdP configuration.
@@ -192,6 +194,7 @@ Key path                    | Type   | Default | Description
   "data": {
     "attributes": {
       "enabled": true,
+      "debug": false,
       "idp-cert": "SAMPLE-CERTIFICATE",
       "slo-endpoint-url": "https://example.com/slo",
       "sso-endpoint-url": "https://example.com/sso",
@@ -224,6 +227,7 @@ curl \
     "type":"saml-settings",
     "attributes": {
       "enabled": true,
+      "debug": false,
       "idp-cert": "SAMPLE-CERTIFICATE",
       "slo-endpoint-url": "https://example.com/slo",
       "sso-endpoint-url": "https://example.com/sso",


### PR DESCRIPTION
Two changes to the Admin Settings docs:

* There is a new endpoint for General settings, which currently contains a single value `limit-user-organization-creation` cc: @davidcelis 
* The SAML endpoint has added a new value `debug` which enables a debug dialog for admins during login cc: @zhssh 