### PR TITLE
No migration between internal and external vault

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -173,8 +173,13 @@ at install time and cannot be changed once the install is running.
 1. **Demo** - This mode stores all data on the instance. The data can be
    backed up with the snapshot mechanism for restore later.
 
-
 The decision you make will be entered during setup.
+
+#### External Vault Option
+
+If you choose to run the instance in the Production operational mode, during the installation, you can also choose to use an external Vault cluster, rather than the default internal Vault provided by PTFE.
+
+This option is also selected at initial installation, and cannot be changed later. If you will want to use an external Vault cluster when running Terraform Enterprise in production, select that option when initially switching to the Production operational mode. See [Externally Managed Vault Cluster](./vault.html) for more information on what this option requires.
 
 ## Installation
 

--- a/content/source/docs/enterprise/private/vault.html.md
+++ b/content/source/docs/enterprise/private/vault.html.md
@@ -17,6 +17,10 @@ When an external Vault cluster is configured along with the External Services in
 Private Terraform Enterprise becomes fully stateless and can be run in a hot-standby
 configuration to provide failover.
 
+-> **NOTE:** The external Vault option must be selected at initial installation, and cannot be changed later.
+Do not attempt to migrate an existing Terraform Enterprise instance between internal and external
+Vault options.
+
 ## Setup
 
 Use the following as a guide to configure an external Vault instance:


### PR DESCRIPTION
Add a callout on the Vault page and a section on the install page to alert users that the Vault decision is one and done.