### PR TITLE
Adjust display settings of Twitter card.

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -14,7 +14,7 @@
     <meta name="msapplication-config" content="/microsoft-tile.xml" />
     <meta name="theme-color" content="#ffffff">
 
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@HashiCorp" />
     <meta name="twitter:creator" content="@HashiCorp" />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
If you designate "twitter:card" as "summary_large_image", the logo image is trimmed in a rectangle when sharing pages on Twitter.

By setting it as "summary" you get the proper display.

Sample of "summary_large_image":
![image](https://user-images.githubusercontent.com/4744735/42984740-04b8cbb4-8c29-11e8-981d-b77b08cd839b.png)

Sample of "summary":
![image](https://user-images.githubusercontent.com/4744735/42984708-f16fc6de-8c28-11e8-8f91-775316ea2466.png)

