### PR TITLE
Clarify the maximal docker version supported

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -65,7 +65,8 @@ Terraform Enterprise application as well as the Terraform plans and applies.
 
 For Linux distributions other than RHEL, check Docker compatibility:
 
-  * The instance should run a current version of Docker engine (1.7.1 or later, minimum 17.06.2-ce recommended). This also requires a 64-bit distribution with a minimum Linux Kernel version of 3.10.
+  * The instance should run a supported version of Docker engine (1.7.1 or later, minimum 17.06.2-ce, maximum 17.12.1). This also requires a 64-bit distribution with a minimum Linux Kernel version of 3.10.
+    * At this time, the **18.x and higher Docker versions are not supported**
     * In Online mode, the installer will install Docker automatically
     * In Airgapped mode, Docker should be installed before you begin
   * For _Redhat Enterprise_, _Oracle Linux_, and _SUSE Enterprise_, you **must** pre-install Docker as these distributions are [not officially supported by Docker Community Edition](https://docs.docker.com/engine/installation/#server).


### PR DESCRIPTION
Clarify that the Docker 18.x versions and higher are not supported at this point.