### PR TITLE
Add blurb on best practices landing page

### DIFF
--- a/content/source/docs/extend/best-practices/index.html.md
+++ b/content/source/docs/extend/best-practices/index.html.md
@@ -35,6 +35,16 @@ Drift][drift], we cover some best practices to ensure Terraform's statefile is
 an accurate reflection of reality, in order to provide accurate plan and apply
 functionality. 
 
+## Testing Patterns
+
+Terraform developers are encouraged to write acceptance tests that create real
+resource to verify the behavior of plugins, ensuring a reliable and safe
+way to manage infrastructure. In [Testing Patterns][testing-patterns] we cover
+some basic acceptance tests that almost all resources should have to validate
+not only the functionality of the resource, but that the resource behaves as
+Terraform would expect a resource to behave. 
+
 [Click here to learn more.][drift]
 
 [drift]: /docs/extend/best-practices/detecting-drift.html
+[testing-patterns]: /docs/extend/best-practices/testing.html

--- a/content/source/docs/extend/best-practices/testing.html.md
+++ b/content/source/docs/extend/best-practices/testing.html.md
@@ -7,7 +7,7 @@ description: |-
   to extend Terraform's core offering.
 ---
 
-# Testing Best Practices
+# Testing Patterns
 
 In [Testing Terraform Plugins][1] we introduce Terraform’s Testing Framework,
 providing reference for its functionality and introducing the basic parts of

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -45,7 +45,7 @@
           </li>
 
           <li<%= sidebar_current("docs-extend-best-practices-testing") %>>
-            <a href="/docs/extend/best-practices/testing.html">Test Patterns</a>
+            <a href="/docs/extend/best-practices/testing.html">Testing Patterns</a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
Introduce the testing patterns page on `/docs/extend/best-practices/index.html` and update link name