### PR TITLE
add local-exec install information for V2

### DIFF
--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -9,7 +9,7 @@ sidebar_current: "docs-enterprise2-run-install"
 In some cases, it may be useful to install certain software on the Terraform worker, 
 such as a configuration management tool or cloud CLI.
 
-Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, it should be used in conjunction with the resource(s) the software will be used to interact with, as relying on a null resource would mean inconsistencies in whether the software is installed.
+Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, it should be used in conjunction with the resource(s) the software will be used to interact with, as relying on a placeholder (such as a null resource) may result in inconsistencies as to whether the software is installed.
 
 ```hcl
 resource "aws_instance" "example" {
@@ -24,7 +24,7 @@ EOH
 }
 ```
 
-An [explicit `depends_on`](/intro/getting-started/dependencies.html#implicit-and-explicit-dependencies) may also be required to place the installation correctly in the provisioning sequence.
+An [explicit `depends_on`](/intro/getting-started/dependencies.html#implicit-and-explicit-dependencies) may sometimes be needed to place the installation correctly in the provisioning sequence.
 
 Using `local-exec` is only recommended where using a more standard provider-based action is not possible or feasible. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
 

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "enterprise2"
-page_title: "Installing Software in the Environment - Runs - Terraform Enterprise"
+page_title: "Installing Software in the Run Environment - Runs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-run-install"
 ---
 

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -1,15 +1,15 @@
 ---
 layout: "enterprise2"
-page_title: "Installing Software - Runs - Terraform Enterprise"
+page_title: "Installing Software in the Envuronment - Runs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-run-install"
 ---
 
-# Installing Custom Software
+#  Installing Software in the Run Environment
 
-In some cases it may be useful to install certain software on the Terraform worker, 
+In some cases, it may be useful to install certain software on the Terraform worker,
 such as a configuration management tool or cloud CLI.
 
-Terraform's local-exec provisioner provisioner can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, the provisioner configuration block containing the local-exec provisioner should be added to the resource(s) the software being installed will be used to interact with.
+Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, the provisioner configuration block containing the local-exec provisioner should be added to the resource(s) the software being installed will interact with.
 
 ```hcl
 resource "aws_instance" "example" {
@@ -24,12 +24,10 @@ EOH
 }
 ```
 
-Using software installed via local-exec to create unmanaged infrastructure is not recommended. Instead, if possible, use a provider that can manage the resource using a Terraform configuration. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
+Using software installed via local-exec to create unmanaged infrastructure is not recommended. Instead, if possible, use a provider that can manage the resource using a Terraform configuration. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) for information on how to use custom and community providers in TFE.
 
 Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need to install any custom software on each run.
 
-For this reason, a null resource with the `local-exec` provisioner will only install software on the first run when the `null_resource` is created. The `null_resource` will not be automatically recreated in subsequent runs, so the software will not be reinstalled into the new container, which may cause runs to encounter errors.
+Because the run environments are disposable, using a null resource with a `local-exec` provisioner to install software, rather than a related resource, is only appropriate if the null resource can be properly configured with [triggers](https://www.terraform.io/docs/provisioners/null_resource.html#example-usage). Otherwise, a null resource with the `local-exec` provisioner will only install software on the initial run where the `null_resource` is created. The `null_resource` will not be automatically recreated in subsequent runs and the related software won't be installed, which may cause runs to encounter errors.
 
-However, it may be appropriate to use a null resource with a `local-exec` provisioner to install software if the null resource can be properly configured with [triggers](https://www.terraform.io/docs/provisioners/null_resource.html#example-usage).
-
-Currently, the Terraform workers run the latest version of Ubuntu LTS, however this is subject to change in the future.
+Currently, the Terraform workers run the latest version of Ubuntu LTS, but this may change in the future.

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -9,7 +9,7 @@ sidebar_current: "docs-enterprise2-run-install"
 In some cases, it may be useful to install certain software on the Terraform worker, 
 such as a configuration management tool or cloud CLI.
 
-Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) is available for use in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform.
+Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform.
 
 ```hcl
 resource "null_resource" "local-software" {
@@ -22,9 +22,8 @@ EOH
 }
 ```
 
-Using `local-exec` is only recommended where using a more standard provider-based action is not possible or feasible. See [Terraform Runs: Custom and Community Providers](https://www.terraform.io/docs/enterprise/run/index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
+Using `local-exec` is only recommended where using a more standard provider-based action is not possible or feasible. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
 
-Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need
-to install any custom software on each run.
+Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need to install any custom software on each run.
 
 Currently, the Terraform workers run the latest version of Ubuntu LTS (16.04).

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "enterprise2"
-page_title: "Installing Software in the Envuronment - Runs - Terraform Enterprise"
+page_title: "Installing Software in the Environment - Runs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-run-install"
 ---
 

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -9,10 +9,12 @@ sidebar_current: "docs-enterprise2-run-install"
 In some cases, it may be useful to install certain software on the Terraform worker, 
 such as a configuration management tool or cloud CLI.
 
-Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform.
+Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, it should be used in conjunction with the resource(s) the software will be used to interact with, as relying on a null resource would mean inconsistencies in whether the software is installed.
 
 ```hcl
-resource "null_resource" "local-software" {
+resource "aws_instance" "example" {
+  ami           = "${var.ami}"
+  instance_type = "t2.micro"
   provisioner "local-exec" {
     command = <<EOH
 sudo apt-get update
@@ -22,8 +24,10 @@ EOH
 }
 ```
 
+An [explicit `depends_on`](/intro/getting-started/dependencies.html#implicit-and-explicit-dependencies) may also be required to place the installation correctly in the provisioning sequence.
+
 Using `local-exec` is only recommended where using a more standard provider-based action is not possible or feasible. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
 
 Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need to install any custom software on each run.
 
-Currently, the Terraform workers run the latest version of Ubuntu LTS (16.04).
+Currently, the Terraform workers run the latest version of Ubuntu LTS.

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -6,10 +6,10 @@ sidebar_current: "docs-enterprise2-run-install"
 
 # Installing Custom Software
 
-In some cases, it may be useful to install certain software on the Terraform worker, 
+In some cases it may be useful to install certain software on the Terraform worker, 
 such as a configuration management tool or cloud CLI.
 
-Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, it should be used in conjunction with the resource(s) the software will be used to interact with, as relying on a placeholder (such as a null resource) may result in inconsistencies as to whether the software is installed.
+Terraform's local-exec provisioner provisioner can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, the provisioner configuration block containing the local-exec provisioner should be added to the resource(s) the software being installed will be used to interact with.
 
 ```hcl
 resource "aws_instance" "example" {
@@ -24,10 +24,12 @@ EOH
 }
 ```
 
-An [explicit `depends_on`](/intro/getting-started/dependencies.html#implicit-and-explicit-dependencies) may sometimes be needed to place the installation correctly in the provisioning sequence.
-
-Using `local-exec` is only recommended where using a more standard provider-based action is not possible or feasible. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
+Using software installed via local-exec to create unmanaged infrastructure is not recommended. Instead, if possible, use a provider that can manage the resource using a Terraform configuration. See [Terraform Runs: Custom and Community Providers](index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
 
 Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need to install any custom software on each run.
 
-Currently, the Terraform workers run the latest version of Ubuntu LTS.
+For this reason, a null resource with the `local-exec` provisioner will only install software on the first run when the `null_resource` is created. The `null_resource` will not be automatically recreated in subsequent runs, so the software will not be reinstalled into the new container, which may cause runs to encounter errors.
+
+However, it may be appropriate to use a null resource with a `local-exec` provisioner to install software if the null resource can be properly configured with [triggers](https://www.terraform.io/docs/provisioners/null_resource.html#example-usage).
+
+Currently, the Terraform workers run the latest version of Ubuntu LTS, however this is subject to change in the future.

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -1,0 +1,30 @@
+---
+layout: "enterprise2"
+page_title: "Installing Software - Runs - Terraform Enterprise"
+sidebar_current: "docs-enterprise2-run-install"
+---
+
+# Installing Custom Software
+
+In some cases, it may be useful to install certain software on the Terraform worker, 
+such as a configuration management tool or cloud CLI.
+
+Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) is available for use in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform.
+
+```hcl
+resource "null_resource" "local-software" {
+  provisioner "local-exec" {
+    command = <<EOH
+sudo apt-get update
+sudo apt-get install -y ansible
+EOH
+  }
+}
+```
+
+Using `local-exec` is only recommended where using a more standard provider-based action is not possible or feasible. See [Terraform Runs: Custom and Community Providers](https://www.terraform.io/docs/enterprise/run/index.html#custom-and-community-providers) in the documentation for information on how to use custom and community providers in TFE.
+
+Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need
+to install any custom software on each run.
+
+Currently, the Terraform workers run the latest version of Ubuntu LTS (16.04).

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -123,6 +123,9 @@
           <li<%= sidebar_current("docs-enterprise2-run-cli") %>>
             <a href="/docs/enterprise/run/cli.html">CLI-driven Runs</a>
           </li>
+          <li<%= sidebar_current("docs-enterprise2-run-install") %>>
+            <a href="/docs/enterprise/run/install-software.html">Installing Software</a>
+          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
We had this for the legacy, and it's really more or less the same in V2, so I ported it over with slight updates/additions so it can encompass PTFE as well.