### PR TITLE
Update configuration-versions.html.md

### DIFF
--- a/content/source/docs/enterprise/api/configuration-versions.html.md
+++ b/content/source/docs/enterprise/api/configuration-versions.html.md
@@ -144,6 +144,7 @@ Properties without a default value are required.
 Key path                          | Type    | Default | Description
 --------------------------------- | ------- | ------- | -----------
 `data.attributes.auto-queue-runs` | boolean | true    | When true, runs are queued automatically when the configuration version is uploaded.
+`data.attributes.speculative`     | boolean | false   | When true, this configuration version may only be used to create runs which are speculative, that is, cannot be confirmed nor applied.
 
 ### Sample Payload
 


### PR DESCRIPTION
We added a new attribute that you can use when creating configuration versions meant to be speculative. When a configuration version is speculative, it can only be used to create runs which cannot be confirmed nor applied.