### PR TITLE
Fixed external vault commands to use more modern syntax

### DIFF
--- a/content/source/docs/enterprise/private/vault.html.md
+++ b/content/source/docs/enterprise/private/vault.html.md
@@ -25,10 +25,10 @@ Vault options.
 
 Use the following as a guide to configure an external Vault instance:
 
-1. Enable AppRole: `vault auth-enable approle`
-1. Enable transit: `vault mount transit`
+1. Enable AppRole: `vault auth enable approle`
+1. Enable transit: `vault secrets enable transit`
 1. Install the `ptfe` policy (See below for policy):
-   `vault policy-write ptfe ptfe.hcl`
+   `vault policy write ptfe ptfe.hcl`
 1. Create an AppRole instance:
    `vault write auth/approle/role/ptfe policies="ptfe"`.
 1. Retrieve the AppRole `role_id`: `vault read auth/approle/role/ptfe/role-id`


### PR DESCRIPTION
I had my Git email or username wrong on my system somehow, so first commit came through as "Test User" but I then fixed so it shows up as from rberlind (me).

3 changes to Vault commands to use more modern syntax that won't give yellow warnings when running as the current ones do.