### PR TITLE
Adding note about Azure Disk size requirements

### DIFF
--- a/content/source/docs/enterprise/private/azure-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/azure-setup-guide.html.md
@@ -75,6 +75,12 @@ instances.
     a consistent high workload in the form of concurrent terraform
     runs.
 
+##### Azure VM Disk Size Considerations
+
+The default root disk size for most Linux distros in Azure is 30GB. Even when assigning an instance more storage to the root partition, depending on the operating system, there may be additional steps required to fully utlize the full 50GB+ of disk, such as using a tool like `fdisk`.
+
+This process is documented in the Azure knowledge base article ["How to: Resize Linux osDisk partition on Azure"](https://blogs.msdn.microsoft.com/linuxonazure/2017/04/03/how-to-resize-linux-osdisk-partition-on-azure/).
+
 ### Object Storage (Azure Blob Storage)
 
 An Azure Blob Storage
@@ -346,7 +352,7 @@ and summarised below:
 > ***Automated Backups** – Azure Database for PostgreSQL automatically
 > creates server backups and stores them in user configured locally
 > redundant or geo-redundant storage.*
-> 
+>
 > ***Backup redundancy** – Azure Database for PostgreSQL provides the
 > flexibility to choose between locally redundant or geo-redundant
 > backup storage.*

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -27,7 +27,7 @@ Before you begin, you'll need to prepare data files and a Linux instance.
 ### Data Files
 
 * TLS private key and certificate
-  * The installer allows for using a certificate signed by a public or private CA. If you do not use a trusted certificate, your VCS provider will likely reject that certificate when sending webhooks. 
+  * The installer allows for using a certificate signed by a public or private CA. If you do not use a trusted certificate, your VCS provider will likely reject that certificate when sending webhooks.
 * License key (provided by HashiCorp)
 
 ~> **Note:** If you use a certificate issued by a private Certificate
@@ -189,6 +189,12 @@ The follow are **supported** mounted disk types:
 * iSCSI
 * SAN
 * Physically connected disks as in non-cloud hardware
+
+###### Additional Note about Disk Resizing
+
+Depending on your Cloud or storage application, you may need to confirm the disk has been resized to above Private Terraform Enterprise's minimum disk size of 40GB.
+
+For example, with RedHat-flavour (eg. RHEL, CentOS, Oracle Linux) images in Azure Cloud, the storage disk must be resized above the 30GB default after initial boot with `fdisk`, as documented in the Azure knowledge base article ["How to: Resize Linux osDisk partition on Azure"](https://blogs.msdn.microsoft.com/linuxonazure/2017/04/03/how-to-resize-linux-osdisk-partition-on-azure/)..
 
 ##### Unsupported Mounted Disk Types
 


### PR DESCRIPTION
* Azure RedHat and Debian images require `fdisk`
after boot, Ubuntu is unaffected
* It’s a gotcha that some don’t know about
* Adds note to both Azure documentation and
installer document