### PR TITLE
update/reorg support & bundle generation content

### DIFF
--- a/content/source/docs/enterprise/private/diagnostics.html.md
+++ b/content/source/docs/enterprise/private/diagnostics.html.md
@@ -6,8 +6,7 @@ sidebar_current: "docs-enterprise2-private-diagnostics"
 
 # Private Terraform Enterprise Diagnostics
 
-This document contains information on how to provide HashiCorp with diagnostic information about a Private Terraform Enterprise (PTFE)
-installation that requires assistance from HashiCorp support.
+This document contains information on how to provide HashiCorp with diagnostic information about a Private Terraform Enterprise (PTFE) installation that requires assistance from HashiCorp support.
 
 ## Installer-based Instances
 
@@ -72,8 +71,8 @@ tfe.mycompany.com:~$ ls -F /var/lib/hashicorp-support/
 gnupg/  hashicorp-support.tar.gz  hashicorp-support.tar.gz.enc
 ```
 
-Next, copy the `hashicorp-support.tar.gz.enc` file listed above off the instance. This
-can be done via scp or another tool that can interface with the system over SSH/SFTP. For example, on Linux and Mac OS X:
+For your privacy and security, the entire contents of the support bundle are encrypted with a 2048
+bit RSA key to generate the `tar.gz.enc` file. Once the process is complete, copy the `hashicorp-support.tar.gz.enc` file listed above off the instance. This can be done via scp or another tool that can interface with the system over SSH/SFTP. For example, on Linux and Mac OS X:
 
 ```
 local$ scp -i ~/.ssh/hc-eng-emp.pem tfe-admin@1.2.3.4:/var/lib/hashicorp-support/hashicorp-support.tar.gz.enc .
@@ -82,9 +81,39 @@ hashicorp-support.tar.gz.enc                                                    
 
 Then, attach the bundle to your support ticket. If possible, use the SendSafely integration (as it allows for large file uploads).
 
-### Windows
+### Scrubbing Secrets
+
+If you have extremely sensitive data in your Terraform build logs you
+may opt to omit these logs from your bundle. However, this may impede our
+efforts to diagnose any problems you are encountering. To create a custom
+support bundle, run the following commands:
+
+    sudo -s
+    hashicorp-support
+    cd /var/lib/hashicorp-support
+    tar -xzf hashicorp-support.tar.gz
+    rm hashicorp-support.tar.gz*
+    rm nomad/*build-worker*
+    tar -czf hashicorp-support.tar.gz *
+    gpg2 -e -r "Terraform Enterprise Support" \
+        --cipher-algo AES256 \
+        --compress-algo ZLIB \
+        -o hashicorp-support.tar.gz.enc \
+        hashicorp-support.tar.gz
+
+You will note that we first create a support bundle using the normal procedure,
+extract it, remove the files we want to omit, and then create a new one.
+
+
+## Windows
 
 On Microsoft Windows, tools such as [PSCP](https://www.ssh.com/ssh/putty/putty-manuals/0.68/Chapter5.html) and [WinSCP](https://winscp.net/eng/index.php) can be used to transfer the file.
+
+## About the Bundle
+
+The support bundle contains logging and telemetry data from various components
+in Private Terraform Enterprise. It may also include log data from Terraform builds you have executed on your Private Terraform Enterprise installation.
+
 
 ## Pre-Sales uploads
 

--- a/content/source/docs/enterprise/private/diagnostics.html.md
+++ b/content/source/docs/enterprise/private/diagnostics.html.md
@@ -105,7 +105,7 @@ You will note that we first create a support bundle using the normal procedure,
 extract it, remove the files we want to omit, and then create a new one.
 
 
-## Windows
+### Windows
 
 On Microsoft Windows, tools such as [PSCP](https://www.ssh.com/ssh/putty/putty-manuals/0.68/Chapter5.html) and [WinSCP](https://winscp.net/eng/index.php) can be used to transfer the file.
 

--- a/content/source/docs/enterprise/private/faq.html.md
+++ b/content/source/docs/enterprise/private/faq.html.md
@@ -277,70 +277,20 @@ expected, please reach out to support for help.
 
 ### Email
 
-You can engage HashiCorp support via <support@hashicorp.com>. Please make sure
+You can engage HashiCorp support via the web portal at https://support.hashicorp.com or
+by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our
 response.
 
 ### Diagnostics
 
-For most technical issues HashiCorp support will ask you to include diagnostic
-information in your support request. You can create a support bundle by
-connecting to your Private Terraform Enterprise instance via SSH and running
+For most technical issues, HashiCorp support will ask you to include diagnostic
+information in your support request. To ensure the required information is included,
+PTFE has the ability to automatically generate a support bundle including logs and configuration details.
 
-    sudo hashicorp-support
-
-You will see output similar to:
-
-    ==> Creating HashiCorp Support Bundle in /var/lib/hashicorp-support
-    ==> Wrote support tarball to /var/lib/hashicorp-support/hashicorp-support.tar.gz
-    gpg: checking the trustdb
-    gpg: marginals needed: 3  completes needed: 1  trust model: PGP
-    gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
-    gpg: next trustdb check due at 2019-04-14
-    ==> Wrote encrypted support tarball to /var/lib/hashicorp-support/hashicorp-support.tar.gz.enc
-    Please send your support bundle to HashiCorp support.
-
-Attach the `hashicorp-support.tar.gz.enc` file to your support request. If it is
-too large to attach you can send this to us via S3, FTP, or another data store
-you control.
-
-**Warning:** Make sure to attach the file ending in `.tar.gz.enc` as the
-contents of `.tar.gz` are not encrypted!
-
-**Note:** The GPG key used to encrypt the bundle is imported for the `root` user
-only. If you use `sudo -sH`, change `$HOME`, or take a similar action, the
-encryption step will fail. To assume `root` use `sudo -s` instead.
-
-#### About the Bundle
-
-The support bundle contains logging and telemetry data from various components
-in Private Terraform Enterprise. It may also include log data from Terraform builds you have executed on your Private Terraform Enterprise installation. For your privacy and
-security, the entire contents of the support bundle are encrypted with a 2048
-bit RSA key.
-
-#### Scrubbing Secrets
-
-If you have extremely sensitive data in your Terraform build logs you
-may opt to omit these logs from your bundle. However, this may impede our
-efforts to diagnose any problems you are encountering. To create a custom
-support bundle, run the following commands:
-
-    sudo -s
-    hashicorp-support
-    cd /var/lib/hashicorp-support
-    tar -xzf hashicorp-support.tar.gz
-    rm hashicorp-support.tar.gz*
-    rm nomad/*build-worker*
-    tar -czf hashicorp-support.tar.gz *
-    gpg2 -e -r "Terraform Enterprise Support" \
-        --cipher-algo AES256 \
-        --compress-algo ZLIB \
-        -o hashicorp-support.tar.gz.enc \
-        hashicorp-support.tar.gz
-
-You will note that we first create a support bundle using the normal procedure,
-extract it, remove the files we want to omit, and then create a new one.
+* [AMI-based instance bundle generation](./diagnostics.html#ami-based-installs)
+* [Installer-based instance bundle generation](./diagnostics.html#installer-based-instances)
 
 ---
 


### PR DESCRIPTION
I changed the FAQ to refer to the diagnostics page instead of only having the AMI info (and a duplicate of it at that). Moved the info we didn't initially have on the diagnostics page over as well.