### PR TITLE
Nav: Expand PTFE items into the top nav level, and add clarifying headers

### DIFF
--- a/content/source/docs/enterprise/private/index.html.md
+++ b/content/source/docs/enterprise/private/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "enterprise2"
 page_title: "Private Terraform Enterprise"
-sidebar_current: "docs-enterprise2-private"
+sidebar_current: "docs-enterprise2-private-home"
 ---
 
 # Private Terraform Enterprise

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -15,6 +15,12 @@
 
       <hr>
 
+      <li><strong>Terraform Enterprise</strong></li>
+
+      <li<%= sidebar_current("docs-enterprise2-home") %>>
+        <a href="/docs/enterprise/index.html">Home</a>
+      </li>
+
       <li<%= sidebar_current("docs-enterprise2-started") %>>
         <a href="/docs/enterprise/getting-started/index.html">Getting Started</a>
         <ul class="nav">
@@ -194,108 +200,6 @@
         </ul>
       </li>
 
-      <hr>
-
-      <li<%= sidebar_current("docs-enterprise2-private") %>>
-        <a href="/docs/enterprise/private/index.html">Private Terraform Enterprise</a>
-        <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-private-installer") %>>
-            <a href="/docs/enterprise/private/install-installer.html">Installation (Installer)</a>
-            <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-private-installer-install") %>>
-                <a href="/docs/enterprise/private/install-installer.html">Installation</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-migration") %>>
-                <a href="/docs/enterprise/private/migrate.html">Migrate from AMI</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-rhel") %>>
-                <a href="/docs/enterprise/private/rhel-install-guide.html">RedHat Enterprise Linux Install Guide</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-centos") %>>
-                <a href="/docs/enterprise/private/centos-install-guide.html">CentOS Linux Install Guide</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-aws") %>>
-                <a href="/docs/enterprise/private/aws-setup-guide.html">AWS Setup Guide</a>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-azure") %>>
-                <a href="/docs/enterprise/private/azure-setup-guide.html">Azure Setup Guide</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-vmware") %>>
-                <a href="/docs/enterprise/private/vmware-setup-guide.html">VMware Setup Guide</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-minio") %>>
-                <a href="/docs/enterprise/private/minio-setup-guide.html">Minio Setup Guide</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-automating") %>>
-                <a href="/docs/enterprise/private/automating-the-installer.html">Automated Installation</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-upgrades") %>>
-                <a href="/docs/enterprise/private/upgrades.html">Upgrades</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-vault") %>>
-                <a href="/docs/enterprise/private/vault.html">External Vault</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-automated-recovery") %>>
-                <a href="/docs/enterprise/private/automated-recovery.html">Automated Recovery</a>
-              </li>
-            </ul>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-install-ami") %>>
-            <a href="/docs/enterprise/private/install-ami.html">Installation (AMI)</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-config") %>>
-            <a href="/docs/enterprise/private/config.html">Configuration</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-saml") %>>
-            <a href="/docs/enterprise/saml/index.html">SAML SSO</a>
-            <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-private-saml-configuration") %>>
-                <a href="/docs/enterprise/saml/configuration.html">Configuration</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-team-membership") %>>
-                <a href="/docs/enterprise/saml/team-membership.html">Team Membership</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-attributes") %>>
-                <a href="/docs/enterprise/saml/attributes.html">Attributes</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-login") %>>
-                <a href="/docs/enterprise/saml/login.html">Login</a>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration") %>>
-                <a href="/docs/enterprise/saml/identity-provider-configuration.html">Identity Provider Configuration</a>
-                <ul class="nav">
-                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-onelogin") %>>
-                    <a href="/docs/enterprise/saml/identity-provider-configuration-onelogin.html">OneLogin</a>
-                  </li>
-                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-adfs") %>>
-                    <a href="/docs/enterprise/saml/identity-provider-configuration-adfs.html">ADFS</a>
-                  </li>
-                </ul>
-              </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-troubleshooting") %>>
-                <a href="/docs/enterprise/saml/troubleshooting.html">Troubleshooting</a>
-              </li>
-            </ul>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-reliability-availability") %>>
-            <a href="/docs/enterprise/private/reliability-availability.html">Reliability &amp; Availability</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-data-security") %>>
-            <a href="/docs/enterprise/private/data-security.html">Data Security</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-logging") %>>
-            <a href="/docs/enterprise/private/logging.html">Logging</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-diagnostics") %>>
-            <a href="/docs/enterprise/private/diagnostics.html">Diagnostics</a>
-          </li>
-          <li<%= sidebar_current("docs-enterprise2-private-faq") %>>
-            <a href="/docs/enterprise/private/faq.html">FAQs</a>
-          </li>
-        </ul>
-      </li>
-
-      <hr>
-
       <li<%= sidebar_current("docs-enterprise2-api") %>>
         <a href="/docs/enterprise/api/index.html">API</a>
         <ul class="nav">
@@ -378,6 +282,108 @@
           </li>
         </ul>
       </li>
+
+      <hr>
+
+      <li><strong>Private Terraform Enterprise</strong></li>
+
+      <li<%= sidebar_current("docs-enterprise2-private-home") %>>
+        <a href="/docs/enterprise/private/index.html">Home</a>
+      </li>
+
+      <li<%= sidebar_current("docs-enterprise2-private-installer") %>>
+        <a href="/docs/enterprise/private/install-installer.html">Installation (Installer)</a>
+        <ul class="nav">
+          <li<%= sidebar_current("docs-enterprise2-private-installer-install") %>>
+            <a href="/docs/enterprise/private/install-installer.html">Installation</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-migration") %>>
+            <a href="/docs/enterprise/private/migrate.html">Migrate from AMI</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-rhel") %>>
+            <a href="/docs/enterprise/private/rhel-install-guide.html">RedHat Enterprise Linux Install Guide</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-centos") %>>
+            <a href="/docs/enterprise/private/centos-install-guide.html">CentOS Linux Install Guide</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-aws") %>>
+            <a href="/docs/enterprise/private/aws-setup-guide.html">AWS Setup Guide</a>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-azure") %>>
+            <a href="/docs/enterprise/private/azure-setup-guide.html">Azure Setup Guide</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-vmware") %>>
+            <a href="/docs/enterprise/private/vmware-setup-guide.html">VMware Setup Guide</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-minio") %>>
+            <a href="/docs/enterprise/private/minio-setup-guide.html">Minio Setup Guide</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-automating") %>>
+            <a href="/docs/enterprise/private/automating-the-installer.html">Automated Installation</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-upgrades") %>>
+            <a href="/docs/enterprise/private/upgrades.html">Upgrades</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-vault") %>>
+            <a href="/docs/enterprise/private/vault.html">External Vault</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-installer-automated-recovery") %>>
+            <a href="/docs/enterprise/private/automated-recovery.html">Automated Recovery</a>
+          </li>
+        </ul>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-install-ami") %>>
+        <a href="/docs/enterprise/private/install-ami.html">Installation (AMI)</a>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-config") %>>
+        <a href="/docs/enterprise/private/config.html">Configuration</a>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-saml") %>>
+        <a href="/docs/enterprise/saml/index.html">SAML SSO</a>
+        <ul class="nav">
+          <li<%= sidebar_current("docs-enterprise2-private-saml-configuration") %>>
+            <a href="/docs/enterprise/saml/configuration.html">Configuration</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-saml-team-membership") %>>
+            <a href="/docs/enterprise/saml/team-membership.html">Team Membership</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-saml-attributes") %>>
+            <a href="/docs/enterprise/saml/attributes.html">Attributes</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-saml-login") %>>
+            <a href="/docs/enterprise/saml/login.html">Login</a>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration") %>>
+            <a href="/docs/enterprise/saml/identity-provider-configuration.html">Identity Provider Configuration</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-onelogin") %>>
+                <a href="/docs/enterprise/saml/identity-provider-configuration-onelogin.html">OneLogin</a>
+              </li>
+              <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-adfs") %>>
+                <a href="/docs/enterprise/saml/identity-provider-configuration-adfs.html">ADFS</a>
+              </li>
+            </ul>
+          </li>
+          <li<%= sidebar_current("docs-enterprise2-private-saml-troubleshooting") %>>
+            <a href="/docs/enterprise/saml/troubleshooting.html">Troubleshooting</a>
+          </li>
+        </ul>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-reliability-availability") %>>
+        <a href="/docs/enterprise/private/reliability-availability.html">Reliability &amp; Availability</a>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-data-security") %>>
+        <a href="/docs/enterprise/private/data-security.html">Data Security</a>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-logging") %>>
+        <a href="/docs/enterprise/private/logging.html">Logging</a>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-diagnostics") %>>
+        <a href="/docs/enterprise/private/diagnostics.html">Diagnostics</a>
+      </li>
+      <li<%= sidebar_current("docs-enterprise2-private-faq") %>>
+        <a href="/docs/enterprise/private/faq.html">FAQs</a>
+      </li>
+
 
     </ul>
   <% end %>


### PR DESCRIPTION
**Discuss before merging,** since this might be mildly controversial. 

@armchairlinguist pointed out that the PTFE docs seem somewhat hidden, or somewhat second-class; or at the least, harder to navigate to than it seems like they should be, given their importance. 

So, with this adjustment, I'm trying to make them easier to work with in multiple ways at once: 

- If you definitely need a document within the PTFE nav hierarchy, you have a bigger initial target, plus we saved you a whole click. 
- If you don't KNOW whether you need a document within the PTFE docs, exposing the top-level topics should make the division between app concerns and operational concerns a lot more transparent.
- If you don't know whether you need PTFE at all, the summary of topics quietly helps you evaluate that; right off the bat, I'm seeing that it would give me SAML sign-ins, some additional logging, and more control over my data security (for good and ill). 

![screen shot 2018-08-01 at 5 46 05 pm](https://user-images.githubusercontent.com/484309/43556079-cfb8ee42-95b2-11e8-87ce-a9c830e1aa07.png)

FAQ: 

- Why aren't those big headers clickable? Well, the default link styling within that sidebar made them look kind of wack. Can easily fix that in CSS, but for the proof of concept I just put "home" links underneath.