### PR TITLE
Make code blocks visually obvious

### DIFF
--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -4,7 +4,7 @@
   }
 
   p code {
-    background-color: #efeef7;
+    background-color: #EFEEF7;
     color: #5C4EE5;
   }
   

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -1,4 +1,13 @@
 #inner {
+  p a code {
+    text-decoration: underline;
+  }
+
+  p code {
+    background-color: #f9f2f4;
+    color: #c7254e;
+  }
+  
   p, li, .alert {
     font-size: $font-size;
     font-family: $font-family-open-sans;

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -4,8 +4,8 @@
   }
 
   p code {
-    background-color: #EFEEF7;
-    color: #5C4EE5;
+    background-color: $terraform-purple-light;
+    color: $terraform-purple;
   }
   
   p, li, .alert {

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -4,8 +4,8 @@
   }
 
   p code {
-    background-color: #f9f2f4;
-    color: #c7254e;
+    background-color: #efeef7;
+    color: #5C4EE5;
   }
   
   p, li, .alert {

--- a/content/source/assets/stylesheets/_variables.scss
+++ b/content/source/assets/stylesheets/_variables.scss
@@ -9,6 +9,7 @@ $packer-blue: #1DAEFF;
 $packer-blue-dark: #1D94DD;
 $terraform-purple: #5C4EE5;
 $terraform-purple-dark: #4040B2;
+$terraform-purple-light: #EFEEF7;
 $vagrant-blue: #1563FF;
 $vagrant-blue-dark: #104EB2;
 $vault-black: #000000;


### PR DESCRIPTION
Restoring the aspect of code blocks for code in paragraphs, so they are visually more evident than the regular text.