### PR TITLE
extend: Expand and migrate versioning and changelog information from maintainer page to its own best practices page

### DIFF
--- a/content/source/docs/extend/best-practices/versioning.html.md
+++ b/content/source/docs/extend/best-practices/versioning.html.md
@@ -6,23 +6,13 @@ description: |-
   Recommendations for version numbering and documentation.
 ---
 
-# Versioning
+# Versioning and Changelog
 
-Given the breadth of available Terraform providers, ensuring a consistent experience means setting a standard guideline for compatibility promises. These guidelines are enforced for providers released by HashiCorp and are recommended for all community providers.
-
-## Table of Contents
-
-- [Versioning Specification](#versioning-specification)
-- [Changelog Specification](#changelog-specification)
-  - [Version Headers](#version-headers)
-  - [Catagorization](#catagorization)
-  - [Entry Format](#entry-format)
-  - [Entry Ordering](#entry-ordering)
-  - [Example Changelog](#example-changelog)
+Given the breadth of available Terraform plugins, ensuring a consistent experience across them requires a standard guideline for compatibility promises. These guidelines are enforced for plugins released by HashiCorp and are recommended for all community plugins.
 
 ## Versioning Specification
 
-Observing that Terraform providers are in many ways analogous to shared libraries in a programming language, we adopted a version numbering scheme for providers that follows the guidelines of [Semantic Versioning](http://semver.org/). In summary, this means that with a version number of the form `MAJOR`.`MINOR`.`PATCH`, the following meanings apply:
+Observing that Terraform plugins are in many ways analogous to shared libraries in a programming language, we adopted a version numbering scheme that follows the guidelines of [Semantic Versioning](http://semver.org/). In summary, this means that with a version number of the form `MAJOR`.`MINOR`.`PATCH`, the following meanings apply:
 
 - Increasing only the patch number suggests that the release includes only bug fixes, and is intended to be functionally equivalent.
 - Increasing the minor number suggests that new features have been added but that existing functionality remains broadly compatible.
@@ -40,7 +30,7 @@ The upcoming release version number is always at the top of the file and is mark
 
 ~> **NOTE:** For HashiCorp released providers, the release process will replace the "Unreleased" header with the current date. This line must be present with the target release version to successfully release that version.
 
-```md
+```text
 ## X.Y.Z (Unreleased)
 
 ...
@@ -51,19 +41,19 @@ The upcoming release version number is always at the top of the file and is mark
 ...
 ```
 
-### Catagorization
+### Categorization
 
 Information in the changelog should broken down as follows:
 
-- Backwards incompatibilities (`BACKWARDS INCOMPATIBILITIES`/`BREAKING CHANGES`): This section documents in brief any incompatible changes and how to handle them. This should only be present in major version upgrades.
-- Notes (`NOTES`): Additional information for potentially unexpected upgrade behavior, upcoming deprecations, or to highlight very important crash fixes (e.g. due to upstream API changes)
-- Features (`FEATURES`): These are major new improvements that deserve a special highlight, such as a new resource or data source.
-- Improvements (`IMPROVEMENTS`/`ENHANCEMENTS`): Smaller features added to the project such as a new attribute for a resource.
-- Bug fixes (`BUG FIXES`): Any bugs that were fixed.
+- **BACKWARDS INCOMPATIBILITIES** or **BREAKING CHANGES**: This section documents in brief any incompatible changes and how to handle them. This should only be present in major version upgrades.
+- **NOTES**: Additional information for potentially unexpected upgrade behavior, upcoming deprecations, or to highlight very important crash fixes (e.g. due to upstream API changes)
+- **FEATURES**: These are major new improvements that deserve a special highlight, such as a new resource or data source.
+- **IMPROVEMENTS** or **ENHANCEMENTS**: Smaller features added to the project such as a new attribute for a resource.
+- **BUG FIXES**: Any bugs that were fixed.
 
-These should be displayed as a top level keyword (e.g. `BUG FIXES:`) with new lines above and below:
+These should be displayed as left aligned text with new lines above and below:
 
-```md
+```text
 
 CATEGORY:
 
@@ -73,11 +63,11 @@ CATEGORY:
 
 Each entry under a category should use the following format:
 
-```md
+```text
 * subsystem: Descriptive message [GH-1234]
 ```
 
-For provider development typically the "subsystem" is the resource or data source affected e.g. `resource/vpc`, or `provider` if the change affects whole provider (e.g. authentication logic). Each bullet also references the corresponding pull request number that contained the code changes, in the format of `[GH-####]` (for HashiCorp released providers, this will be automatically updated on release).
+For provider development typically the "subsystem" is the resource or data source affected e.g. `resource/load_balancer`, or `provider` if the change affects whole provider (e.g. authentication logic). Each bullet also references the corresponding pull request number that contained the code changes, in the format of `[GH-####]` (for HashiCorp released plugins, this will be automatically updated on release).
 
 ### Entry Ordering
 
@@ -88,7 +78,7 @@ To order entries, these basic rules should be followed:
 
 ### Example Changelog
 
-```md
+```text
 ## 1.0.0 (Unreleased)
 
 BREAKING CHANGES:

--- a/content/source/docs/extend/best-practices/versioning.html.md
+++ b/content/source/docs/extend/best-practices/versioning.html.md
@@ -1,0 +1,112 @@
+---
+layout: "extend"
+page_title: "Extending Terraform: Versioning Best Practices"
+sidebar_current: "docs-extend-best-practices-versioning"
+description: |-
+  Recommendations for version numbering and documentation.
+---
+
+# Versioning
+
+Given the breadth of available Terraform providers, ensuring a consistent experience means setting a standard guideline for compatibility promises. These guidelines are enforced for providers released by HashiCorp and are recommended for all community providers.
+
+## Table of Contents
+
+- [Versioning Specification](#versioning-specification)
+- [Changelog Specification](#changelog-specification)
+  - [Version Headers](#version-headers)
+  - [Catagorization](#catagorization)
+  - [Entry Format](#entry-format)
+  - [Entry Ordering](#entry-ordering)
+  - [Example Changelog](#example-changelog)
+
+## Versioning Specification
+
+Observing that Terraform providers are in many ways analogous to shared libraries in a programming language, we adopted a version numbering scheme for providers that follows the guidelines of [Semantic Versioning](http://semver.org/). In summary, this means that with a version number of the form `MAJOR`.`MINOR`.`PATCH`, the following meanings apply:
+
+- Increasing only the patch number suggests that the release includes only bug fixes, and is intended to be functionally equivalent.
+- Increasing the minor number suggests that new features have been added but that existing functionality remains broadly compatible.
+- Increasing the major number indicates that significant breaking changes have been made, and thus extra care or attention is required during an upgrade.
+
+Version numbers above `1.0.0` signify stronger compatibility guarantees, based on the rules above.
+
+## Changelog Specification
+
+For better operator experience, we provide a standardized format so development information is available across all providers consistently. The changelog should live in a top level file in the project, named `CHANGELOG` or `CHANGELOG.md`. We generally recommend that the changelog is updated outside of pull requests unless a clear process is setup for handling merge conflicts.
+
+### Version Headers
+
+The upcoming release version number is always at the top of the file and is marked specifically as `(Unreleased)`, with other previously released versions below.
+
+~> **NOTE:** For HashiCorp released providers, the release process will replace the "Unreleased" header with the current date. This line must be present with the target release version to successfully release that version.
+
+```md
+## X.Y.Z (Unreleased)
+
+...
+
+
+## A.B.C (Month Day, Year)
+
+...
+```
+
+### Catagorization
+
+Information in the changelog should broken down as follows:
+
+- Backwards incompatibilities (`BACKWARDS INCOMPATIBILITIES`/`BREAKING CHANGES`): This section documents in brief any incompatible changes and how to handle them. This should only be present in major version upgrades.
+- Notes (`NOTES`): Additional information for potentially unexpected upgrade behavior, upcoming deprecations, or to highlight very important crash fixes (e.g. due to upstream API changes)
+- Features (`FEATURES`): These are major new improvements that deserve a special highlight, such as a new resource or data source.
+- Improvements (`IMPROVEMENTS`/`ENHANCEMENTS`): Smaller features added to the project such as a new attribute for a resource.
+- Bug fixes (`BUG FIXES`): Any bugs that were fixed.
+
+These should be displayed as a top level keyword (e.g. `BUG FIXES:`) with new lines above and below:
+
+```md
+
+CATEGORY:
+
+```
+
+### Entry Format
+
+Each entry under a category should use the following format:
+
+```md
+* subsystem: Descriptive message [GH-1234]
+```
+
+For provider development typically the "subsystem" is the resource or data source affected e.g. `resource/vpc`, or `provider` if the change affects whole provider (e.g. authentication logic). Each bullet also references the corresponding pull request number that contained the code changes, in the format of `[GH-####]` (for HashiCorp released providers, this will be automatically updated on release).
+
+### Entry Ordering
+
+To order entries, these basic rules should be followed:
+
+1. If large cross-cutting changes are present, list them first (e.g. `provider`)
+2. Order other entries lexicographically based on subsystem (e.g. `resource/load_balancer` then `resource/subnet`)
+
+### Example Changelog
+
+```md
+## 1.0.0 (Unreleased)
+
+BREAKING CHANGES:
+
+* Resource `network_port` has been removed [GH-1]
+
+FEATURES:
+
+* **New Resource:** `cluster` [GH-43]
+
+IMPROVEMENTS:
+
+* resource/load_balancer: Add `ATTRIBUTE` argument (support X new functionality) [GH-12]
+* resource/subnet: Now better [GH-22, GH-32]
+
+## 0.2.0 (Month Day, Year)
+
+FEATURES:
+
+...
+```

--- a/content/source/docs/extend/community/maintainers.html.md
+++ b/content/source/docs/extend/community/maintainers.html.md
@@ -53,63 +53,11 @@ Pull requests should cover the following:
 
 If a pull request has been approved by a maintainer and the submitter has push privileges (recognizable via Collaborator or Member badge), the submitter should merge their own pull request. Any pull request that significantly changes or breaks user experience should always get at least one vote of approval from a HashiCorp employee prior to merge. We prefer to merge via the GitHub web interface using the green merge button. Squash when the commit history is irrelevant.
 
-### Changelog
+### Versioning and Changelog
 
-Changelogs are an important piece of documentation within a provider. All providers should follow a consistent CHANGELOG that is broken down as follows:
-
-- Backwards incompatibilities: This section documents in brief any incompatible changes and how to handle them. This is only present in certain versions that can have breaking changes, see the subsection of "versioning" for more information.
-- Features: These are major new features or major new improvements that deserve a special highlight, such as a new resource or data source like EKS cluster for the AWS provider.
-- Improvements: Smaller features or enhancements added to the project such as a new field for a resource.
-- Bug fixes: Any bugs that were fixed.
+All providers should follow a consistent versioning scheme and changes should be documented in a `CHANGELOG` file. The specific changelog formatting required for HashiCorp released providers (due to the release process) and recommended for all community providers is outlined in our [versioning best practices documentation](/docs/extend/best-practices/versioning.html).
 
 To keep the CHANGELOG up to date, we recommend updating the CHANGELOG after every set of commits that change the project. Never include CHANGELOG updates in a pull request. If you do, it will very likely cause a merge conflict with other pull requests. Instead, make the pull request without CHANGELOG updates, and add to the CHANGELOG only after merge.
-
-#### Entry Format
-
-To keep the CHANGELOG entries standardized across our tools, we follow a simple format scheme as follows:
-
-```
-CATEGORY: [BACKWARDS INCOMPATIBILITY / NEW FEATURES / BUG FIXES]
-
-* subsystem: Descriptive message [GH-1234]
-```
-For provider development typically the "subsystem" is the resource or data source affected e.g. `resource/vpc`, or `provider` if the change affects whole provider (e.g. authentication logic).
-
-#### Entry Ordering
-
-To order entries, these basic rules should be followed:
-
-1. If large cross-cutting changes are present, we list them as "provider: "
-2. Order entries lexicographically in the subsystem (`resource/eks` < `resource/rds`)
-
-#### Example Changelog
-```
-## 1.27.0 (Unreleased)
-
-BREAKING CHANGES:
-
-  * The only thing that's changed is everything [GH-1]
-
-FEATURES:
-
-  * New resource: eks [GH-43]
-
-IMPROVEMENTS:
-
-  * resource/elb: Super improved [GH-12]
-  * resource/vpc: Now better [GH-22, GH-32]
-```
-The upcoming release is always at the top of the file and is marked specifically as "Unreleased". Each bullet also references the corresponding pull request number that contained the code changes. During the release process the "Unreleased" header is removed and all pull request references are linked to automatically.
-
-#### Versioning
-
-Provider development follows [semantic versioning guidelines](https://semver.org/). In summary, this means that with a version number of the form MAJOR.MINOR.PATCH, the following meanings apply:
-
-- Increasing only the patch number suggests that the release includes only bug fixes, and is intended to be functionally equivalent.
-- Increasing the minor number suggests that new features have been added but that existing functionality remains broadly compatible.
-- Increasing the major number indicates that significant breaking changes have been made, and thus extra care or attention is required during an upgrade.
-
-For more details please visit a [blog post](https://www.hashicorp.com/blog/hashicorp-terraform-provider-versioning) made regarding Provider versioning.
 
 ### Release process
 

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -47,6 +47,10 @@
           <li<%= sidebar_current("docs-extend-best-practices-testing") %>>
             <a href="/docs/extend/best-practices/testing.html">Testing Patterns</a>
           </li>
+
+          <li<%= sidebar_current("docs-extend-best-practices-versioning") %>>
+            <a href="/docs/extend/best-practices/versioning.html">Versioning and Changelog</a>
+          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
This should raise awareness of the documentation and provide a better place to link for an upcoming best practices page on provider resource and attribute deprecation.