### PR TITLE
Extend sweepers

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/index.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/index.html.md
@@ -28,7 +28,7 @@ for Terraform to leave orphaned or “dangling” resources behind, depending on
 correctness of the code in development. The testing framework provides means to
 validate all resources are destroyed, alerting developers if any fail to
 destroy. It is the developer's responsibility to clean up any dangling resources
-left over fromduring testing and development. 
+left over from testing and development. 
 
 ## Test files
 

--- a/content/source/docs/extend/testing/acceptance-tests/sweepers.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/sweepers.html.md
@@ -9,9 +9,9 @@ description: |-
 
 # Sweepers
 
-Acceptance tests in Terraform provision and verify real infrastructure using Terraform's testing framework (see [Acceptance Tests](/docs/extend/testing/acceptance-tests/index.html) for more information). Ideally all infrastructure created is then destroyed within the lifecycle of a test, however the reality is that there are several situations that can arise where resources created during a test are “leaked”. Leaked test resources are resources created by Terraform during a test, but Terraform either failed to destroy them at it’s conclusion, or the test falsely reported all resources were destroyed after completing the test. Common causes are intermittent errors or failures in vendor APIs, or developer error in the resource code or test.
+Acceptance tests in Terraform provision and verify real infrastructure using [Terraform's testing framework](/docs/extend/testing/acceptance-tests/index.html). Ideally all infrastructure created is then destroyed within the lifecycle of a test, however the reality is that there are several situations that can arise where resources created during a test are “leaked”. Leaked test resources are resources created by Terraform during a test, but Terraform either failed to destroy them as part of the test, or the test falsely reported all resources were destroyed after completing the test. Common causes are intermittent errors or failures in vendor APIs, or developer error in the resource code or test.
 
-To address the possibility of leaked resources, Terraform provides a mechanism called `sweepers` to cleanup leftover infrastructure. We will add a file to our folder structure that will invoke the sweeper helper.
+To address the possibility of leaked resources, Terraform provides a mechanism called sweepers to cleanup leftover infrastructure. We will add a file to our folder structure that will invoke the sweeper helper.
 
 ```
 terraform-plugin-example/
@@ -23,7 +23,7 @@ terraform-plugin-example/
 │   ├── resource_example_compute_test.go
 ```
 
-example_sweeper_test.go
+__`example_sweeper_test.go`__
 
 ```go
 package example
@@ -47,7 +47,7 @@ func sharedClientForRegion(region string) (interface{}, error) {
 
 `resource.TestMain` is responsible for parsing the special test flags and invoking the sweepers. Sweepers should be added within the acceptance test file of a resource.
 
-resource_example_compute_test.go
+__`resource_example_compute_test.go`__
 
 ```go
 package example
@@ -87,11 +87,11 @@ func init() {
 }
 ```
 
-This example demonstrates adding a sweeper, it is important to note that the string passed to `resource.AddTestSweepers` is added to a map, this name must be unique. Also note there needs to be a way of identifying resources created by Terraform during acceptance tests, a common practice is to prefix all resource names created during acceptance tests with `"test-acc"` or something similar.
+This example demonstrates adding a sweeper, it is important to note that the string passed to `resource.AddTestSweepers` is added to a map, this name must therefore be unique. Also note there needs to be a way of identifying resources created by Terraform during acceptance tests, a common practice is to prefix all resource names created during acceptance tests with `"test-acc"` or something similar.
 
 For more complex leaks, sweepers can also specify a list of sweepers that need to be run prior to the one being defined.
 
-resource_example_compute_disk_test.go
+__`resource_example_compute_disk_test.go`__
 
 ```go
 package example

--- a/content/source/docs/extend/testing/acceptance-tests/sweepers.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/sweepers.html.md
@@ -1,0 +1,121 @@
+---
+layout: "extend-testing"
+page_title: "Extending Terraform - Acceptance Testing"
+sidebar_current: "docs-extend-testing-acceptance-sweepers"
+description: |-
+  Extending Terraform is a section for content dedicated to developing Plugins
+  to extend Terraform's core offering.
+---
+
+# Sweepers
+
+Acceptance tests in Terraform provision and verify real infrastructure using Terraform's testing framework (see [Acceptance Tests](/docs/extend/testing/acceptance-tests/index.html) for more information). Ideally all infrastructure created is then destroyed within the lifecycle of a test, however the reality is that there are several situations that can arise where resources created during a test are “leaked”. Leaked test resources are resources created by Terraform during a test, but Terraform either failed to destroy them at it’s conclusion, or the test falsely reported all resources were destroyed after completing the test. Common causes are intermittent errors or failures in vendor APIs, or developer error in the resource code or test.
+
+To address the possibility of leaked resources, Terraform provides a mechanism called `sweepers` to cleanup leftover infrastructure. We will add a file to our folder structure that will invoke the sweeper helper.
+
+```
+terraform-plugin-example/
+├── provider.go
+├── provider_test.go
+├── example/
+│   ├── example_sweeper_test.go
+│   ├── resource_example_compute.go
+│   ├── resource_example_compute_test.go
+```
+
+example_sweeper_test.go
+
+```go
+package example
+
+import (
+    "testing"
+
+    "github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+    resource.TestMain(m)
+}
+
+// sharedClientForRegion returns a common provider client configured for the specified region
+func sharedClientForRegion(region string) (interface{}, error) {
+    ...
+    return client, nil
+}
+```
+
+`resource.TestMain` is responsible for parsing the special test flags and invoking the sweepers. Sweepers should be added within the acceptance test file of a resource.
+
+resource_example_compute_test.go
+
+```go
+package example
+
+import (
+    "log"
+    "strings"
+    "testing"
+
+    "github.com/hashicorp/terraform/helper/resource"
+)
+
+func init() {
+    resource.AddTestSweepers("example_compute", &resource.Sweeper{
+        Name:   "example_compute",
+        F:      func (region string) error {
+            client, err := sharedClientForRegion(region)
+            if err != nil {
+                return fmt.Errorf("Error getting client: %s", err)
+            }
+ 	        conn := client.(*ExampleClient)
+
+            instances, err := conn.DescribeComputeInstances()
+            if err != nil {
+                return fmt.Errorf("Error getting instances: %s", err)
+            }
+            for _, instance := range instances {
+                if strings.HasPrefix(instance.Name, "test-acc") {
+                    err := conn.DestroyInstance(instance.ID)
+                }
+                if err != nil {
+                    log.Printf("Error destroying %s during sweep: %s", instance.Name, err)
+                }
+            }
+        },
+    })
+}
+```
+
+This example demonstrates adding a sweeper, it is important to note that the string passed to `resource.AddTestSweepers` is added to a map, this name must be unique. Also note there needs to be a way of identifying resources created by Terraform during acceptance tests, a common practice is to prefix all resource names created during acceptance tests with `"test-acc"` or something similar.
+
+For more complex leaks, sweepers can also specify a list of sweepers that need to be run prior to the one being defined.
+
+resource_example_compute_disk_test.go
+
+```go
+package example
+
+import (
+   "testing"
+  
+    "github.com/hashicorp/terraform/helper/resource"
+)
+
+func init() {
+    resource.AddTestSweepers("example_compute_disk", &resource.Sweeper{
+       Name: "example_compute_disk",
+       Dependencies: []string{"example_compute"}
+        ...
+    })
+}
+```
+
+The sweepers can be invoked with the common make target `sweep`:
+
+```
+$ make sweep
+WARNING: This will destroy infrastructure. Use only in development accounts.
+go test ...
+...
+```

--- a/content/source/docs/extend/testing/acceptance-tests/teststep.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/teststep.html.md
@@ -287,5 +287,6 @@ func testAccCheckExampleWidgetExists(resourceName string, widget *example.Widget
 }
 ```
 
+## Next Steps
 
-[1]: /docs/extend/testing/acceptance-testing/bestpractices.html
+Acceptance Testing is an essential approach to validating the implementation of a Terraform Provider. Using actual APIs to provision resources for testing can leave behind real infrastructure that costs money between tests. The reasons for these leaks can vary, regardless Terraform provides a mechanism known as [Sweepers](/docs/extend/testing/acceptance-tests/sweepers.html) to help keep the testing account clean.

--- a/content/source/layouts/extend-testing.erb
+++ b/content/source/layouts/extend-testing.erb
@@ -18,6 +18,9 @@
                 <li<%= sidebar_current("docs-extend-testing-acceptance-teststep") %>>
                   <a href="/docs/extend/testing/acceptance-tests/teststep.html">Test Steps</a>
                 </li>
+                <li<%= sidebar_current("docs-extend-testing-acceptance-sweepers") %>>
+                  <a href="/docs/extend/testing/acceptance-tests/sweepers.html">Test Steps</a>
+                </li>
               </ul>
           </li>
           <li<%= sidebar_current("docs-extend-testing-unit") %>>

--- a/content/source/layouts/extend-testing.erb
+++ b/content/source/layouts/extend-testing.erb
@@ -19,7 +19,7 @@
                   <a href="/docs/extend/testing/acceptance-tests/teststep.html">Test Steps</a>
                 </li>
                 <li<%= sidebar_current("docs-extend-testing-acceptance-sweepers") %>>
-                  <a href="/docs/extend/testing/acceptance-tests/sweepers.html">Test Steps</a>
+                  <a href="/docs/extend/testing/acceptance-tests/sweepers.html">Sweepers</a>
                 </li>
               </ul>
           </li>


### PR DESCRIPTION
Added Sweepers doc under acceptance testing guides. Linked to it via "Next Steps" block, keeping consistent with the rest of the guide.

Preview:
http://tf-alex-preview.s3-website-us-west-2.amazonaws.com/docs/extend/testing/acceptance-tests/sweepers.html