### PR TITLE
Revert data source split changes

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -15,10 +15,10 @@ to describe the desired infrastructure state. This import alone doesn't
 give you access to the state of the infrastructure. To view the state
 of the infrastructure, see the `tfstate` import.
 
-Policies using the tfconfig import can access all aspects of the configuration:
-providers, resources, data sources, modules, variables, etc. Note that since
-this is the configuration and not an invocation of Terraform, you can't see
-values for variables, state, etc.
+Policies using the tfconfig import can access all aspects of the
+configuration: providers, resources, modules, variables, etc. Note
+that since this is the configuration and not an invocation of Terraform,
+you can't see values for variables, state, etc.
 
 ### tfconfig.modules
 
@@ -62,21 +62,6 @@ value, see `m.resources.TYPE.NAME`
 
 This returns the resource with the given type and name.
 
-### m.data
-
-This returns all the data sources in the module as a map. The map
-key is the type, the value is the same as `m.data.TYPE`.
-
-### m.data.TYPE
-
-This returns all the data sources in the module with the given type
-as a map from name to data source. For the documentation on the
-value, see `m.data.TYPE.NAME`
-
-### m.data.TYPE.NAME
-
-This returns the data source with the given type and name.
-
 ### m.variables
 
 This returns all the defined variables for the module.
@@ -111,13 +96,6 @@ This returns the value of the field.
 ### r.config.FIELD
 
 The FIELD is a field within the resource to access. This returns the
-value of the field.
-
-## Type: d
-
-### d.config.FIELD
-
-The FIELD is a field within the data source to access. This returns the
 value of the field.
 
 ## Type: v

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -119,14 +119,6 @@ validate a policy against all resources of a particular type, you will
 need to use logic similar to that in the second example in the
 [tfplan.module_paths](#tfplan-module_paths) section above.
 
-### tfplan.data
-
-`data` returns a map of all the data sources in the root module.
-This is identical to `tfplan.module([]).data`. If you want to
-validate a policy against all data sources of a particular type,
-you will need to use logic similar to that in the second example in
-the [tfplan.module_paths](#tfplan-module_paths) section above.
-
 ### tfplan.module(path)
 
 The module function finds the module at the given path and returns
@@ -212,16 +204,6 @@ r = m.resources.aws_instance.app
 // There should only be a single app instance being created.
 main = rule { length(r) is 1 }
 ```
-
-### module.data.TYPE.NAME
-
-This returns a list of data sources with the given type and name, and behaves
-exactly how a resource lookup behaves with the module.resources.TYPE.NAME syntax
-above. All fields that are accessible within [resources](#type-resource) are
-available within a data source.
-
-Note for a data source to be present here, it must be in the plan, which
-generally means it must have some unknown data at plan time.
 
 ## Type: resource
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -24,11 +24,6 @@ The terraform version that made this state.
 Resources returns a map of all the resources in the root module.
 This is identical to tfstate.module([]).resources.
 
-### tfstate.data
-
-Resources returns a map of all the data sources in the root module.
-This is identical to tfstate.module([]).data.
-
 ### tfstate.module(path)
 
 The module function finds the module at the given path.
@@ -56,24 +51,6 @@ value, see `m.resources.TYPE.NAME`
 This returns the list of resources with the given type and name. The
 result is a list because the plan is aware that the count may be greater
 than zero.
-
-### m.data
-
-This returns all the data sources in the module as a map. The map key is the
-type, the value is the same as `m.data.TYPE`.
-
-### m.data.TYPE
-
-This returns all the data sources in the module with the given type as a map
-from name to data source. For the documentation on the value, see
-`m.data.TYPE.NAME`
-
-### m.data.TYPE.NAME
-
-This returns a list of data sources and behaves exactly how a resource lookup
-behaves with the m.resources.TYPE.NAME syntax above. All fields that are
-accessible within resources are available within a data source, except for
-`tainted`, as data sources cannot be tainted.
 
 ### m.outputs.NAME
 


### PR DESCRIPTION
These docs will be added at a later time once the namespace split is
ready to be put back in.

This reverts commit 900dc25e7ce802a9a1dcefe420d868d409bc6111, reversing
changes made to c8b8b45d8cdaa003e0f62a6fd4a23cd5c9b6c4ab.