### PR TITLE
Add new attributes to Plans API

### DIFF
--- a/content/source/docs/enterprise/api/plans.html.md
+++ b/content/source/docs/enterprise/api/plans.html.md
@@ -49,9 +49,9 @@ curl \
     "type": "plans",
     "attributes": {
       "has-changes": true,
-      "resources-to-add": 0,
-      "resources-to-change": 1,
-      "resources-to-destroy": 0,
+      "resource-additions": 0,
+      "resource-changes": 1,
+      "resource-destructions": 0,
       "status": "finished",
       "status-timestamps": {
         "queued-at": "2018-07-02T22:29:53+00:00",

--- a/content/source/docs/enterprise/api/plans.html.md
+++ b/content/source/docs/enterprise/api/plans.html.md
@@ -49,6 +49,9 @@ curl \
     "type": "plans",
     "attributes": {
       "has-changes": true,
+      "resources-to-add": 0,
+      "resources-to-change": 1,
+      "resources-to-destroy": 0,
       "status": "finished",
       "status-timestamps": {
         "queued-at": "2018-07-02T22:29:53+00:00",


### PR DESCRIPTION
These are now live and reflect the number of resources that a Terraform run would add, change, and destroy.