### PR TITLE
Fix a sample payload to properly show `null`

### DIFF
--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -101,7 +101,7 @@ curl \
           "mode":"advisory"
         }
       ],
-      "updated-at":"2017-10-10T20:52:13.898Z"
+      "updated-at": null
     },
     "links": {
       "self":"/api/v2/policies/pol-u3S5p2Uwk21keu1s",


### PR DESCRIPTION
When creating a Sentinel policy via the API, there's no `updated-at` attribute initially; any request will get a `null` value for `updated-at` until they go through the upload process.