### PR TITLE
Update reference to team settings page

### DIFF
--- a/content/source/docs/enterprise/getting-started/access.html.md
+++ b/content/source/docs/enterprise/getting-started/access.html.md
@@ -46,8 +46,6 @@ First, navigate to the settings page for your organization — you can reach it
 
 The list of teams starts with just one team, named "owners." Don't add users to this team yet; instead, enter a new team name (like "core-infrastructure") in the text field and click the "Create team" button.
 
-Once the team is created, click its name. This will navigate to the team page:
-
 ![adding members to a team](./images/access-add-members.png)
 
 Add as many users as you'd like by typing their TFE username in the text field and clicking "Add user." Added users won't receive a notification, but your organization will be available the next time they access TFE.

--- a/content/source/docs/enterprise/getting-started/access.html.md
+++ b/content/source/docs/enterprise/getting-started/access.html.md
@@ -42,7 +42,7 @@ TFE cannot currently import settings and workspaces from an existing TFE legacy 
 
 To collaborate with your colleagues in TFE, you'll all need access to the same TFE organization. You can add users to an organization by creating a _team_ and adding users to it.
 
-First, navigate to the settings page for your organization — you can reach it from the organization dropdown menu at the top of every page. Once there, click the "Teams" link in the sidebar navigation.
+First, navigate to the settings page for your organization — you can reach it from the "Settings" link found at the top of every page. Once there, click the "Teams" link in the sidebar navigation.
 
 The list of teams starts with just one team, named "owners." Don't add users to this team yet; instead, enter a new team name (like "core-infrastructure") in the text field and click the "Create team" button.
 


### PR DESCRIPTION
It seems like this particular sentence is a bit out of date:

> First, navigate to the settings page for your organization — you can reach it from the organization dropdown menu at the top of every page. Once there, click the "Teams" link in the sidebar navigation.

![](http://screenshots.chrisarcand.com/t8v3h.jpg)