### PR TITLE
extend: Add Versioning and Changelog synopsis to Best Practices index page

### DIFF
--- a/content/source/docs/extend/best-practices/index.html.md
+++ b/content/source/docs/extend/best-practices/index.html.md
@@ -41,7 +41,7 @@ infrastructure, Terraform needs to be able to detect changes made outside of
 it's configuration and provide means of reconciliation. In [Detecting
 Drift][drift], we cover some best practices to ensure Terraform's statefile is
 an accurate reflection of reality, in order to provide accurate plan and apply
-functionality. 
+functionality.
 
 ## Testing Patterns
 
@@ -50,10 +50,18 @@ resource to verify the behavior of plugins, ensuring a reliable and safe
 way to manage infrastructure. In [Testing Patterns][testing-patterns] we cover
 some basic acceptance tests that almost all resources should have to validate
 not only the functionality of the resource, but that the resource behaves as
-Terraform would expect a resource to behave. 
+Terraform would expect a resource to behave.
 
-[Click here to learn more.][drift]
+## Versioning and Changelog
+
+Terraform development serves two distinct audiences: those writing plugin code
+and those implementing them. By clearly and consistently allowing operators to
+easily understand changes in plugin implementation via version numbering and
+documenting those changes, a trust is formed between the two audiences. In
+[Versioning and Changelog][versioning] we cover some guidelines when deciding
+release versions and how to relay changes through documentation.
 
 [deprecations]: /docs/extend/best-practices/deprecations.html
 [drift]: /docs/extend/best-practices/detecting-drift.html
 [testing-patterns]: /docs/extend/best-practices/testing.html
+[versioning]: /docs/extend/best-practices/versioning.html


### PR DESCRIPTION
Also removes extraneous link to the drift page.