### PR TITLE
Revert migration instructions to use the `atlas` backend

### DIFF
--- a/content/source/docs/enterprise/migrate/index.html.md
+++ b/content/source/docs/enterprise/migrate/index.html.md
@@ -8,8 +8,6 @@ sidebar_current: "docs-enterprise2-migrating"
 [backend]: /docs/backends/index.html
 [cli-workspaces]: /docs/state/workspaces.html
 [user-token]: ../users-teams-organizations/users.html#api-tokens
-[remote-backend]: /docs/backends/types/remote.html
-[cli-credentials]: /docs/commands/cli-config.html#credentials
 
 # Migrating State from Terraform Open Source
 
@@ -17,11 +15,7 @@ If you already use Terraform to manage infrastructure, you're probably managing 
 
 ~> **Important:** These instructions are for migrating state in a basic working directory that only uses the `default` workspace. If you use multiple [workspaces][cli-workspaces] in one working directory, the instructions are different; see [Migrating State from Multiple Terraform Workspaces](./workspaces.html) instead.
 
-## Step 1: Ensure Terraform ≥ 0.11.8 is Installed
-
-To follow these instructions, you need Terraform 0.11.8 or later on the workstation where you are performing the migration. The remote backend this process relies on is not present in older versions.
-
-## Step 2: Gather Credentials, Data, and Code
+## Step 1: Gather Credentials, Data, and Code
 
 Make sure you have all of the following:
 
@@ -31,7 +25,19 @@ Make sure you have all of the following:
     - If you were using the default `local` backend, your state is a file on disk. You need the original working directory where you've been running Terraform, or a copy of the `terraform.tfstate` file to copy into a fresh working directory.
     - For remote backends, you need the path to the particular storage being used (usually already included in the configuration) and access credentials (which you usually must set as an environment variable).
 - A TFE user account which is a member of your organization's owners team, so you can create workspaces.
-- A [user API token][user-token] for your TFE user account configured using your [CLI configuration file][cli-credentials]. (Organization and team tokens will not work; the token must be associated with an individual user.)
+- A [user API token][user-token] for your TFE user account. (Organization and team tokens will not work; the token must be associated with an individual user.)
+
+    In your shell, set an `ATLAS_TOKEN` environment variable with your API token as the value.
+
+    ``` bash
+    export ATLAS_TOKEN=<USER TOKEN>
+    ```
+
+## Step 2: Create a New TFE Workspace
+
+Create a new workspace in your TFE organization to take over management of this infrastructure. Set the VCS repository and any necessary variable values appropriately. You can set team access permissions now or later, whichever is more convenient.
+
+**Do not perform any runs in this workspace yet,** and consider locking the workspace to be sure. If an apply happens prematurely, you'll need to destroy the workspace and start the process over.
 
 ## Step 3: Stop Terraform Runs
 
@@ -55,49 +61,40 @@ Add a `terraform { backend ...` block to the configuration.
 
 ``` hcl
 terraform {
-  backend "remote" {
-    hostname = "app.terraform.io"
-    organization = "my-org"
-
-    workspaces {
-      name = "my-workspace"
-    }
+  backend "atlas" {
+    name = "<TFE ORG>/<WORKSPACE NAME>"
+    address = "https://<TFE HOSTNAME>"
   }
 }
 ```
 
-- Use the `remote` backend.
-- In the `organization` attribute, specify the name of your TFE organization.
-- The `hostname` attribute is only necessary with private TFE instances. You can omit it if you're using the SaaS version of TFE.
-- In the `name` attribute in the `workspaces` block, specify the name of a new workspace to create with your state. You should ensure that a workspace with this name does not already exist in your organization. See [the remote backend documentation][remote-backend] for details.
+- Use the `atlas` backend. (This is TFE's backend; the Atlas name is used here for historical reasons.)
+- In the `name` attribute, specify the name of your TFE organization and the target workspace, separated by a slash. (For example, `example_corp/database-prod`.)
+- The `address` attribute is only necessary with private TFE instances. You can omit it if you're using the SaaS version of TFE.
+
+~> **Note:** The `atlas` backend block is temporary; it isn't needed once TFE takes over Terraform runs. It's easiest to put the backend block in a separate `backend.tf` file which isn't checked into version control.
 
 ## Step 6: Run `terraform init` and Answer "Yes"
 
 Run `terraform init`.
 
-The init command will offer to migrate the previous state to a new TFE workspace. The prompt usually looks like this:
+The init command will notice that your new TFE workspace doesn't have any state, and will offer to migrate the previous state to it. The prompt usually looks like this:
 
 ```
 Do you want to copy existing state to the new backend?
   Pre-existing state was found while migrating the previous "local" backend to the
-  newly configured "remote" backend. No existing state was found in the newly
-  configured "remote" backend. Do you want to copy this state to the new "remote"
+  newly configured "atlas" backend. No existing state was found in the newly
+  configured "atlas" backend. Do you want to copy this state to the new "atlas"
   backend? Enter "yes" to copy and "no" to start with an empty state.
 ```
 
 Answer "yes," and Terraform will migrate your state.
 
-## Step 7: Configure the TFE Workspace
+After the init has finished, you can delete the temporary `atlas` backend block.
 
-Make any settings changes necessary for your new workspace.
+## Step 7: Enable Runs in the New Workspace
 
-- [Set the VCS repository](../workspaces/settings.html#vcs-connection-and-repository)
-- [Set variable values appropriately](../workspaces/variables.html)
-- [Set team access permissions](../workspaces/access.html)
-
-## Step 8: Queue a Run in the New Workspace
-
-In TFE, queue a plan in the new workspace. Examine the results.
+In TFE, unlock the new workspace and queue a plan. Examine the results.
 
 If all went well, the plan should result in no changes or very small changes. TFE can now take over all Terraform runs for this infrastructure.
 
@@ -107,4 +104,5 @@ If all went well, the plan should result in no changes or very small changes. TF
 
     In the case of a wrong state file, you can recover by fixing your local working directory and trying again. You'll need to re-set to the local backend, run `terraform init`, replace the state file with the correct one, change back to the `atlas` backend, run `terraform init` again, and confirm that you want to replace the remote state with the current local state.
 - If the plan recognizes the existing resources but would make unexpected changes, check whether the designated VCS branch for the workspace is the same branch you've been running Terraform on, and update it, if it is not. You can also check whether variables in the TFE workspace have the correct values.
-- If you try to migrate state into a workspace which already exists in TFE and already has state, Terraform will indicate that you can overwrite your existing state in TFE. However, this will not work and result in a state mismatched lineage conflict.
+
+

--- a/content/source/docs/enterprise/migrate/workspaces.html.md
+++ b/content/source/docs/enterprise/migrate/workspaces.html.md
@@ -7,8 +7,7 @@ sidebar_current: "docs-enterprise2-migrating-workspaces"
 [cli-workspaces]: /docs/state/workspaces.html
 [user-token]: ../users-teams-organizations/users.html#api-tokens
 [backend]: /docs/backends/index.html
-[remote-backend]: /docs/backends/types/remote.html
-[cli-credentials]: /docs/commands/cli-config.html#credentials
+
 
 # Migrating State from Multiple Terraform Workspaces
 
@@ -18,13 +17,9 @@ These workspaces, managed with the `terraform workspace` command, aren't the sam
 
 If you use multiple workspaces, you'll need to migrate each one to a separate TFE workspace.
 
-Migrating multiple workspaces is similar to [migrating a single workspace](./index.html), but it requires a different attribute in the `terraform { backend ...` block.
+Migrating multiple workspaces is similar to [migrating a single workspace](./index.html), but it requires some extra steps.
 
-## Step 1: Ensure Terraform ≥ 0.11.8 is Installed
-
-To follow these instructions, you need Terraform 0.11.8 or later on the workstation where you are performing the migration. The remote backend this process relies on is not present in older versions.
-
-## Step 2: Gather Credentials, Data, and Code
+## Step 1: Gather Credentials, Data, and Code
 
 Make sure you have all of the following:
 
@@ -34,7 +29,19 @@ Make sure you have all of the following:
     - If you were using the `local` backend, your state is files on disk. You need the original working directory where you've been running Terraform, or a copy of the `terraform.tfstate` and `terraform.tfstate.d` files to copy into a fresh working directory.
     - For remote backends, you need the path to the particular storage being used (usually already included in the configuration) and access credentials (which you usually must set as an environment variable).
 - A TFE user account which is a member of your organization's owners team, so you can create workspaces.
-- A [user API token][user-token] for your TFE user account configured using your [CLI configuration file][cli-credentials]. (Organization and team tokens will not work; the token must be associated with an individual user.)
+- A [user API token][user-token] for your TFE user account. (Organization and team tokens will not work; the token must be associated with an individual user.)
+
+    In your shell, set an `ATLAS_TOKEN` environment variable with your API token as the value.
+
+    ``` bash
+    export ATLAS_TOKEN=<USER TOKEN>
+    ```
+
+## Step 2: Create New TFE Workspaces
+
+For each workspace you're migrating, create a new workspace in your TFE organization to take over management of the infrastructure. Set the VCS repository and any necessary variable values appropriately. You can set team access permissions now or later, whichever is more convenient.
+
+**Do not perform any runs in these workspaces yet,** and consider locking them to be sure. If an apply happens prematurely, you'll need to destroy the workspace and start the process over.
 
 ## Step 3: Stop Terraform Runs
 
@@ -46,81 +53,98 @@ This might involve locking or deleting CI jobs, restricting access to the state 
 
 In your shell, go to the directory with the Terraform configuration you're migrating.
 
-First, ensure the necessary state data is present.
-
 - If you've already been doing Terraform runs in this directory, you should be ready to go.
 - If you had to retrieve state files from elsewhere, copy them into the root of the working directory and run `terraform init`.
 - If you use a remote backend and had to check out a fresh working directory from version control, run `terraform init`.
 
-Next, **switch to a non-default workspace** by running `terraform workspace select <NAME>`. The migration process will fail if the special `default` workspace is currently active.
+## Step 5: Migrate to the `local` Backend, if Necessary
 
-~> **Important:** If you previously used a combination of named workspaces and the special `default` workspace, you must migrate the `default` workspace separately by following the instructions to [migrate a single workspace](./index.html). Before proceeding any further, back up the default workspace's state data to a safe place outside the working directory.
+If you use a remote backend that supports multiple workspaces, migrate to the local backend now. You need copies of each state file on disk, and this is the easiest way to get them.
 
-## Step 5: Edit the Backend Configuration
+To migrate to `local`, delete the `terraform { backend {...` configuration block and run `terraform init`. Confirm that you want to copy existing state to the new `local` backend, even if there's already data in it. (Any existing local data is probably out of date.)
 
-If the Terraform configuration has an existing backend block, delete it now.
+## Step 6: Back Up Your State Files
 
-Add a `terraform { backend ...` block to the configuration.
+Copy the following files to outside your working directory:
+
+- `terraform.tfstate`
+- `terraform.tfstate.d` (directory)
+
+It's easy to delete data when switching backends and workspaces, and the local copy of the `default` workspace's state is usually deleted during the next steps. Save copies now in case you need to start over.
+
+## Step 7: Switch to the `default` Workspace
+
+If you're not currently on the `default` workspace, run `terraform workspace select default` to activate it.
+
+## Step 8: Set the Backend Configuration for the Default Workspace
+
+Add a `terraform { backend ...` block to the configuration. Specify the TFE workspace that corresponds to the `default` workspace.
 
 ``` hcl
 terraform {
-  backend "remote" {
-    hostname = "app.terraform.io"
-    organization = "my-org"
-
-    workspaces {
-      prefix = "my-app-"
-    }
+  backend "atlas" {
+    name = "<TFE ORG>/<WORKSPACE NAME>"
+    address = "https://<TFE HOSTNAME>"
   }
 }
 ```
 
-- Use the `remote` backend.
-- In the `organization` attribute, specify the name of your TFE organization.
-- The `hostname` attribute is only necessary with private TFE instances. You can omit it if you're using the SaaS version of TFE.
-- In the `prefix` attribute in the `workspaces` block, specify a prefix to use when naming newly created TFE workspaces. Terraform will concatenate the prefix with the name of your local workspaces. See [the remote backend documentation][remote-backend] for details.
+- Use the `atlas` backend. (This is TFE's backend; the Atlas name is used here for historical reasons.)
+- In the `name` attribute, specify the name of your TFE organization and the target workspace, separated by a slash. (For example, `example_corp/database-prod`.)
+- The `address` attribute is only necessary with private TFE instances. You can omit it if you're using the SaaS version of TFE.
 
-## Step 6: Run `terraform init` and Answer "Yes"
+~> **Note:** The `atlas` backend block is temporary; it isn't needed once TFE takes over Terraform runs. It's easiest to put the backend block in a separate `backend.tf` file which isn't checked into version control.
+
+## Step 9: Migrate `default` by Running `terraform init`
+
+Run `terraform init` to migrate the default workspace.
+
+Terraform will ask two questions:
+
+- **"Do you want to copy only your current workspace?"** Answer "yes."
+
+    Terraform init can only handle the default workspace, so you'll use a different command for the others.
+- **"Do you want to copy existing state to the new backend?"** Answer "yes."
+
+The `default` workspace is now migrated.
+
+You can test the migration by unlocking the corresponding TFE workspace and queueing a plan; if the plan results in no changes or very small changes, the migration probably worked correctly.
+
+## Step 10: Edit the Backend to Change Workspaces
+
+Edit your backend configuration, and change the `name` to the next TFE workspace you want to migrate. For example, if the next local workspace is `dev1`, its new name in TFE might be something like `example_corp/database-dev1`.
+
+At this point, it's a good idea to use a checklist of workspaces to keep track of your progress.
+
+## Step 11: Run `terraform init` and Answer "No"
 
 Run `terraform init`.
 
-The init command will offer to migrate the previous states to a new TFE workspaces. The prompt usually looks like this:
+When asked if you want to migrate state, **answer "no."**
 
 ```
-Do you want to migrate all workspaces to "remote"?
-  Both the existing "local" backend and the newly configured "remote" backend support
-  workspaces. When migrating between backends, Terraform will copy all
-  workspaces (with the same names). THIS WILL OVERWRITE any conflicting
-  states in the destination.
-
-  Terraform initialization doesn't currently migrate only select workspaces.
-  If you want to migrate a select number of workspaces, you must manually
-  pull and push those states.
-
-  If you answer "yes", Terraform will migrate all states. If you answer
-  "no", Terraform will abort.
+Do you want to copy existing state to the new backend?
+  Pre-existing state was found while migrating the previous "atlas" backend to the
+  newly configured "atlas" backend. No existing state was found in the newly
+  configured "atlas" backend. Do you want to copy this state to the new "atlas"
+  backend? Enter "yes" to copy and "no" to start with an empty state.
 ```
 
-Answer "yes," and Terraform will migrate your state.
+If you answer yes, Terraform will copy the state from the last workspace you migrated, which is not what you want.
 
-## Step 7: Configure the TFE Workspaces
+## Step 12: Run `terraform state push <FILE>`
 
-Make any settings changes necessary for your new workspaces.
+Locate the state file for the workspace you want to migrate. Its local path should be something like `./terraform.tfstate.d/<WORKSPACE NAME>/terraform.tfstate`.
 
-- [Set the VCS repository](../workspaces/settings.html#vcs-connection-and-repository)
-- [Set variable values appropriately](../workspaces/variables.html)
-- [Set team access permissions](../workspaces/access.html)
+Run `terraform state push ./terraform.tfstate.d/<WORKSPACE NAME>/terraform.tfstate`.
 
-## Step 8: Queue Runs in the New Workspaces
+The workspace is now migrated. You can check the migration by unlocking the TFE workspace and queuing a plan.
 
-In TFE, queue a plan in the new workspaces. Examine the results.
+## Step 13: Repeat Steps 10-12 as Needed
 
-If all went well, the plan should result in no changes or very small changes. TFE can now take over all Terraform runs for this infrastructure.
+Repeat the last three steps for each remaining workspace, until every workspace is migrated.
 
-## Troubleshooting
+## Step 14: Enable Runs in the New Workspaces
 
-- If the plan would create an entirely new set of infrastructure resources, you probably have the wrong state file.
+After checking the results of the migrations, unlock each new workspace to allow TFE to take over management of this infrastructure.
 
-    In the case of a wrong state file, you can recover by fixing your local working directory and trying again. You'll need to re-set to the local backend, run `terraform init`, replace the state file with the correct one, change back to the `atlas` backend, run `terraform init` again, and confirm that you want to replace the remote state with the current local state.
-- If the plan recognizes the existing resources but would make unexpected changes, check whether the designated VCS branch for the workspace is the same branch you've been running Terraform on, and update it, if it is not. You can also check whether variables in the TFE workspace have the correct values.
-- If you try to migrate state into a workspace which already exists in TFE and already has state, Terraform will indicate that you can overwrite your existing state in TFE. However, this will not work and result in a state mismatched lineage conflict.


### PR DESCRIPTION
We've decided not to push the use of the `remote` backend while we resolve some
issues and improve the user experience. While that's in progress, new users
should continue using the `atlas` backend to migrate Terraform OSS state into
TFE.

This squashed commit reverts the following prior commits:

a3b32164e7d3d96af0ea916346ef87606f99c9d0
  "migration: Add 0.11.8 requirements and notes about the special default workspace"
6bde6e8e9fad92f4b44f8a1bd09283dd6b0919ba.
  "Prefer credentials file over env var for token"
b5eabbb52f06ac8b0c54caedcc0518e1049fddc8.
  "Update migrating multiple workspaces to TFE using remote backend"
d61c01bd2a7589995c45a68293c2decc2ae157ae.
  "Update migrating a default workspace state to TFE"

When it's time to for-real promote use of the `remote` backend, we can revert
this single commit and then make any further changes as needed.