### PR TITLE
Add force-cancel API docs

### DIFF
--- a/content/source/docs/enterprise/api/admin/runs.html.md
+++ b/content/source/docs/enterprise/api/admin/runs.html.md
@@ -143,6 +143,22 @@ Status  | Response                               | Reason
 [JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
+### Request body
+
+This POST endpoint allows an optional JSON object with the following properties as a request payload.
+
+Key path  | Type   | Default | Description
+----------|--------|---------|------------
+`comment` | string | `null`  | An optional explanation for why the run was force canceled.
+
+### Sample Payload
+
+```json
+{
+  "comment": "This run was stuck and would never finish."
+}
+```
+
 ### Sample Request
 
 ```shell
@@ -150,6 +166,7 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
+  --data @payload.json \
   "https://app.terraform.io/api/v2/admin/runs/run-VCsNJXa59eUza53R/actions/force-cancel"
 ```
 

--- a/content/source/docs/enterprise/api/admin/runs.html.md
+++ b/content/source/docs/enterprise/api/admin/runs.html.md
@@ -125,13 +125,13 @@ curl \
 
 ## Force a run into the "cancelled" state
 
-`POST /admin/runs/:id/actions/cancel`
+`POST /admin/runs/:id/actions/force-cancel`
 
 Parameter | Description
 ----------|------------
 `:id`     | The ID of the run to cancel.
 
-This endpoint forces a run (and its plan/apply, if applicable) into the `"errored"` state. This action should only be performed for runs that are stuck and no longer progressing normally, as there is a risk of lost state data if a progressing apply is force-canceled. Healthy runs can be [requested for cancellation by end-users](../../run/states.html).
+This endpoint forces a run (and its plan/apply, if applicable) into the `"canceled"` state. This action should only be performed for runs that are stuck and no longer progressing normally, as there is a risk of lost state data if a progressing apply is force-canceled. Healthy runs can be [requested for cancellation by end-users](../../run/states.html).
 
 Status  | Response                               | Reason
 --------|----------------------------------------|----------
@@ -150,7 +150,7 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  "https://app.terraform.io/api/v2/admin/runs/run-VCsNJXa59eUza53R/actions/cancel"
+  "https://app.terraform.io/api/v2/admin/runs/run-VCsNJXa59eUza53R/actions/force-cancel"
 ```
 
 ### Sample Response

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -439,7 +439,7 @@ This endpoint represents an action as opposed to a resource. As such, it does no
 Status  | Response                  | Reason(s)
 --------|---------------------------|----------
 [202][] | none                      | Successfully queued a cancel request.
-[409][] | [JSON API error object][] | Run was not planning or applying; cancel not allowed.
+[409][] | [JSON API error object][] | Run was not planning or applying, has not been canceled non-forcefully, or the cool-off period has not yet passed.
 
 ### Request Body
 

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -257,11 +257,13 @@ curl \
           "is-cancelable": false,
           "is-confirmable": true,
           "is-discardable": true,
+          "is-force-cancelable": false
         },
         "permissions": {
           "can-apply": true,
           "can-cancel": true,
           "can-discard": true,
+          "can-force-cancel": false,
           "can-force-execute": true
         }
       },
@@ -336,11 +338,13 @@ curl \
         "is-cancelable": false,
         "is-confirmable": true,
         "is-discardable": true,
+        "is-force-cancelable": false
       },
       "permissions": {
         "can-apply": true,
         "can-cancel": true,
         "can-discard": true,
+        "can-force-cancel": false,
         "can-force-execute": true
       }
     },

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -277,13 +277,91 @@ curl \
         "run-events": {...},
         "policy-checks": {...},
         "comments": {...},
-        "workspace-run-alerts": {...},
+        "workspace-run-alerts": {...}
+      },
       "links": {
         "self": "/api/v2/runs/run-bWSq4YeYpfrW4mx7"
       }
     },
     {...}
   ]
+}
+```
+
+## Get run details
+
+`GET /runs/:run_id`
+
+Parameter     | Description
+--------------|----------------------
+`:run_id`     | The run ID to get.
+
+This endpoint is used for showing details of a specific run.
+
+Status  | Response                               | Reason
+--------|----------------------------------------|-------
+[200][] | [JSON API document][] (`type: "runs"`) | Success
+[404][] | [JSON API error object][]              | Run not found or user not authorized
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  https://app.terraform.io/api/v2/runs/run-bWSq4YeYpfrW4mx7
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "run-bWSq4YeYpfrW4mx7",
+    "type": "runs",
+    "attributes": {
+      "auto-apply": false,
+      "error-text": null,
+      "is-destroy": false,
+      "message": "",
+      "metadata": {},
+      "source": "tfe-configuration-version",
+      "status": "planned",
+      "status-timestamps": {
+        "planned-at": "2017-11-28T22:52:51+00:00"
+      },
+      "terraform-version": "0.11.0",
+      "created-at": "2017-11-28T22:52:46.711Z",
+      "has-changes": true,
+      "actions": {
+        "is-cancelable": false,
+        "is-confirmable": true,
+        "is-discardable": true,
+      },
+      "permissions": {
+        "can-apply": true,
+        "can-cancel": true,
+        "can-discard": true,
+        "can-force-execute": true
+      }
+    },
+    "relationships": {
+      "workspace": {...},
+      "apply": {...},
+      "canceled-by": {...},
+      "configuration-version": {...},
+      "confirmed-by": {...},
+      "created-by": {...},
+      "input-state-version": {...},
+      "plan": {...},
+      "run-events": {...},
+      "policy-checks": {...},
+      "comments": {...},
+      "workspace-run-alerts": {...}
+    },
+    "links": {
+      "self": "/api/v2/runs/run-bWSq4YeYpfrW4mx7"
+    }
+  }
 }
 ```
 
@@ -398,7 +476,7 @@ Parameter | Description
 
 The `force-cancel` action is like [cancel](#cancel-a-run), but ends the run immediately. Once invoked, the run is placed into a `canceled` state, and the running Terraform process is terminated. The workspace is immediately unlocked, allowing further runs to be queued.
 
-This endpoint enforces a prerequisite that a [non-forceful cancel](#cancel-a-run) is performed first. Once a non-forceful cancel has been performed, an additional cool-off period is enforced. The time remaining in the cool-off period can be found using the `GET` endpoint for the run, in the key `force_cancel_delay_seconds`. Once this time period expires, if the run has still not ended, the force-cancel endpoint may be used successfully.
+This endpoint enforces a prerequisite that a [non-forceful cancel](#cancel-a-run) is performed first. Once a non-forceful cancel has been performed, an additional cool-off period is enforced. The time remaining in the cool-off period can be found using the [run details endpoint](#get-run-details), in the key `force_cancel_delay_seconds`. Once this time period expires, if the run has still not ended, the force-cancel endpoint may be used successfully.
 
 This endpoint represents an action as opposed to a resource. As such, it does not return any object in the response body.
 

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -524,10 +524,6 @@ curl \
 
 ## Available Related Resources
 
-
-
-## Available Related Resources
-
 The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
 
 - `plan` - Additional information about plans.


### PR DESCRIPTION
Added force-cancel API docs for site admin as well as the runs API. I also added a missing endpoint (`GET /runs/:run_id`) because I wanted to link to it. I noticed a few other little JSON errors in here too so I fixed those up.