### PR TITLE
extend: Add Community Events section

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -40,16 +40,7 @@
 /docs/configuration/atlas.html                   /docs/configuration/terraform-enterprise.html
 /docs/enterprise/packer/builds.html              /docs/enterprise/packer/builds/index.html
 /docs/providers/atlas                            /docs/providers/terraform-enterprise/index.html
-/docs/providers/aws/r/alb.html                    /docs/providers/aws/r/lb.html
-/docs/providers/aws/r/alb_listener.html           /docs/providers/aws/r/lb_listener.html
-/docs/providers/aws/r/alb_listener_rule.html      /docs/providers/aws/r/lb_listener_rule.html
-/docs/providers/aws/r/alb_target_group.html       /docs/providers/aws/r/lb_target_group.html
-/docs/providers/aws/r/alb_target_group_attachment.html    /docs/providers/aws/r/lb_target_group_attachment.html
-/docs/providers/aws/r/code_commit_repository.html /docs/providers/aws/r/codecommit_repository.html
-/docs/providers/aws/r/code_commit_trigger.html    /docs/providers/aws/r/codecommit_trigger.html
-/docs/providers/aws/d/alb.html                    /docs/providers/aws/d/lb.html
-/docs/providers/aws/d/alb_listener.html           /docs/providers/aws/d/lb_listener.html
-/docs/providers/aws/d/alb_target_group.html       /docs/providers/aws/d/lb_target_group.html
+
 # The great TFE GA release
 /docs/enterprise-beta/api/configuration-versions.html   /docs/enterprise/api/configuration-versions.html
 /docs/enterprise-beta/api/index.html                    /docs/enterprise/api/index.html
@@ -183,3 +174,16 @@
 /docs/enterprise/workspaces/run-ui.html                  /docs/enterprise/run/ui.html
 /docs/enterprise/workspaces/run-api.html                 /docs/enterprise/run/api.html
 /docs/enterprise/workspaces/run-cli.html                 /docs/enterprise/run/cli.html
+
+# AWS Provider
+/docs/providers/aws/d/alb_listener.html                /docs/providers/aws/d/lb_listener.html
+/docs/providers/aws/d/alb_target_group.html            /docs/providers/aws/d/lb_target_group.html
+/docs/providers/aws/d/alb.html                         /docs/providers/aws/d/lb.html
+/docs/providers/aws/events/gardening-summer-2018.html  /docs/extend/community/events/2018/summer-gardening.html
+/docs/providers/aws/r/alb_listener_rule.html           /docs/providers/aws/r/lb_listener_rule.html
+/docs/providers/aws/r/alb_listener.html                /docs/providers/aws/r/lb_listener.html
+/docs/providers/aws/r/alb_target_group_attachment.html /docs/providers/aws/r/lb_target_group_attachment.html
+/docs/providers/aws/r/alb_target_group.html            /docs/providers/aws/r/lb_target_group.html
+/docs/providers/aws/r/alb.html                         /docs/providers/aws/r/lb.html
+/docs/providers/aws/r/code_commit_repository.html      /docs/providers/aws/r/codecommit_repository.html
+/docs/providers/aws/r/code_commit_trigger.html         /docs/providers/aws/r/codecommit_trigger.html

--- a/content/source/docs/extend/community/events/2018/fall-gardening.html.md
+++ b/content/source/docs/extend/community/events/2018/fall-gardening.html.md
@@ -1,0 +1,34 @@
+---
+layout: "extend"
+page_title: "Terraform Ecosystem Community Events - 2018 Fall Gardening"
+sidebar_current: "docs-extend-community-events-2018-fall-gardening"
+description: |-
+  Fall 2018 community gardening event for Terraform providers.
+
+---
+
+# Terraform Ecosystem Community Events - 2018 Fall Gardening
+
+HashiCorp does quarterly community gardening sessions for Terraform providers. Our second is September 12, 2018 for Azure. It is an all virtual event across time zones. As a user, you will be able to ask HashiCorp employees Azure Terraform provider questions in our [Slack room](https://terraform-azure.slack.com/). The concept is based on the [Go Gardening](https://github.com/golang/go/wiki/Gardening) idea.
+
+What are we planning to do?
+
+* Weeding
+* New resources/data sources
+* Enhancements to existing resources/data sources
+* Bug fixes
+* Documentation
+* Verifying and adding tests to existing resources/data sources
+
+Why we love hosting these?
+
+* We want to get our community involved and introduced to each other.
+* This allows people with all levels to participate from the small, medium to larger infrastructures. As well as the beginners having an opportunity to get positive support from more advanced users.
+
+The Slack room is open and available for conversations among participants, drop ins, all while someone from HashiCorp will be available throughout the time zones.
+
+Anything marked `HashiCorp in Progress` please reach out first via Slack please.
+
+Please send all good, bad, and could be better feedback to [beth@hashicorp.com](mailto:beth@hashicorp.com) so that we can make improvements on a continuous basis.
+
+We really appreciate the communities feedback, help and participation. We also want to make sure we are bring you along with our roadmap and listening to your feedback about what business problems you are running into so that we can adjust quicker.

--- a/content/source/docs/extend/community/events/2018/summer-gardening.html.md
+++ b/content/source/docs/extend/community/events/2018/summer-gardening.html.md
@@ -1,0 +1,51 @@
+---
+layout: "extend"
+page_title: "Terraform Ecosystem Community Events - 2018 Summer Gardening"
+sidebar_current: "docs-extend-community-events-2018-summer-gardening"
+description: |-
+  Summer 2018 community gardening event for Terraform providers.
+---
+
+# Terraform Ecosystem Community Events - 2018 Fall Gardening
+
+On June 21, 2018 the Terraform AWS team is going to put together a virtual, all time zones (best we can), community gardening session for the Terraform AWS provider, inspired by [Go's gardening concept](https://github.com/golang/go/wiki/Gardening). We plan to do this for other Terraform providers and OSS projects eventually.
+
+We have some amazing contributors to AWS and want to get them more involved. This allows people with all levels of AWS knowledge to participate from small, medium, and larger infrastructures. Beginners will have an opportunity to get positive support from more advanced users and HashiCorp will provide participants for quick knowledge.
+
+## What to Expect
+
+What do we plan to do first?
+
+* Weeding
+
+Why are we starting here?
+
+* We currently have 1600 issues for AWS.
+* There are certainly duplicates
+* Bugs that have been fixed
+* Bugs that need to be fixed that we do not have time for due to volume
+
+What we are giving away for participating?
+
+* Sweatshirts for the top 5 people who close the most issues via bug closure or finding duplicates and closing issues
+* T-shirts for the next top 10 people who close the most issues via bug closure or finding duplicates and closing issues
+* HashiCorp mug for the next top 10 who close the most issues via bug closure or finding duplicates and closing issues
+* Stickers for everyone.
+
+If you are going to be at HashiDays or HashiConf, let us know and we will set the goodies aside for you. Otherwise please feel free to reach out to Beth Fuller with your address and she’ll send that to you.
+
+## Event Information
+
+### Realtime Communication
+
+We will have a [Gitter](https://gitter.im/) room available at [`hashicorp-terraform/gardening`](https://gitter.im/hashicorp-terraform/gardening) and a someone from HashiCorp on [Zoom conferencing](https://zoom.us/) through out the time zones.
+
+### Community Issue Selection
+
+Anything marked `HashiCorp in Progress` please reach out first via the Gitter room or Zoom channel.
+
+## Feedback
+
+AWS is our first step, as contributors to this project, we want your feedback on how the event went. Please send all good, bad, could be better feedback to beth@hashicorp.com so that we can make improvements on a continuous basis.
+
+We really appreciate the communities feedback, help and participation. We also want to make sure we are bring you along with our roadmap and listening to your feedback about what business problems you are running into so that we can adjust quicker.

--- a/content/source/docs/extend/community/events/index.html.md
+++ b/content/source/docs/extend/community/events/index.html.md
@@ -1,0 +1,22 @@
+---
+layout: "extend"
+page_title: "Terraform Ecosystem Community Events"
+sidebar_current: "docs-extend-community-events"
+description: |-
+  HashiCorp sponsored community events for the Terraform development ecosystem.
+---
+
+# Terraform Ecosystem Community Events
+
+The Terrafom development ecosystem has amazing contributors and community members. HashiCorp sponsors various community events to bring together Terraform developers of all experience for realtime collaboration and growth.
+
+## Upcoming Events
+
+Additional upcoming events including webinars and HashiCorp User Groups can be found on the [HashiCorp Events](https://www.hashicorp.com/events) page.
+
+* [Community Gardening - Fall 2018](/docs/extend/community/events/2018/fall-gardening.html) (September 12, 2018) - Terraform Azure provider gardening event.
+* [HashiConf 2018](https://www.hashiconf.com/) (October 22-24, 2018) - Annual HashiCorp user and technology conference. Three days of hands-on product training, keynotes, technical talks, and one-on-one time with the HashiCorp developers.
+
+## Past Events
+
+* [Community Gardening - Summer 2018](/docs/extend/community/events/2018/summer-gardening.html) (June 21, 2018) - Terraform AWS provider gardening event.

--- a/content/source/docs/extend/community/index.html.md
+++ b/content/source/docs/extend/community/index.html.md
@@ -12,6 +12,10 @@ description: |-
 Terraform is a mature project with a growing community. There are active,
 dedicated people willing to help you through various mediums.
 
+**Events:** HashiCorp sponsors various community events to bring together
+Terraform ecosystem developers. See the
+[events](/docs/extend/community/events/index.html) page for more information.
+
 **Stack Exchange:** Terraform questions often get asked and answered on [Server
 Fault](https://serverfault.com/) and [Stack
 Overflow](https://stackoverflow.com/). Use the tag "terraform" to help your

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -86,6 +86,14 @@
           <li<%= sidebar_current("docs-extend-community-code-of-conduct") %>>
             <a href="/docs/extend/community/code-of-conduct.html">Code of Conduct</a>
           </li>
+          <li<%= sidebar_current("docs-extend-community-events") %>>
+            <a href="/docs/extend/community/events/index.html">Events</a>
+            <ul class="nav">
+              <li<%= sidebar_current("docs-extend-community-events-2018-fall-gardening") %>>
+                <a href="/docs/extend/community/events/2018/fall-gardening.html">Gardening - Fall 2018</a>
+              </li>
+            </ul>
+          </li>
           <li<%= sidebar_current("docs-extend-community-maintainers") %>>
             <a href="/docs/extend/community/maintainers.html">Maintainers</a>
           </li>


### PR DESCRIPTION
* Add new Events section under Community including links to HashiConf and HashiCorp Events page
* Add Fall 2018 Gardening sidebar and link under Community Events
* Redirect AWS provider event page from June 2018 to new page