### PR TITLE
Update Sentinel docs link

### DIFF
--- a/content/source/docs/enterprise/sentinel/index.html.md
+++ b/content/source/docs/enterprise/sentinel/index.html.md
@@ -12,7 +12,7 @@ fine-grained, logic-based policy decisions, and can be extended to use
 information from external sources.
 
 To learn how to use Sentinel and begin writing policies with the Sentinel
-language, see [the Sentinel documentation](https://docs.hashicorp.com/sentinel/app/terraform/).
+language, see [the Sentinel documentation](https://docs.hashicorp.com/sentinel/writing/).
 
 ## Sentinel in Terraform Enterprise
 


### PR DESCRIPTION
Realized only after I changed the words here that it doesn't make a lot of sense to link to the minimal Terraform docs on the Sentinel site (which just basically references here). Since this sentence describes writing generic Sentinel policies, refer to the Writing Policies section instead.