### PR TITLE
sentinel: Re-write import documentation

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -195,12 +195,12 @@ for the root module. They are essentially the equivalent of running
 
 ## Namespace: Resources/Data Sources
 
-The **resource namespace** is a namespace shared between resources and data
-sources, and is identical in structure and behavior regardless of which
-classification you are loading.
+The **resource namespace** is a namespace _type_ that applies to both resources
+(accessed by using the `resources` namespace key) and data sources (accessed
+using the `data` namespace key).
 
-Accessing an individual resource or data source within this namespace can be
-accomplished by specifying the type and name, in the syntax
+Accessing an individual resource or data source within each individual namespace
+can be accomplished by specifying the type and name, in the syntax
 `[resources|data].TYPE.NAME`, depending on whether or not you are loading the
 namespace for a resource (accessed in the `resources` name space) or data
 sources (accessed in the `data`) namespace.

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -183,7 +183,6 @@ get_vms = func() {
 }
 ```
 
-
 ## Namespace: Module
 
 The **module namespace** can be loaded by calling [`module()`](#function-module-)

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -208,8 +208,7 @@ It can be used to load the following child namespaces:
 
 The root-level `data`, `modules`, `providers`, `resources`, and `variables` keys
 all alias to their corresponding namespaces within the module namespace, loaded
-for the root module. They are essentially the equivalent of running
-`module([]).KEY`.
+for the root module. They are the equivalent of running `module([]).KEY`.
 
 ## Namespace: Resources/Data Sources
 

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -216,16 +216,20 @@ The **resource namespace** is a namespace _type_ that applies to both resources
 (accessed by using the `resources` namespace key) and data sources (accessed
 using the `data` namespace key).
 
-Accessing an individual resource or data source within each individual namespace
+Accessing an individual resource or data source within each respective namespace
 can be accomplished by specifying the type and name, in the syntax
-`[resources|data].TYPE.NAME`, depending on whether or not you are loading the
-namespace for a resource (accessed in the `resources` name space) or data
-sources (accessed in the `data`) namespace.
+`[resources|data].TYPE.NAME`.
 
-In addition, each of these namespace levels is a map, so to access all items
-_matching_ a certain type, you can use `[resources|data].TYPE`, and to access
-all data sources _grouped by_ type, you can use a simple bareword `resources` or
-`data` map.
+In addition, each of these namespace levels is a map, allowing you to filter
+based on type and name. Some examples of multi-level access are below:
+
+* To fetch all `aws_instance` resources within the root module, you can specify
+  `tfconfig.resources.aws_instance`. This would give you a map of resource
+  namespaces indexed off of the names of each resource (`foo`, `bar`, and so
+  on).
+* To fetch all resources within the root module, irrespective of type, use
+  `tfconfig.resources`. This is indexed by type, as shown above with
+  `tfconfig.resources.aws_instance`, with names being the next level down.
 
 Further explanation of the namespace will be in the context of resources. As
 mentioned, when operating on data sources, use the same syntax, except with

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -428,6 +428,17 @@ This namespace is indexed by provider type and _only_ contains data about
 providers when actually declared. If you are using a completely implicit
 provider configuration, this namespace will be empty.
 
+This namespace is populated based on the following criteria:
+
+* The top-level namespace [`config`](#value-config-3) and
+  [`version`](#value-version) values are populated with the configuration and
+  version information from the default provider (the provider declaration that
+  lacks an alias).
+* Any aliased providers are added as namespaces within the
+  [`alias`](value-alias) value.
+* If a module lacks a default provider configuration, the top-level `config` and
+  `version` values will be empty.
+
 ### Value: `alias`
 
 * **Value Type:** A map of [provider namespaces](#namespace-providers), indexed

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -101,6 +101,11 @@ Hence, a module with an address of simply `foo` (or `root.foo`) would be
 `["foo"]`, and a module within that (so address `foo.bar`) would be read as
 `["foo", "bar"]`.
 
+[`null`][ref-null] is returned if a module address is invalid, or if the module
+is not present in the configuration.
+
+[ref-null]: https://docs.hashicorp.com/sentinel/language/spec#null
+
 As an example, given the following module block:
 
 ```hcl
@@ -133,9 +138,13 @@ main = rule { subject.module(["foo"]).resources.null_resource.foo.config.trigger
 * **Value Type:** List of a list of strings.
 
 The `module_paths` value within the [root namespace](#namespace-root) is a list
-of all of the modules within the Terraform configuration. This data is
-represented as a list of a list of strings, with the inner list being the module
-address, split on the period (`.`).
+of all of the modules within the Terraform configuration.
+
+Modules not present in the configuration will not be present here, even if they
+are present in the diff or state.
+
+This data is represented as a list of a list of strings, with the inner list
+being the module address, split on the period (`.`).
 
 The root module is included in this list, represented as an empty inner list.
 

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -167,9 +167,14 @@ main = rule { tfconfig.module_paths contains ["foo"] }
 
 #### Iterating through modules
 
-Here is an example of a function to retrieve all resources of a particular type
-from all modules. Note the use of `else []` in case some modules don't have any
+Iterating through all modules to find particular resources can be useful. This
+example shows how to use `module_paths` with the [`module()`
+function](#function-module-) to retrieve all resources of a particular type from
+all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
+resource). Note the use of `else []` in case some modules don't have any
 resources; this is necessary to avoid the function returning undefined.
+
+[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
 
 ```python
 import "tfconfig"

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -422,7 +422,7 @@ The **provider namespace** represents data on the declared providers within a
 namespace.
 
 This namespace is indexed by provider type and _only_ contains data about
-providers when actually declared. Hence, if you are using a completely implicit
+providers when actually declared. If you are using a completely implicit
 provider configuration, this namespace will be empty.
 
 ### Value: `alias`

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -28,9 +28,9 @@ The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
 -> Note that the root-level alias keys shown here (`data`, `modules`,
-`providers`, `resources`, and `variables`) are shortcuts to the [module
-namespace](#namespace-module). For more details, see the section on [root
-namespace aliases](#root-namespace-aliases).
+`providers`, `resources`, and `variables`) are shortcuts to a [module
+namespace](#namespace-module) scoped to the root module. For more details, see
+the section on [root namespace aliases](#root-namespace-aliases).
 
 ```
 tfconfig

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -193,7 +193,7 @@ get_vms = func() {
 The **module namespace** can be loaded by calling [`module()`](#function-module-)
 for a particular module.
 
-It's a namespace that can be used to load the following data:
+It can be used to load the following child namespaces:
 
 * `data` - Loads the [resource namespace](#namespace-resources-data-sources),
   filtered against data sources.

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -148,7 +148,16 @@ module "foo" {
 }
 ```
 
-The following policy would evaluate to `true`:
+The value of `module_paths` would be:
+
+```
+[
+	[],
+	["foo"],
+]
+```
+
+And the following policy would evaluate to `true`:
 
 ```python
 import "tfconfig"

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -399,7 +399,8 @@ main = rule { tfconfig.modules.foo.source is "./foo" }
 
 The `config` value within the [module configuration
 namespace](#namespace-module-configuration) represents the values of the keys
-within the module configuration.
+within the module configuration. This is every key within a module declaration
+block except [`source`](#value-source), which has its own value.
 
 As an example, given the module declaration block:
 
@@ -477,8 +478,9 @@ main = rule { tfconfig.providers.aws.alias.east.config.region is "us-east-1" }
 
 The `config` value within the [provider namespace](#namespace-providers)
 represents the values of the keys within the provider's configuration, with the
-exception of the provider version, which is represented by the [`version`
-value](#value-version).
+exception of the provider version, which is represented by the
+[`version`](#value-version) value. [`alias`](#value-alias) is also not included
+when the provider is aliased.
 
 As an example, given the following provider declaration block:
 

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -27,6 +27,11 @@ can't see values for variables, the state, or the diff for a pending plan.
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
+-> Note that the root-level alias keys shown here (`data`, `modules`,
+`providers`, `resources`, and `variables`) are shortcuts to the [module
+namespace](#namespace-module). For more details, see the section on [root
+namespace aliases](#root-namespace-aliases).
+
 ```
 tfconfig
 ├── module() (function)

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -273,8 +273,8 @@ main = rule { default_foo and default_number and default_map_string and default_
 The **module namespace** can be loaded by calling
 [`module()`](#function-module-) for a particular module.
 
-It's a namespace that can be used to load the following child namespaces, in
-addition to the values documented below:
+It can be used to load the following child namespaces, in addition to the values
+documented below:
 
 * `data` - Loads the [resource namespace](#namespace-resources-data-sources),
   filtered against data sources.

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -149,14 +149,24 @@ module "foo" {
 }
 ```
 
-The following policy would evaluate to `true`, _only_ if the diff had changes
-for that module:
+The value of `module_paths` would be:
+
+```
+[
+	[],
+	["foo"],
+]
+```
+
+And the following policy would evaluate to `true`:
 
 ```python
 import "tfplan"
 
 main = rule { tfplan.module_paths contains ["foo"] }
 ```
+
+-> Note the above example only applies if the module is present in the diff.
 
 #### Iterating through modules
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -513,8 +513,8 @@ The `old` value within the [diff namespace](#namespace-resource-diff) contains
 the old value of a changing attribute.
 
 Note that this value is _always_ a string, regardless of the actual type of the
-value changing. Type conversion within policy may be necessary to achieve the
-comparison needed.
+value changing. [Type conversion][ref-sentinel-type-conversion] within policy
+may be necessary to achieve the comparison needed.
 
 As an example, given the following resource:
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -431,14 +431,14 @@ namespace](#namespace-resources-data-sources).
 * **Value Type:** Boolean.
 
 The `computed` value within the [diff namespace](#namespace-resource-diff) is
-`true` if a value is currently unknown in the diff, but is changing. This
-happens when a value depends on a value belonging to a resource that either does
-not exist yet or is changing state in a way that the new value will not be known
-until the apply for that resource completes.
+`true` if the resource key in question depends on another value that isn't yet
+known. Typically, that means the value it depends on belongs to a resource that
+either doesn't exist yet, or is changing state in such a way as to affect the
+dependent value so that it can't be known until the apply is complete.
 
--> Keep in mind when using `computed` with complex structures such as maps,
-lists, and sets, that it's sometimes necessary to test the count attribute for
-the structure, versus a key within it, depending on whether or not the diff has
+-> Keep in mind that when using `computed` with complex structures such as maps,
+lists, and sets, it's sometimes necessary to test the count attribute for the
+structure, versus a key within it, depending on whether or not the diff has
 marked the whole structure as computed. This is demonstrated in the example
 below.  Count keys are `%` for maps, and `#` for lists and sets. If you are
 having trouble determining the actual type of specific field within a resource,

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -307,7 +307,7 @@ equivalent of running `module([]).KEY`.
 
 The `path` value within the [module namespace](#namespace-module) contains the
 path of the module that the namespace represents. This is represented as a list
-of stings.
+of strings.
 
 As an example, if the following module block was present within a Terraform
 configuration:

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -357,7 +357,7 @@ Some examples of multi-level access are below:
 * To fetch all `aws_instance` resources within the root module, you can specify
   `tfplan.resources.aws_instance`. This would be indexed off of the names of
   each resource (`foo`, `bar`, and so on), with each of those maps containing
-  instances indexed on count index as per above.
+  instances indexed by resource count index as per above.
 * To fetch all resources indiscriminately within the root module,
   `tfplan.resources` will do. This is then indexed by resource type
   (`aws_instance`, for example), with the other maps cascading down from there.

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -170,11 +170,12 @@ main = rule { tfplan.module_paths contains ["foo"] }
 
 #### Iterating through modules
 
-Here is an example of a function to retrieve all resources of a particular type
-from all modules (in this case, the
-[`azurerm_virtual_machine`][ref-tf-azurerm-vm] resource). Note the use of `else
-[]` in case some modules don't have any resources; this is necessary to avoid
-the function returning undefined.
+Iterating through all modules to find particular resources can be useful. This
+example shows how to use `module_paths` with the [`module()`
+function](#function-module-) to retrieve all resources of a particular type from
+all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
+resource). Note the use of `else []` in case some modules don't have any
+resources; this is necessary to avoid the function returning undefined.
 
 [ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -8,21 +8,20 @@ description: |-
 
 # Import: tfplan
 
-The `tfplan` import provides access to a Terraform plan. A Terraform
-plan is the file created as a result of `terraform plan` and is
-the input to `terraform apply`. The plan represents the changes that
-Terraform needs to make to infrastructure to reach the desired state
-represented by the configuration.
+The `tfplan` import provides access to a Terraform plan. A Terraform plan is the
+file created as a result of `terraform plan` and is the input to `terraform
+apply`. The plan represents the changes that Terraform needs to make to
+infrastructure to reach the desired state represented by the configuration.
 
-The Terraform plan import also allows you to access the configuration files (an
-alias to the [`tfconfig`][import-tfconfig] import) as well as the Terraform
-state (an alias to the [`tfstate`][import-tfstate] import) at the time the plan
-was run.  You can also access an "applied" state that merges the plan with the
-state to create the planned state after apply. Note that any computed values
-will not be visible in this state.
+In addition to the diff data available in the plan, there is an
+[`applied`](#value-applied) state available that merges the plan with the state
+to create the planned state after apply. Note that any computed values will not
+be visible in this state.
 
-[import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
-[import-tfstate]: /docs/enterprise/sentinel/import/tfstate.html
+Finally, this import also allows you to access the configuration files and the
+Terraform state at the time the plan was run. See the section on [accessing a
+plan's state and configuration
+data](#accessing-a-plan-39-s-state-and-configuration-data) for more information.
 
 ## The Namespace
 
@@ -75,9 +74,26 @@ In addition to this, the root-level `data`, `path`, and `resources` keys alias
 to their corresponding namespaces or values within the [module
 namespace](#namespace-module).
 
-Further, the `config` and `state` keys alias to the
-[`tfconfig`][import-tfconfig] and [`tfstate`][import-tfstate] namespaces,
-respectively.
+### Accessing a Plan's State and Configuration Data
+
+The `config` and `state` keys alias to the [`tfconfig`][import-tfconfig] and
+[`tfstate`][import-tfstate] namespaces, respectively, with the data sourced from
+the Terraform _plan_ (as opposed to actual configuration and state).
+
+[import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
+[import-tfstate]: /docs/enterprise/sentinel/import/tfstate.html
+
+-> Note that these aliases are not represented as maps. While they will appear
+empty when viewed as maps, the specific import namespace keys will still be
+accessible.
+
+-> Note that while current versions of Terraform Enterprise (TFE) source _all_
+data (including configuration and state) from the plan for the Terraform run in
+question, future versions of TFE may source data accessed through the `tfconfig`
+and `tfstate` imports (as opposed to `tfplan.config` and `tfplan.state`) from
+actual config bundles, or state as stored by TFE. When this happens, the
+distinction here will be useful - the data in the aliased namespaces will be the
+config and state data as the _plan_ sees it, versus the actual "physical" data.
 
 ### Function: `module()`
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -477,9 +477,8 @@ main = rule { tfplan.resources.null_resource.bar[0].diff["triggers.%"].computed 
 The `new` value within the [diff namespace](#namespace-resource-diff) contains
 the new value of a changing attribute, _if_ the value is known at plan time.
 
-If the value is currently unknown, this field will be blank. Use the
-[`computed`](#value-computed) value to determine if the value contained here is
-actually a known zero value or not.
+-> `new` will be an empty string if the attribute's value is currently unknown.
+For more details on detecting unknown values, see [`computed`](#value-computed).
 
 Note that this value is _always_ a string, regardless of the actual type of the
 value changing. [Type conversion][ref-sentinel-type-conversion] within policy

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -344,8 +344,8 @@ based on type and name.
 
 -> The (somewhat strange) notation here of `TYPE.NAME[NUMBER]` may imply that
 the inner resource index map is actually a list, but it's not - using the square
-bracket notation over the dotted notation (as instead of `TYPE.NAME.NUMBER`) is
-actually required here as an identifier cannot start with number.
+bracket notation over the dotted notation (`TYPE.NAME.NUMBER`) is required here
+as an identifier cannot start with number.
 
 Some examples of multi-level access are below:
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -297,9 +297,9 @@ documented below:
 
 ### Root Namespace Aliases
 
-The root-level `data`, and `resources` keys both alias to their corresponding
-namespaces within the module namespace, loaded for the root module. They are
-essentially the equivalent of running `module([]).KEY`.
+The root-level `data` and `resources` keys both alias to their corresponding
+namespaces within the module namespace, loaded for the root module. They are the
+equivalent of running `module([]).KEY`.
 
 ### Value: `path`
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -233,10 +233,8 @@ main = rule { tfplan.terraform_version matches "^0\\.11\\.\\d+$" }
 * **Value Type:** A string-keyed map of values.
 
 The `variables` value within the [root namespace](#namespace-root) represents
-all of the variables that were set when creating the plan.
-
-As only root module variables when creating a plan, `variables` will only
-contain variables configured within the root module. 
+all of the variables that were set when creating the plan. This will only
+contain variables set for the root module.
 
 Note that unlike the [`default`][import-tfconfig-variables-default] value in the
 [`tfconfig` variables namespace][import-tfconfig-variables], primitive values

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -29,6 +29,11 @@ will not be visible in this state.
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
+-> Note that the root-level alias keys shown here (`data`, `modules`,
+`providers`, `resources`, and `variables`) are shortcuts to the [module
+namespace](#namespace-module). For more details, see the section on [root
+namespace aliases](#root-namespace-aliases).
+
 ```
 tfplan
 ├── module() (function)

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -496,7 +496,7 @@ resource "null_resource" "foo" {
 }
 ```
 
-The following policy would evaluate to `true`, if the resource was in the diff,
+The following policy would evaluate to `true`, if the resource was in the diff
 and each of the concerned keys were changing to new values:
 
 ```python

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -15,8 +15,7 @@ infrastructure to reach the desired state represented by the configuration.
 
 In addition to the diff data available in the plan, there is an
 [`applied`](#value-applied) state available that merges the plan with the state
-to create the planned state after apply. Note that any computed values will not
-be visible in this state.
+to create the planned state after apply.
 
 Finally, this import also allows you to access the configuration files and the
 Terraform state at the time the plan was run. See the section on [accessing a
@@ -380,9 +379,11 @@ pending resource's diff on top of the existing data from the resource's state
 The map is a complex representation of these values with data going as far down
 as needed to represent any state values such as maps, lists, and sets.
 
-Note that currently, computed values are represented by the placeholder value
-`74D93920-ED26-11E3-AC10-0800200C9A66`. This is not a stable API and should not
-be relied on. Instead, use the [`computed`](#value-computed) key within the [diff
+Note that some values will not be available in the `applied` state because they
+cannot be known until the plan is actually applied. These values are represented
+by a placeholder (the UUID value `74D93920-ED26-11E3-AC10-0800200C9A66`). This
+is not a stable API and should not be relied on. Instead, use the
+[`computed`](#value-computed) key within the [diff
 namespace](#namespace-resource-diff) to determine if a value is known or not.
 
 As an example, given the following resource:

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -395,7 +395,7 @@ resource "null_resource" "foo" {
 }
 ```
 
-The following policy would evaluate to `true`, if the resource was in the diff:
+The following policy would evaluate to `true` if the resource was in the diff:
 
 ```python
 import "tfplan"

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -460,9 +460,9 @@ resource "null_resource" "bar" {
 }
 ```
 
-The following policy would evaluate to `true`, if the resource was in the diff,
-the value of the tag was changing, and the `id` of `null_resource.foo` was
-currently not known (example: the resource has not been created yet):
+The following policy would evaluate to `true`, if the `id` of
+`null_resource.foo` was currently not known, such as when the resource is
+pending creation, or is being deleted and re-created:
 
 ```python
 import "tfplan"

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -422,7 +422,7 @@ usage examples.
 ## Namespace: Resource Diff
 
 The **diff namespace** is a namespace that represents the diff for a specific
-attribute within a resource. For particulars on reading a particular attribute,
+attribute within a resource. For details on reading a particular attribute,
 see the [`diff`](#diff) value in the [resource
 namespace](#namespace-resources-data-sources).
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -55,6 +55,7 @@ tfplan
 ├── variables (map of keys)
 │
 ├── data (root module alias)
+├── path (root module alias)
 ├── resources (root module alias)
 │
 ├── config (tfconfig namespace alias)
@@ -65,8 +66,9 @@ tfplan
 
 The root-level namespace consists of the values and functions documented below.
 
-In addition to this, the root-level `data`, and `resources` keys alias to their
-corresponding namespaces within the [module namespace](#namespace-module).
+In addition to this, the root-level `data`, `path`, and `resources` keys alias
+to their corresponding namespaces or values within the [module
+namespace](#namespace-module).
 
 Further, the `config` and `state` keys alias to the
 [`tfconfig`][import-tfconfig] and [`tfstate`][import-tfstate] namespaces,

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -522,6 +522,9 @@ Note that this value is _always_ a string, regardless of the actual type of the
 value changing. [Type conversion][ref-sentinel-type-conversion] within policy
 may be necessary to achieve the comparison needed.
 
+If the value did not exist in the previous state, `old` will always be an empty
+string.
+
 As an example, given the following resource:
 
 ```hcl

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -482,8 +482,10 @@ If the value is currently unknown, this field will be blank. Use the
 actually a known zero value or not.
 
 Note that this value is _always_ a string, regardless of the actual type of the
-value changing. Type conversion within policy may be necessary to achieve the
-comparison needed.
+value changing. [Type conversion][ref-sentinel-type-conversion] within policy
+may be necessary to achieve the comparison needed.
+
+[ref-sentinel-type-conversion]: https://docs.hashicorp.com/sentinel/language/values#type-conversion
 
 As an example, given the following resource:
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -257,7 +257,8 @@ main = rule { default_foo and default_number and default_map_string and default_
 The **module namespace** can be loaded by calling
 [`module()`](#function-module-) for a particular module.
 
-It's a namespace that can be used to load the following data:
+It's a namespace that can be used to load the following child namespaces, in
+addition to the values documented below:
 
 * `data` - Loads the [resource namespace](#namespace-resources-data-sources),
   filtered against data sources.
@@ -339,7 +340,7 @@ mentioned, when operating on data sources, use the same syntax, except with
 
 * **Value Type:** A string-keyed map of values.
 
-The `path` value within the [resource
+The `applied` value within the [resource
 namespace](#namespace-resources-data-sources) contains a "predicted"
 representation of the resource's state post-apply. It's created using the
 existing data from the resource's state (if any), and merging the pending
@@ -350,7 +351,7 @@ as needed to represent any state values such as maps, lists, and sets.
 
 Note that currently, computed values are represented by the placeholder value
 `74D93920-ED26-11E3-AC10-0800200C9A66`. This is not a stable API and should not
-be relied on. Instead, use the [`computed`](#) key within the [diff
+be relied on. Instead, use the [`computed`](#value-computed) key within the [diff
 namespace](#namespace-resource-diff) to determine if a value is known or not.
 
 As an example, given the following resource:

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -318,8 +318,8 @@ module "foo" {
 }
 ```
 
-The following policy would evaluate to `true`, _only_ if the diff had changes
-for that module:
+The following policy would evaluate to `true` _only_ if the diff had changes for
+that module:
 
 ```python
 import "tfplan"

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -299,12 +299,12 @@ main = rule { tfplan.module(["foo"]).path contains "foo" }
 
 ## Namespace: Resources/Data Sources
 
-The **resource namespace** is a namespace shared between resources and data
-sources, and is identical in structure and behavior regardless of which
-classification you are loading.
+The **resource namespace** is a namespace _type_ that applies to both resources
+(accessed by using the `resources` namespace key) and data sources (accessed
+using the `data` namespace key).
 
-Accessing an individual resource or data source within this namespace can be
-accomplished by specifying the type, name, and resource number (as if the
+Accessing an individual resource or data source within each individual namespace
+can be accomplished by specifying the type, name, and resource number (as if the
 resource or data source had a `count` value in it) in the syntax
 `[resources|data].TYPE.NAME[NUMBER]`. Note that NUMBER is always needed, even if
 you did not use `count` in the resource.

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -373,9 +373,9 @@ mentioned, when operating on data sources, use the same syntax, except with
 
 The `applied` value within the [resource
 namespace](#namespace-resources-data-sources) contains a "predicted"
-representation of the resource's state post-apply. It's created using the
-existing data from the resource's state (if any), and merging the pending
-resource's diff on top of it.
+representation of the resource's state post-apply. It's created by merging the
+pending resource's diff on top of the existing data from the resource's state
+(if any).
 
 The map is a complex representation of these values with data going as far down
 as needed to represent any state values such as maps, lists, and sets.

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -269,7 +269,7 @@ variable "map" {
 ```
 
 The following policy would evaluate to `true`, if no values were entered to
-change them:
+change these variables:
 
 ```python
 import "tfplan"

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -358,9 +358,10 @@ Some examples of multi-level access are below:
   `tfplan.resources.aws_instance`. This would be indexed off of the names of
   each resource (`foo`, `bar`, and so on), with each of those maps containing
   instances indexed by resource count index as per above.
-* To fetch all resources indiscriminately within the root module,
-  `tfplan.resources` will do. This is then indexed by resource type
-  (`aws_instance`, for example), with the other maps cascading down from there.
+* To fetch all resources within the root module, irrespective of type, use
+  `tfplan.resources`. This is indexed by type, as shown above with
+  `tfplan.resources.aws_instance`, with names being the next level down, and so
+  on.
 
 Further explanation of the namespace will be in the context of resources. As
 mentioned, when operating on data sources, use the same syntax, except with

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -333,7 +333,7 @@ The **resource namespace** is a namespace _type_ that applies to both resources
 (accessed by using the `resources` namespace key) and data sources (accessed
 using the `data` namespace key).
 
-Accessing an individual resource or data source within each individual namespace
+Accessing an individual resource or data source within each respective namespace
 can be accomplished by specifying the type, name, and resource number (as if the
 resource or data source had a `count` value in it) in the syntax
 `[resources|data].TYPE.NAME[NUMBER]`. Note that NUMBER is always needed, even if

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -441,8 +441,8 @@ lists, and sets, it's sometimes necessary to test the count attribute for the
 structure, versus a key within it, depending on whether or not the diff has
 marked the whole structure as computed. This is demonstrated in the example
 below.  Count keys are `%` for maps, and `#` for lists and sets. If you are
-having trouble determining the actual type of specific field within a resource,
-contact the support team.
+having trouble determining the type of specific field within a resource, contact
+the support team.
 
 As an example, given the following resource:
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -112,6 +112,11 @@ Hence, a module with an address of simply `foo` (or `root.foo`) would be
 `["foo"]`, and a module within that (so address `foo.bar`) would be read as
 `["foo", "bar"]`.
 
+[`null`][ref-null] is returned if a module address is invalid, or if the module
+is not present in the plan.
+
+[ref-null]: https://docs.hashicorp.com/sentinel/language/spec#null
+
 As an example, given the following module block:
 
 ```hcl
@@ -144,10 +149,10 @@ main = rule { tfplan.module(["foo"]).resources.null_resource.foo[0].applied.trig
 * **Value Type:** List of a list of strings.
 
 The `module_paths` value within the [root namespace](#namespace-root) is a list
-of all of the modules within the Terraform _diff_ for the current plan.
+of all of the modules within the Terraform diff for the current plan.
 
-Note the distinction here - this means if there are no changes for any resources
-within the module of concern, the module will not show up in `module_paths`.
+Modules not present in the diff will not be present here, even if they are
+present in the configuration or state.
 
 This data is represented as a list of a list of strings, with the inner list
 being the module address, split on the period (`.`).

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -416,7 +416,8 @@ Note that unlike the [`applied`](#value-applied) value, this map is not complex;
 the map is only 1 level deep with each key possibly representing a diff for a
 particular complex value within the resource.
 
-See the diff namespace for specific examples.
+See the below section for more details on the diff namespace, in addition to
+usage examples.
 
 ## Namespace: Resource Diff
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -28,10 +28,10 @@ data](#accessing-a-plan-39-s-state-and-configuration-data) for more information.
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
--> Note that the root-level alias keys shown here (`data`, `modules`,
-`providers`, `resources`, and `variables`) are shortcuts to the [module
-namespace](#namespace-module). For more details, see the section on [root
-namespace aliases](#root-namespace-aliases).
+-> Note that the root-level alias keys shown here (`data`, `path`, and
+`resources`) are shortcuts to the [module namespace](#namespace-module). For
+more details, see the section on [root namespace
+aliases](#root-namespace-aliases).
 
 ```
 tfplan

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -350,10 +350,10 @@ as an identifier cannot start with number.
 Some examples of multi-level access are below:
 
 * To fetch all `aws_instance.foo` resource instances within the root module, you
-  can specify `tfplan.resources.aws_instance.foo`. This would then be indexed
-  off of the resource count index (`0`, `1`, `2`, and so on). Note that as
-  mentioned above, these elements must be accessed using square-bracket map
-  notation (so `["0"]`, `["1"]`, `["2"]`, and so on) instead of dotted notation.
+  can specify `tfplan.resources.aws_instance.foo`. This would then be indexed by
+  resource count index (`0`, `1`, `2`, and so on). Note that as mentioned above,
+  these elements must be accessed using square-bracket map notation (so `[0]`,
+  `[1]`, `[2]`, and so on) instead of dotted notation.
 * To fetch all `aws_instance` resources within the root module, you can specify
   `tfplan.resources.aws_instance`. This would be indexed off of the names of
   each resource (`foo`, `bar`, and so on), with each of those maps containing

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -29,8 +29,8 @@ The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
 -> Note that the root-level alias keys shown here (`data`, `path`, and
-`resources`) are shortcuts to the [module namespace](#namespace-module). For
-more details, see the section on [root namespace
+`resources`) are shortcuts to a [module namespace](#namespace-module) scoped to
+the root module. For more details, see the section on [root namespace
 aliases](#root-namespace-aliases).
 
 ```

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -166,7 +166,7 @@ the function returning undefined.
 Remember again that this will only locate modules (and hence resources) that
 have pending changes.
 
-```
+```python
 import "tfplan"
 
 get_vms = func() {

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -39,9 +39,9 @@ The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
 -> Note that the root-level alias keys shown here (`data`, `modules`,
-`providers`, `resources`, and `variables`) are shortcuts to the [module
-namespace](#namespace-module). For more details, see the section on [root
-namespace aliases](#root-namespace-aliases).
+`providers`, `resources`, and `variables`) are shortcuts to a [module
+namespace](#namespace-module) scoped to the root module. For more details, see
+the section on [root namespace aliases](#root-namespace-aliases).
 
 ```
 tfstate

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -222,8 +222,8 @@ main = rule { tfstate.terraform_version matches "^0\\.11\\.\\d+$" }
 The **module namespace** can be loaded by calling
 [`module()`](#function-module-) for a particular module.
 
-It's a namespace that can be used to load the following child namespaces, in
-addition to the values documented below:
+It can be used to load the following child namespaces, in addition to the values
+documented below:
 
 * `data` - Loads the [resource namespace](#namespace-resources-data-sources),
   filtered against data sources.

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -38,6 +38,11 @@ import.
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
+-> Note that the root-level alias keys shown here (`data`, `modules`,
+`providers`, `resources`, and `variables`) are shortcuts to the [module
+namespace](#namespace-module). For more details, see the section on [root
+namespace aliases](#root-namespace-aliases).
+
 ```
 tfstate
 ├── module() (function)

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -497,15 +497,10 @@ main = rule { type_string and type_list and type_map }
 The `value` value within the [output namespace](#namespace-outputs) is the value
 of the output in question.
 
-Note that unlike the [`default`][import-tfconfig-variables-default] value in the
-[`tfconfig` variables namespace][import-tfconfig-variables], primitive values
-here are stringified, and type conversion will need to be performed to perform
-comparison for int, float, or boolean values. This only applies to values
-that are primitives themselves and not primitives within maps and lists, which
-will be their original types.
-
-[import-tfconfig-variables-default]: /docs/enterprise/sentinel/import/tfconfig.html#value-default
-[import-tfconfig-variables]: /docs/enterprise/sentinel/import/tfconfig.html#namespace-variables
+Note that the only valid primitive output type in Terraform is currently a
+string, which means that any int, float, or boolean value will need to be
+converted before it can be used in comparison. This does not apply to primitives
+within maps and lists, which will be their original types.
 
 As an example, given the following output blocks:
 
@@ -515,7 +510,7 @@ output "foo" {
 }
 
 output "number" {
-  value = 42
+  value = "42"
 }
 
 output "map" {
@@ -531,10 +526,10 @@ The following policy would evaluate to `true`:
 ```python
 import "tfstate"
 
-value_foo = rule { tfstate.outputs.foo is "bar" }
-value_number = rule { tfstate.outputs.number is "42" }
-value_map_string = rule { tfstate.outputs.map["foo"] is "bar" }
-value_map_int = rule { tfstate.outputs.map["number"] is 42 }
+value_foo = rule { tfstate.outputs.foo.value is "bar" }
+value_number = rule { int(tfstate.outputs.number.value) is 42 }
+value_map_string = rule { tfstate.outputs.map.value["foo"] is "bar" }
+value_map_int = rule { tfstate.outputs.map.value["number"] is 42 }
 
 main = rule { value_foo and value_number and value_map_string and value_map_int }
 ```

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -477,7 +477,7 @@ main = rule { tfstate.outputs.foo.sensitive }
 * **Value Type:** String.
 
 The `type` value within the [output namespace](#namespace-outputs) gives the
-output's type. This will be one of either `string`, `list`, or `map`, which are
+output's type. This will be one of `string`, `list`, or `map`. These are
 currently the only types available for outputs in Terraform.
 
 As an example, given the following output:

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -317,7 +317,7 @@ mentioned, when operating on data sources, use the same syntax, except with
 
 * **Value Type:** A string-keyed map of values.
 
-The `applied` value within the [resource
+The `attr` value within the [resource
 namespace](#namespace-resources-data-sources) is a direct mapping to the state
 of the resource. 
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -8,29 +8,25 @@ description: |-
 
 # Import: tfstate
 
-The tfstate import provides access to the Terraform state.
+The `tfstate` import provides access to the Terraform state.
 
-Depending on the state of a Terraform workspace, the data in this import may be
-incomplete (such as when a resource has not been created yet).
+The _state_ is the data that Terraform has recorded about a workspace at a
+particular point in its lifecycle, usually after an apply. You can read more
+general information about how Terraform uses state [here][ref-tf-state].
 
-Depending on what you are looking for, the [`tfconfig`][import-tfconfig] and
-[`tfplan`][import-tfplan] imports can assist with providing a more complete view
-of the state and configuration of the workspace as it exists currently, or in
-the future as well. `tfplan` also has aliases to both the `tfconfig` and
-`tfplan` imports to help simplify policy.
+[ref-tf-state]: /docs/state/index.html
+
+`tfstate` is also the only import that can provide introspection into the
+outputs in a Terraform workspace. For more information, see the [output
+namespace](#namespace-outputs) documentation.
+
+-> **NOTE:** Terraform Enterprise currently only supports policy checks at plan
+time, limiting the usefulness of this import. This will be resolved in future
+releases. Until that time, the [`tfconfig`][import-tfconfig] and
+[`tfplan`][import-tfplan] imports will probably prove to be more useful.
 
 [import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
 [import-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
-
--> To reiterate, this import works with the Terraform state that
-_currently exists_ at plan time, not what it will look like _after_ the plan is
-applied.  This means that resources that have not been created yet (and hence,
-can have no state) will not be present in the namespaces in this import. If you
-are looking for something state-like that also contains future data, see the
-[`applied`][import-tfplan-applied] resource namespace value in the `tfplan`
-import.
-
-[import-tfplan-applied]: /docs/enterprise/sentinel/import/tfplan.html#value-applied
 
 ## The Namespace
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -329,7 +329,7 @@ resource "null_resource" "foo" {
 }
 ```
 
-The following policy would evaluate to `true`, if the resource was in the state:
+The following policy would evaluate to `true` if the resource was in the state:
 
 ```python
 import "tfstate"

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -10,6 +10,56 @@ description: |-
 
 The tfstate import provides access to the Terraform state.
 
+This is the Terraform state as it exists at plan time. Depending on the state of
+a Terraform workspace, the data in this import may be incomplete (such as when a
+resource has not been created yet).
+
+Depending on what you are looking for, the [`tfconfig`][import-tfconfig] and
+[`tfplan`][import-tfplan] imports can assist with providing a more complete view
+of the state and configuration of the workspace as it exists currently, or in
+the future as well. `tfplan` also has aliases to both the `tfconfig` and
+`tfplan` imports to help simplify policy.
+
+[import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
+[import-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
+
+## The Namespace
+
+The following is a tree view of the import namespace. For more detail on a
+particular part of the namespace, see below.
+
+```
+tfstate
+├── module() (function)
+│   └── (module namespace)
+│       ├── path ([]string)
+│       ├── data
+│       │   └── TYPE.NAME.NUMBER
+│       │       ├── attr (map of keys)
+│       │       ├── depends_on ([]string)
+│       │       ├── id (string)
+│       │       └── tainted (boolean)
+│       ├── outputs
+│       │   └── NAME
+│       │       ├── sensitive (bool)
+│       │       ├── type (string)
+│       │       └── value (value)
+│       └── resources
+│           └── TYPE.NAME.NUMBER
+│               ├── attr (map of keys)
+│               ├── depends_on ([]string)
+│               ├── id (string)
+│               └── tainted (boolean)
+│
+├── module_paths ([][]string)
+├── terraform_version (string)
+│
+├── data (root module alias)
+├── outputs (root module alias)
+├── path (root module alias)
+└── resources (root module alias)
+```
+
 ### tfstate.module_paths
 
 All the module paths represented in the state. This can be used along

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -10,9 +10,8 @@ description: |-
 
 The tfstate import provides access to the Terraform state.
 
-This is the Terraform state as it exists at plan time. Depending on the state of
-a Terraform workspace, the data in this import may be incomplete (such as when a
-resource has not been created yet).
+Depending on the state of a Terraform workspace, the data in this import may be
+incomplete (such as when a resource has not been created yet).
 
 Depending on what you are looking for, the [`tfconfig`][import-tfconfig] and
 [`tfplan`][import-tfplan] imports can assist with providing a more complete view

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -451,7 +451,9 @@ This namespace is indexed by output name.
 * **Value Type:** Boolean.
 
 The `sensitive` value within the [output namespace](#namespace-outputs) is
-`true` when the output has been marked as sensitive.
+`true` when the output has been [marked as sensitive][ref-tf-sensitive-outputs].
+
+[ref-tf-sensitive-outputs]: /docs/configuration/outputs.html#sensitive-outputs
 
 As an example, given the following output:
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -175,11 +175,12 @@ main = rule { tfstate.module_paths contains ["foo"] }
 
 #### Iterating through modules
 
-Here is an example of a function to retrieve all resources of a particular type
-from all modules (in this case, the
-[`azurerm_virtual_machine`][ref-tf-azurerm-vm] resource). Note the use of `else
-[]` in case some modules don't have any resources; this is necessary to avoid
-the function returning undefined.
+Iterating through all modules to find particular resources can be useful. This
+example shows how to use `module_paths` with the [`module()`
+function](#function-module-) to retrieve all resources of a particular type from
+all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
+resource). Note the use of `else []` in case some modules don't have any
+resources; this is necessary to avoid the function returning undefined.
 
 [ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -212,6 +212,15 @@ import "tfstate"
 main = rule { tfstate.terraform_version matches "^0\\.11\\.\\d+$" }
 ```
 
+-> **NOTE:** This value is also available via the [`tfplan`][import-tfplan]
+import, which will be more current when a policy check is run against a plan.
+It's recommended you use the value in `tfplan` until Terraform enterprise
+supports policy checks in other stages of the workspace lifecycle. See the
+[`terraform_version`][import-tfplan-terraform-version] reference within the
+`tfplan` import for more details.
+
+[import-tfplan-terraform-version]: /docs/enterprise/sentinel/import/tfplan.html#value-terraform-version
+
 ## Namespace: Module
 
 The **module namespace** can be loaded by calling

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -23,6 +23,16 @@ the future as well. `tfplan` also has aliases to both the `tfconfig` and
 [import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
 [import-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
 
+-> To reiterate, this import works with the Terraform state that _currently
+exists_ at plan time, not what it will look like _after_ the plan is applied.
+This means that resources that have not been created yet (and hence, can have no
+state) will not be present in the namespaces in this import. If you are looking
+for something state-like but also contains future data, see the
+[`applied`][import-tfplan-applied] resource namespace value in the `tfplan`
+import.
+
+[import-tfplan-applied]: /docs/enterprise/sentinel/import/tfplan.html#value-applied
+
 ## The Namespace
 
 The following is a tree view of the import namespace. For more detail on a
@@ -60,103 +70,471 @@ tfstate
 └── resources (root module alias)
 ```
 
-### tfstate.module_paths
+## Namespace: Root
 
-All the module paths represented in the state. This can be used along
-with tfstate.module() to iterate through all modules.
+The root-level namespace consists of the values and functions documented below.
 
-### tfstate.terraform_version
+In addition to this, the root-level `data`, `outputs`, `path`, and `resources`
+keys alias to their corresponding namespaces or values within the [module
+namespace](#namespace-module).
 
-The terraform version that made this state.
+### Function: `module()`
 
-### tfstate.resources
+```
+module = func(ADDR)
+```
 
-Resources returns a map of all the resources in the root module.
-This is identical to tfstate.module([]).resources.
+* **Return Type:** A [module namespace](#namespace-module).
 
-### tfstate.data
+The `module()` function in the [root namespace](#namespace-root) returns the
+[module namespace](#namespace-module) for a particular module address.
 
-Resources returns a map of all the data sources in the root module.
-This is identical to tfstate.module([]).data.
+The address must be a list and is the module address, split on the period (`.`),
+excluding the root module.
 
-### tfstate.module(path)
+Hence, a module with an address of simply `foo` (or `root.foo`) would be
+`["foo"]`, and a module within that (so address `foo.bar`) would be read as
+`["foo", "bar"]`.
 
-The module function finds the module at the given path.
+As an example, given the following module block:
 
-## Type: m
+```hcl
+module "foo" {
+  # ...
+}
+```
 
-### m.path
+If the module contained the following content:
 
-This returns the path for this module. This is a usable argument to
-tfstate.module() if necessary.
-
-### m.resources
-
-This returns all the resources in the module as a map. The map
-key is the type, the value is the same as `m.resources.TYPE`.
-
-### m.resources.TYPE
-
-This returns all the resources in the module with the given type
-as a map from name to resource. For the documentation on the
-value, see `m.resources.TYPE.NAME`
-
-### m.resources.TYPE.NAME
-
-This returns the list of resources with the given type and name. The
-result is a list because the plan is aware that the count may be greater
-than zero.
-
-### m.data
-
-This returns all the data sources in the module as a map. The map key is the
-type, the value is the same as `m.data.TYPE`.
-
-### m.data.TYPE
-
-This returns all the data sources in the module with the given type as a map
-from name to data source. For the documentation on the value, see
-`m.data.TYPE.NAME`
-
-### m.data.TYPE.NAME
-
-This returns a list of data sources and behaves exactly how a resource lookup
-behaves with the m.resources.TYPE.NAME syntax above. All fields that are
-accessible within resources are available within a data source, except for
-`tainted`, as data sources cannot be tainted.
-
-### m.outputs.NAME
-
-Returns the output specified by NAME. This works in submodules as well.
-
-## Type: o
-
-### o.value
-
-The output value
-
-### o.sensitive
-
-True if the output is marked as sensitive
-
-### o.type
-
-The data type of this output.
-
-## Type: r
-
-### r.id
-
-Returns the ID for this resource.
-
-### r.tainted
-
-This returns true if this resource is currently tainted.
-
-### r.attr.FIELD
-
-The FIELD is a field within the resource to access. FIELD May return
-a complex type such as a map or a list depending on the data type in the
-state.
+```hcl
+resource "null_resource" "foo" {
+  triggers = {
+    foo = "bar"
+  }
+}
+```
 
 
+The following policy would evaluate to `true`, if the resource was present in
+the state:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.module(["foo"]).resources.null_resource.foo[0].attr.triggers.foo is "bar" }
+```
+
+### Value: `module_paths`
+
+* **Value Type:** List of a list of strings.
+
+The `module_paths` value within the [root namespace](#namespace-root) is a list
+of all of the modules within the Terraform state at plan-time.
+
+Note the distinction here - this means if a module is not present in state, it
+will not be present in `module_paths`.
+
+This data is represented as a list of a list of strings, with the inner list
+being the module address, split on the period (`.`).
+
+The root module is included in this list, represented as an empty inner list, as
+long as it is present in state.
+
+As an example, if the following module block was present within a Terraform
+configuration:
+
+```hcl
+module "foo" {
+  # ...
+}
+```
+
+The following policy would evaluate to `true`, _only_ if the diff had changes
+for that module:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.module_paths contains ["foo"] }
+```
+
+#### Iterating through modules
+
+Here is an example of a function to retrieve all resources of a particular type
+from all modules (in this case, the
+[`azurerm_virtual_machine`][ref-tf-azurerm-vm] resource). Note the use of `else
+[]` in case some modules don't have any resources; this is necessary to avoid
+the function returning undefined.
+
+[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
+
+Remember again that this will only locate modules (and hence resources) that are
+present in state.
+
+```
+import "tfstate"
+
+get_vms = func() {
+	vms = []
+	for tfstate.module_paths as path {
+		vms += values(tfstate.module(path).resources.azurerm_virtual_machine) else []
+	}
+	return vms
+}
+```
+
+### Value: `terraform_version`
+
+* **Value Type:** String.
+
+The `terraform_version` value within the [root namespace](#namespace-root)
+represents the version of Terraform in use when the state was saved. This can be
+used to enforce a specific version of Terraform in a policy check.
+
+As an example, the following policy would evaluate to `true`, as long as the
+state was made with a version of Terraform in the 0.11.x series, excluding any
+pre-release versions (example: `-beta1` or `-rc1`):
+
+```python
+import "tfstate"
+
+main = rule { tfstate.terraform_version matches "^0\\.11\\.\\d+$" }
+```
+
+## Namespace: Module
+
+The **module namespace** can be loaded by calling
+[`module()`](#function-module-) for a particular module.
+
+It's a namespace that can be used to load the following child namespaces, in
+addition to the values documented below:
+
+* `data` - Loads the [resource namespace](#namespace-resources-data-sources),
+  filtered against data sources.
+* `outputs` - Loads the [output namespace](#namespace-outputs), which supply the
+  outputs present in this module's state.
+* `resources` - Loads the [resource
+  namespace](#namespace-resources-data-sources), filtered against resources.
+
+### Root Namespace Aliases
+
+The root-level `data`, `outputs`, and `resources` keys both alias to their
+corresponding namespaces within the module namespace, loaded for the root
+module. They are essentially the equivalent of running `module([]).KEY`.
+
+### Value: `path`
+
+* **Value Type:** List of strings.
+
+The `path` value within the [module namespace](#namespace-module) contains the
+path of the module that the namespace represents. This is represented as a list
+of stings.
+
+As an example, if the following module block was present within a Terraform
+configuration:
+
+```hcl
+module "foo" {
+  # ...
+}
+```
+
+The following policy would evaluate to `true`, _only_ if the module was present
+in the state:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.module(["foo"]).path contains "foo" }
+```
+
+## Namespace: Resources/Data Sources
+
+The **resource namespace** is a namespace shared between resources and data
+sources, and is identical in structure and behavior regardless of which
+classification you are loading.
+
+Accessing an individual resource or data source within this namespace can be
+accomplished by specifying the type, name, and resource number (as if the
+resource or data source had a `count` value in it) in the syntax
+`[resources|data].TYPE.NAME[NUMBER]`. Note that NUMBER is always needed, even if
+you did not use `count` in the resource.
+
+In addition, each of these namespace levels is a map, allowing you to filter
+based on type and name. 
+
+-> The (somewhat strange) notation here of `TYPE.NAME[NUMBER]` may imply that
+the inner resource index map is actually a list, but it's not - using the square
+bracket notation over the dotted notation (as instead of `TYPE.NAME.NUMBER`) is
+actually required here as an identifier cannot start with number.
+
+Some examples of multi-level access are below:
+
+* To fetch all `aws_instance.foo` resource instances within the root module, you
+  can specify `tfstate.resources.aws_instance.foo`. This would then be indexed
+  off of the resource count index (`0`, `1`, `2`, and so on). Note that as
+  mentioned above, these elements must be accessed using square-bracket map
+  notation (so `["0"]`, `["1"]`, `["2"]`, and so on) instead of dotted notation.
+* To fetch all `aws_instance` resources within the root module, you can specify
+  `tfstate.resources.aws_instance`. This would be indexed off of the names of
+  each resource (`foo`, `bar`, and so on), with each of those maps containing
+  instances indexed on count index as per above.
+* To fetch all resources indiscriminately within the root module,
+  `tfstate.resources` will do. This is then indexed by resource type
+  (`aws_instance`, for example), with the other maps cascading down from there.
+
+Further explanation of the namespace will be in the context of resources. As
+mentioned, when operating on data sources, use the same syntax, except with
+`data` in place of `resources`.
+
+### Value: `attr`
+
+* **Value Type:** A string-keyed map of values.
+
+The `applied` value within the [resource
+namespace](#namespace-resources-data-sources) is a direct mapping to the state
+of the resource. 
+
+The map is a complex representation of these values with data going as far down
+as needed to represent any state values such as maps, lists, and sets.
+
+As an example, given the following resource:
+
+```hcl
+resource "null_resource" "foo" {
+  triggers = {
+    foo = "bar"
+  }
+}
+```
+
+The following policy would evaluate to `true`, if the resource was in the state:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.resources.null_resource.foo[0].attr.triggers.foo is "bar" }
+```
+
+### Value: `depends_on`
+
+* **Value Type:** A list of strings.
+
+The `depends_on` value within the [resource
+namespace](#namespace-resources-data-sources) contains the dependencies for the
+resource.
+
+This is a list of strings which will contain the resource address relative to
+the module.
+
+As an example, given the following resources:
+
+```hcl
+resource "null_resource" "foo" {
+  triggers = {
+    foo = "bar"
+  }
+}
+
+resource "null_resource" "bar" {
+  # ...
+
+  depends_on = [
+    "null_resource.foo",
+  ]
+}
+```
+
+The following policy would evaluate to `true`, if the resource was in the state:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.resources.null_resource.bar[0].depends_on contains "null_resource.foo" }
+```
+
+### Value: `id`
+
+* **Value Type:** String.
+
+The `id` value within the [resource
+namespace](#namespace-resources-data-sources) contains id of the resource.
+
+As an example, given the following data source:
+
+-> Note that we use a _data source_ here because the
+[`null_data_soruce`][ref-tf-null-data-source] data source gives a static ID,
+which makes documenting the example easier. As previously mentioned, data
+sources share the same namespace as resources, but need to be loaded with the
+`data` key. For more information, see the
+[synopsis](#namespace-resources-data-sources) for the namespace itself.
+
+[ref-tf-null-data-source]: /docs/providers/null/d/data_source.html
+
+```hcl
+data "null_data_source" "foo" {
+  # ...
+}
+```
+
+The following policy would evaluate to `true`:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.data.null_data_source.foo[0].id is "static" }
+```
+
+### Value: `tainted`
+
+* **Value Type:** Boolean.
+
+The `tainted` value within the [resource
+namespace](#namespace-resources-data-sources) is `true` if the resource is
+marked as tainted in Terraform state.
+
+As an example, given the following resource:
+
+```hcl
+resource "null_resource" "foo" {
+  triggers = {
+    foo = "bar"
+  }
+}
+```
+
+The following policy would evaluate to `true`, if the resource was marked as
+tainted in the state:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.resources.null_resource.foo[0].tainted }
+```
+
+## Namespace: Outputs
+
+The **output namespace** represents all of the outputs present within a
+[module](#namespace-module). This would be any outputs that would have been
+saved to state either as the result of a previous apply, or from the pre-plan
+refresh if their values were known at plan-time.
+
+Note that this can be used to fetch both the outputs of the root module, and the
+outputs of any module in the state below the root, allowing one to see outputs
+that have not been threaded to the root module
+
+This namespace is indexed by output name.
+
+### Value: `sensitive`
+
+* **Value Type:** Boolean.
+
+The `sensitive` value within the [output namespace](#namespace-outputs) is
+`true` when the output has been marked as sensitive.
+
+As an example, given the following output:
+
+```
+output "foo" {
+  sensitive = true
+  value     = "bar"
+}
+```
+
+The following policy would evaluate to `true`:
+
+```python
+import "tfstate"
+
+main = rule { tfstate.outputs.foo.sensitive }
+```
+
+### Value: `type`
+
+* **Value Type:** String.
+
+The `type` value within the [output namespace](#namespace-outputs) gives the
+output's type. This will be one of either `string`, `list`, or `map`, which are
+currently the only types available for outputs in Terraform.
+
+As an example, given the following output:
+
+```
+output "string" {
+  value = "foo"
+}
+
+output "list" {
+  value = [
+    "foo",
+    "bar",
+  ]
+}
+
+output "map" {
+  value = {
+    foo = "bar"
+  }
+}
+```
+
+The following policy would evaluate to `true`:
+
+```python
+import "tfstate"
+
+type_string = rule { tfstate.outputs.string.type is "string" }
+type_list = rule { tfstate.outputs.list.type is "list" }
+type_map = rule { tfstate.outputs.map.type is "map" }
+
+main = rule { type_string and type_list and type_map }
+```
+
+### Value: `value`
+
+* **Value Type:** String, list, or map.
+
+The `value` value within the [output namespace](#namespace-outputs) is the value
+of the output in question.
+
+Note that unlike the [`default`][import-tfconfig-variables-default] value in the
+[`tfconfig` variables namespace][import-tfconfig-variables], primitive values
+here are stringified, and type conversion will need to be performed to perform
+comparison for int, float, or boolean values. This only applies to values
+that are primitives themselves and not primitives within maps and lists, which
+will be their original types.
+
+[import-tfconfig-variables-default]: /docs/enterprise/sentinel/import/tfconfig.html#value-default
+[import-tfconfig-variables]: /docs/enterprise/sentinel/import/tfconfig.html#namespace-variables
+
+As an example, given the following output blocks:
+
+```hcl
+output "foo" {
+  value = "bar"
+}
+
+output "number" {
+  value = 42
+}
+
+output "map" {
+  value = {
+    foo    = "bar"
+    number = 42
+  }
+}
+```
+
+The following policy would evaluate to `true`:
+
+```python
+import "tfstate"
+
+value_foo = rule { tfstate.outputs.foo is "bar" }
+value_number = rule { tfstate.outputs.number is "42" }
+value_map_string = rule { tfstate.outputs.map["foo"] is "bar" }
+value_map_int = rule { tfstate.outputs.map["number"] is 42 }
+
+main = rule { value_foo and value_number and value_map_string and value_map_int }
+```

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -281,8 +281,8 @@ based on type and name.
 
 -> The (somewhat strange) notation here of `TYPE.NAME[NUMBER]` may imply that
 the inner resource index map is actually a list, but it's not - using the square
-bracket notation over the dotted notation (as instead of `TYPE.NAME.NUMBER`) is
-actually required here as an identifier cannot start with number.
+bracket notation over the dotted notation (`TYPE.NAME.NUMBER`) is required here
+as an identifier cannot start with number.
 
 Some examples of multi-level access are below:
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -288,9 +288,9 @@ Some examples of multi-level access are below:
 
 * To fetch all `aws_instance.foo` resource instances within the root module, you
   can specify `tfstate.resources.aws_instance.foo`. This would then be indexed
-  off of the resource count index (`0`, `1`, `2`, and so on). Note that as
-  mentioned above, these elements must be accessed using square-bracket map
-  notation (so `["0"]`, `["1"]`, `["2"]`, and so on) instead of dotted notation.
+  by resource count index (`0`, `1`, `2`, and so on). Note that as mentioned
+  above, these elements must be accessed using square-bracket map notation (so
+  `[0]`, `[1]`, `[2]`, and so on) instead of dotted notation.
 * To fetch all `aws_instance` resources within the root module, you can specify
   `tfstate.resources.aws_instance`. This would be indexed off of the names of
   each resource (`foo`, `bar`, and so on), with each of those maps containing

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -295,9 +295,10 @@ Some examples of multi-level access are below:
   `tfstate.resources.aws_instance`. This would be indexed off of the names of
   each resource (`foo`, `bar`, and so on), with each of those maps containing
   instances indexed by resource count index as per above.
-* To fetch all resources indiscriminately within the root module,
-  `tfstate.resources` will do. This is then indexed by resource type
-  (`aws_instance`, for example), with the other maps cascading down from there.
+* To fetch all resources within the root module, irrespective of type, use
+  `tfstate.resources`. This is indexed by type, as shown above with
+  `tfstate.resources.aws_instance`, with names being the next level down, and so
+  on.
 
 Further explanation of the namespace will be in the context of resources. As
 mentioned, when operating on data sources, use the same syntax, except with

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -350,8 +350,8 @@ The `depends_on` value within the [resource
 namespace](#namespace-resources-data-sources) contains the dependencies for the
 resource.
 
-This is a list of strings which that contains the resource address relative to
-the module.
+This is a list of full resource addresses, relative to the module (example:
+`null_resource.foo`).
 
 As an example, given the following resources:
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -96,6 +96,11 @@ Hence, a module with an address of simply `foo` (or `root.foo`) would be
 `["foo"]`, and a module within that (so address `foo.bar`) would be read as
 `["foo", "bar"]`.
 
+[`null`][ref-null] is returned if a module address is invalid, or if the module
+is not present in the state.
+
+[ref-null]: https://docs.hashicorp.com/sentinel/language/spec#null
+
 As an example, given the following module block:
 
 ```hcl
@@ -131,8 +136,8 @@ main = rule { tfstate.module(["foo"]).resources.null_resource.foo[0].attr.trigge
 The `module_paths` value within the [root namespace](#namespace-root) is a list
 of all of the modules within the Terraform state at plan-time.
 
-Note the distinction here - this means if a module is not present in state, it
-will not be present in `module_paths`.
+Modules not present in the state will not be present here, even if they are
+present in the configuration or the diff.
 
 This data is represented as a list of a list of strings, with the inner list
 being the module address, split on the period (`.`).

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -345,7 +345,7 @@ The `depends_on` value within the [resource
 namespace](#namespace-resources-data-sources) contains the dependencies for the
 resource.
 
-This is a list of strings which will contain the resource address relative to
+This is a list of strings which that contains the resource address relative to
 the module.
 
 As an example, given the following resources:

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -154,14 +154,24 @@ module "foo" {
 }
 ```
 
-The following policy would evaluate to `true`, _only_ if the diff had changes
-for that module:
+The value of `module_paths` would be:
+
+```
+[
+	[],
+	["foo"],
+]
+```
+
+And the following policy would evaluate to `true`:
 
 ```python
 import "tfstate"
 
 main = rule { tfstate.module_paths contains ["foo"] }
 ```
+
+-> Note the above example only applies if the module is present in the state.
 
 #### Iterating through modules
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -244,7 +244,7 @@ module. They are the equivalent of running `module([]).KEY`.
 
 The `path` value within the [module namespace](#namespace-module) contains the
 path of the module that the namespace represents. This is represented as a list
-of stings.
+of strings.
 
 As an example, if the following module block was present within a Terraform
 configuration:

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -436,9 +436,9 @@ main = rule { tfstate.resources.null_resource.foo[0].tainted }
 ## Namespace: Outputs
 
 The **output namespace** represents all of the outputs present within a
-[module](#namespace-module). This would be any outputs that would have been
-saved to state either as the result of a previous apply, or from the pre-plan
-refresh if their values were known at plan-time.
+[module](#namespace-module). Outputs are present in a state if they were saved
+during a previous apply, or if they were updated with known values during the
+pre-plan refresh.
 
 Note that this can be used to fetch both the outputs of the root module, and the
 outputs of any module in the state below the root, allowing one to see outputs

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -387,7 +387,7 @@ The `id` value within the [resource
 namespace](#namespace-resources-data-sources) contains the id of the resource.
 
 -> **NOTE:** The example below uses a _data source_ here because the
-[`null_data_soruce`][ref-tf-null-data-source] data source gives a static ID,
+[`null_data_source`][ref-tf-null-data-source] data source gives a static ID,
 which makes documenting the example easier. As previously mentioned, data
 sources share the same namespace as resources, but need to be loaded with the
 `data` key. For more information, see the

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -236,7 +236,7 @@ documented below:
 
 The root-level `data`, `outputs`, and `resources` keys both alias to their
 corresponding namespaces within the module namespace, loaded for the root
-module. They are essentially the equivalent of running `module([]).KEY`.
+module. They are the equivalent of running `module([]).KEY`.
 
 ### Value: `path`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -22,11 +22,11 @@ the future as well. `tfplan` also has aliases to both the `tfconfig` and
 [import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
 [import-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
 
--> To reiterate, this import works with the Terraform state that _currently
-exists_ at plan time, not what it will look like _after_ the plan is applied.
-This means that resources that have not been created yet (and hence, can have no
-state) will not be present in the namespaces in this import. If you are looking
-for something state-like but also contains future data, see the
+-> Note: To reiterate, this import works with the Terraform state that
+_currently exists_ at plan time, not what it will look like _after_ the plan is
+applied.  This means that resources that have not been created yet (and hence,
+can have no state) will not be present in the namespaces in this import. If you
+are looking for something state-like that also contains future data, see the
 [`applied`][import-tfplan-applied] resource namespace value in the `tfplan`
 import.
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -115,7 +115,7 @@ resource "null_resource" "foo" {
 ```
 
 
-The following policy would evaluate to `true`, if the resource was present in
+The following policy would evaluate to `true` if the resource was present in
 the state:
 
 ```python

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -366,7 +366,7 @@ resource "null_resource" "bar" {
 }
 ```
 
-The following policy would evaluate to `true`, if the resource was in the state:
+The following policy would evaluate to `true` if the resource was in the state:
 
 ```python
 import "tfstate"

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -38,10 +38,10 @@ import.
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
 
--> Note that the root-level alias keys shown here (`data`, `modules`,
-`providers`, `resources`, and `variables`) are shortcuts to a [module
-namespace](#namespace-module) scoped to the root module. For more details, see
-the section on [root namespace aliases](#root-namespace-aliases).
+-> Note that the root-level alias keys shown here (`data`, `outputs`, `path`,
+and `resources`) are shortcuts to a [module namespace](#namespace-module) scoped
+to the root module. For more details, see the section on [root namespace
+aliases](#root-namespace-aliases).
 
 ```
 tfstate

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -22,7 +22,7 @@ the future as well. `tfplan` also has aliases to both the `tfconfig` and
 [import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
 [import-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
 
--> Note: To reiterate, this import works with the Terraform state that
+-> To reiterate, this import works with the Terraform state that
 _currently exists_ at plan time, not what it will look like _after_ the plan is
 applied.  This means that resources that have not been created yet (and hence,
 can have no state) will not be present in the namespaces in this import. If you

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -381,9 +381,7 @@ main = rule { tfstate.resources.null_resource.bar[0].depends_on contains "null_r
 The `id` value within the [resource
 namespace](#namespace-resources-data-sources) contains id of the resource.
 
-As an example, given the following data source:
-
--> Note that we use a _data source_ here because the
+-> **NOTE:** The example below uses a _data source_ here because the
 [`null_data_soruce`][ref-tf-null-data-source] data source gives a static ID,
 which makes documenting the example easier. As previously mentioned, data
 sources share the same namespace as resources, but need to be loaded with the
@@ -391,6 +389,8 @@ sources share the same namespace as resources, but need to be loaded with the
 [synopsis](#namespace-resources-data-sources) for the namespace itself.
 
 [ref-tf-null-data-source]: /docs/providers/null/d/data_source.html
+
+As an example, given the following data source:
 
 ```hcl
 data "null_data_source" "foo" {

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -384,7 +384,7 @@ main = rule { tfstate.resources.null_resource.bar[0].depends_on contains "null_r
 * **Value Type:** String.
 
 The `id` value within the [resource
-namespace](#namespace-resources-data-sources) contains id of the resource.
+namespace](#namespace-resources-data-sources) contains the id of the resource.
 
 -> **NOTE:** The example below uses a _data source_ here because the
 [`null_data_soruce`][ref-tf-null-data-source] data source gives a static ID,

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -250,12 +250,12 @@ main = rule { tfstate.module(["foo"]).path contains "foo" }
 
 ## Namespace: Resources/Data Sources
 
-The **resource namespace** is a namespace shared between resources and data
-sources, and is identical in structure and behavior regardless of which
-classification you are loading.
+The **resource namespace** is a namespace _type_ that applies to both resources
+(accessed by using the `resources` namespace key) and data sources (accessed
+using the `data` namespace key).
 
-Accessing an individual resource or data source within this namespace can be
-accomplished by specifying the type, name, and resource number (as if the
+Accessing an individual resource or data source within each individual namespace
+can be accomplished by specifying the type, name, and resource number (as if the
 resource or data source had a `count` value in it) in the syntax
 `[resources|data].TYPE.NAME[NUMBER]`. Note that NUMBER is always needed, even if
 you did not use `count` in the resource.

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -274,7 +274,7 @@ The **resource namespace** is a namespace _type_ that applies to both resources
 (accessed by using the `resources` namespace key) and data sources (accessed
 using the `data` namespace key).
 
-Accessing an individual resource or data source within each individual namespace
+Accessing an individual resource or data source within each respective namespace
 can be accomplished by specifying the type, name, and resource number (as if the
 resource or data source had a `count` value in it) in the syntax
 `[resources|data].TYPE.NAME[NUMBER]`. Note that NUMBER is always needed, even if

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -294,7 +294,7 @@ Some examples of multi-level access are below:
 * To fetch all `aws_instance` resources within the root module, you can specify
   `tfstate.resources.aws_instance`. This would be indexed off of the names of
   each resource (`foo`, `bar`, and so on), with each of those maps containing
-  instances indexed on count index as per above.
+  instances indexed by resource count index as per above.
 * To fetch all resources indiscriminately within the root module,
   `tfstate.resources` will do. This is then indexed by resource type
   (`aws_instance`, for example), with the other maps cascading down from there.

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -171,7 +171,7 @@ the function returning undefined.
 Remember again that this will only locate modules (and hence resources) that are
 present in state.
 
-```
+```python
 import "tfstate"
 
 get_vms = func() {
@@ -434,7 +434,7 @@ The `sensitive` value within the [output namespace](#namespace-outputs) is
 
 As an example, given the following output:
 
-```
+```hcl
 output "foo" {
   sensitive = true
   value     = "bar"
@@ -459,7 +459,7 @@ currently the only types available for outputs in Terraform.
 
 As an example, given the following output:
 
-```
+```hcl
 output "string" {
   value = "foo"
 }

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -441,8 +441,8 @@ during a previous apply, or if they were updated with known values during the
 pre-plan refresh.
 
 Note that this can be used to fetch both the outputs of the root module, and the
-outputs of any module in the state below the root, allowing one to see outputs
-that have not been threaded to the root module
+outputs of any module in the state below the root. This makes it possible to see
+outputs that have not been threaded to the root module.
 
 This namespace is indexed by output name.
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -202,7 +202,7 @@ The `terraform_version` value within the [root namespace](#namespace-root)
 represents the version of Terraform in use when the state was saved. This can be
 used to enforce a specific version of Terraform in a policy check.
 
-As an example, the following policy would evaluate to `true`, as long as the
+As an example, the following policy would evaluate to `true` as long as the
 state was made with a version of Terraform in the 0.11.x series, excluding any
 pre-release versions (example: `-beta1` or `-rc1`):
 


### PR DESCRIPTION
This vastly improves the documentation for all three Terraform Sentinel imports: `tfconfig`, `tfplan`, and `tfstate`.

Some specific features of the rewrite include:

- Much more verbose explaniations for every part of the namespace.
- A map of each import's namespace after the synopsis.
- Examples for every value and function in the import namespace.

There will be other things to follow (namely mocks), but this is complete enough to be merged in now, the mocks can be merged in later.
 