### PR TITLE
docs/sentinel: Add mocks

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
@@ -1,0 +1,128 @@
+---
+layout: enterprise2
+page_title: "Sentinel - Terraform Enterprise"
+sidebar_current: "docs-enterprise2-sentinel-imports-tfconfig-mock"
+description: |-
+    This page provides a mock for the tfconfig Sentinel import.
+---
+
+# Mocking tfconfig Data
+
+Below is a sample of what a mock for the [`tfconfig`][ref-tfconfig] import
+would look like. You can use this data with the mocking or testing features of
+the [Sentinel Simulator][ref-sentinel-simulator] to create test data for rules.
+
+[ref-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
+[ref-sentinel-simulator]: https://docs.hashicorp.com/sentinel/commands/
+
+For more details on how to work with mock data in Sentinel, see the section on
+[Mocking Imports][ref-mocking-imports] in the [official Sentinel
+documentation][ref-official-sentinel-documentation].
+
+[ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
+[ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
+
+```json
+{
+  "mock": {
+    "tfconfig": {
+      "module_paths": [
+        [],
+        [
+          "foo"
+        ]
+      ],
+      "data": {
+        "null_data_source": {
+          "baz": {
+            "config": {
+              "inputs": [
+                {
+                  "bar_id": "${null_resource.bar.id}",
+                  "foo_id": "${null_resource.foo.id}"
+                }
+              ]
+            },
+            "provisioners": []
+          }
+        }
+      },
+      "modules": {
+        "foo": {
+          "config": {
+            "bar": "baz"
+          },
+          "source": "./foo"
+        }
+      },
+      "providers": {
+        "aws": {
+          "config": {},
+          "version": "~\u003e 1.34",
+          "alias": {
+            "east": {
+              "config": {
+                "region": "us-east-1"
+              },
+              "version": ""
+            }
+          }
+        },
+        "null": {
+          "config": {},
+          "version": "",
+          "alias": {}
+        }
+      },
+      "resources": {
+        "null_resource": {
+          "bar": {
+            "config": {
+              "triggers": [
+                {
+                  "foo_id": "${null_resource.foo.id}"
+                }
+              ]
+            },
+            "provisioners": []
+          },
+          "foo": {
+            "config": {
+              "triggers": [
+                {
+                  "foo": "bar"
+                }
+              ]
+            },
+            "provisioners": [
+              {
+                "config": {
+                  "command": "echo hello"
+                },
+                "type": "local-exec"
+              }
+            ]
+          }
+        }
+      },
+      "variables": {
+        "foo": {
+          "default": "bar",
+          "description": "foobar"
+        },
+        "map": {
+          "default": {
+            "foo": "bar",
+            "number": 42
+          },
+          "description": ""
+        },
+        "number": {
+          "default": "42",
+          "description": ""
+        }
+      }
+    }
+  }
+}
+```

--- a/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
@@ -1,0 +1,148 @@
+---
+layout: enterprise2
+page_title: "Sentinel - Terraform Enterprise"
+sidebar_current: "docs-enterprise2-sentinel-imports-tfplan-mock"
+description: |-
+    This page provides a mock for the tfplan Sentinel import.
+---
+
+# Mocking tfplan Data
+
+Below is a sample of what a mock for the [`tfplan`][ref-tfplan] import would
+look like. You can use this data with the mocking or testing features of the
+[Sentinel Simulator][ref-sentinel-simulator] to create test data for rules.
+
+[ref-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
+[ref-sentinel-simulator]: https://docs.hashicorp.com/sentinel/commands/
+
+For more details on how to work with mock data in Sentinel, see the section on
+[Mocking Imports][ref-mocking-imports] in the [official Sentinel
+documentation][ref-official-sentinel-documentation].
+
+[ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
+[ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
+
+-> **NOTE:** The top-level `config` and `state` keys are not included in this
+mock. Their layouts are identical to those found in the [`tfconfig`
+mock][ref-tfconfig-mock] and the [`tfstate` mock][ref-tfstate-mock].
+
+[ref-tfconfig-mock]: /docs/enterprise/sentinel/import/mock-tfconfig.html
+[ref-tfstate-mock]: /docs/enterprise/sentinel/import/mock-tfstate.html
+
+```json
+{
+  "mock": {
+    "tfplan": {
+      "terraform_version": "0.11.7",
+      "variables": {
+        "foo": "bar",
+        "map": {
+          "foo": "bar",
+          "number": 42
+        },
+        "number": "42"
+      },
+      "module_paths": [
+        [],
+        [
+          "foo"
+        ]
+      ],
+      "path": [],
+      "data": {
+        "null_data_source": {
+          "baz": {
+            "0": {
+              "diff": {
+                "has_computed_default": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                },
+                "id": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                },
+                "inputs.%": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                },
+                "outputs.%": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                },
+                "random": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                }
+              },
+              "applied": {
+                "has_computed_default": "74D93920-ED26-11E3-AC10-0800200C9A66",
+                "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+                "inputs": {},
+                "outputs": {},
+                "random": "74D93920-ED26-11E3-AC10-0800200C9A66"
+              }
+            }
+          }
+        }
+      },
+      "resources": {
+        "null_resource": {
+          "bar": {
+            "0": {
+              "diff": {
+                "id": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                },
+                "triggers.%": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                }
+              },
+              "applied": {
+                "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+                "triggers": {}
+              }
+            }
+          },
+          "foo": {
+            "0": {
+              "diff": {
+                "id": {
+                  "old": "",
+                  "new": "",
+                  "computed": true
+                },
+                "triggers.%": {
+                  "old": "",
+                  "new": "1",
+                  "computed": false
+                },
+                "triggers.foo": {
+                  "old": "",
+                  "new": "bar",
+                  "computed": false
+                }
+              },
+              "applied": {
+                "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+                "triggers": {
+                  "foo": "bar"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
@@ -1,0 +1,129 @@
+---
+layout: enterprise2
+page_title: "Sentinel - Terraform Enterprise"
+sidebar_current: "docs-enterprise2-sentinel-imports-tfstate-mock"
+description: |-
+    This page provides a mock for the tfstate Sentinel import.
+---
+
+# Mocking tfstate Data
+
+Below is a sample of what a mock for the [`tfstate`][ref-tfstate] import would
+look like. You can use this data with the mocking or testing features of the
+[Sentinel Simulator][ref-sentinel-simulator] to create test data for rules.
+
+[ref-tfstate]: /docs/enterprise/sentinel/import/tfstate.html
+[ref-sentinel-simulator]: https://docs.hashicorp.com/sentinel/commands/
+
+For more details on how to work with mock data in Sentinel, see the section on
+[Mocking Imports][ref-mocking-imports] in the [official Sentinel
+documentation][ref-official-sentinel-documentation].
+
+[ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
+[ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
+
+```json
+{
+  "mock": {
+    "tfstate": {
+      "module_paths": [
+        [],
+        [
+          "foo"
+        ]
+      ],
+      "terraform_version": "0.11.7",
+      "data": {
+        "null_data_source": {
+          "baz": {
+            "0": {
+              "depends_on": [
+                "null_resource.bar",
+                "null_resource.foo"
+              ],
+              "id": "static",
+              "attr": {
+                "has_computed_default": "default",
+                "id": "static",
+                "inputs": {
+                  "bar_id": "5511801804920420639",
+                  "foo_id": "3332481276939020374"
+                },
+                "outputs": {
+                  "bar_id": "5511801804920420639",
+                  "foo_id": "3332481276939020374"
+                },
+                "random": "1637775805155379683"
+              },
+              "tainted": false
+            }
+          }
+        }
+      },
+      "path": [
+        "root"
+      ],
+      "outputs": {
+        "foo": {
+          "sensitive": true,
+          "type": "string",
+          "value": "bar"
+        },
+        "list": {
+          "sensitive": false,
+          "type": "list",
+          "value": [
+            "foo",
+            "bar"
+          ]
+        },
+        "map": {
+          "sensitive": false,
+          "type": "map",
+          "value": {
+            "foo": "bar",
+            "number": 42
+          }
+        },
+        "string": {
+          "sensitive": false,
+          "type": "string",
+          "value": "foo"
+        }
+      },
+      "resources": {
+        "null_resource": {
+          "bar": {
+            "0": {
+              "depends_on": [
+                "null_resource.foo"
+              ],
+              "id": "5511801804920420639",
+              "attr": {
+                "id": "5511801804920420639",
+                "triggers": {
+                  "foo_id": "3332481276939020374"
+                }
+              },
+              "tainted": false
+            }
+          },
+          "foo": {
+            "0": {
+              "depends_on": null,
+              "id": "3332481276939020374",
+              "attr": {
+                "id": "3332481276939020374",
+                "triggers": {
+                  "foo": "bar"
+                }
+              },
+              "tainted": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -32,6 +32,12 @@ particular part of the namespace, see below.
 namespace](#namespace-module) scoped to the root module. For more details, see
 the section on [root namespace aliases](#root-namespace-aliases).
 
+-> You may also be interested in how to [mock `tfconfig`
+data][ref-mock-tfconfig-data], which can help with further namespace
+visualization.
+
+[ref-mock-tfconfig-data]: /docs/enterprise/sentinel/import/mock-tfconfig.html
+
 ```
 tfconfig
 ├── module() (function)

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md.bak
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md.bak
@@ -32,12 +32,6 @@ particular part of the namespace, see below.
 the root module. For more details, see the section on [root namespace
 aliases](#root-namespace-aliases).
 
--> You may also be interested in how to [mock `tfplan`
-data][ref-mock-tfplan-data], which can help with further namespace
-visualization.
-
-[ref-mock-tfplan-data]: /docs/enterprise/sentinel/import/mock-tfplan.html
-
 ```
 tfplan
 ├── module() (function)

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -38,6 +38,12 @@ and `resources`) are shortcuts to a [module namespace](#namespace-module) scoped
 to the root module. For more details, see the section on [root namespace
 aliases](#root-namespace-aliases).
 
+-> You may also be interested in how to [mock `tfstate`
+data][ref-mock-tfstate-data], which can help with further namespace
+visualization.
+
+[ref-mock-tfstate-data]: /docs/enterprise/sentinel/import/mock-tfstate.html
+
 ```
 tfstate
 ├── module() (function)

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -185,12 +185,27 @@
             <ul class="nav">
               <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfplan") %>>
                 <a href="/docs/enterprise/sentinel/import/tfplan.html">import: tfplan</a>
+                <ul class="nav">
+                  <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfplan-mock") %>>
+                    <a href="/docs/enterprise/sentinel/import/mock-tfplan.html">Mocking tfplan Data</a>
+                  </li>
+                </ul>
               </li>
               <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfconfig") %>>
                 <a href="/docs/enterprise/sentinel/import/tfconfig.html">import: tfconfig</a>
+                <ul class="nav">
+                  <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfconfig-mock") %>>
+                    <a href="/docs/enterprise/sentinel/import/mock-tfconfig.html">Mocking tfconfig Data</a>
+                  </li>
+                </ul>
               </li>
               <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfstate") %>>
                 <a href="/docs/enterprise/sentinel/import/tfstate.html">import: tfstate</a>
+                <ul class="nav">
+                  <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfstate-mock") %>>
+                    <a href="/docs/enterprise/sentinel/import/mock-tfstate.html">Mocking tfstate Data</a>
+                  </li>
+                </ul>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
This update adds mocks for all 3 imports. They are linked in the sidebar, and also in each import via an info box in the namespace outline.

This PR is dependent on #450. The PR should probably be re-based off of master post-merge to make the commit load much less overwhelming.
