### PR TITLE
docs/sentinel: examples, add aws_ami owner enforcement

### DIFF
--- a/content/source/docs/enterprise/sentinel/examples.html.md
+++ b/content/source/docs/enterprise/sentinel/examples.html.md
@@ -12,6 +12,7 @@ and are far from exhaustive.
 
 ### Amazon Web Services
 
+* [Enforce owner allow list on `aws_ami` data source](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/enforce-ami-owners.sentinel)
 * [Enforce mandatory tags on instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/enforce-mandatory-tags.sentinel)
 * [Restrict availability zones](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/restrict-aws-availability-zones.sentinel)
 * [Disallow CIDR blocks](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/restrict-aws-cidr-blocks.sentinel)


### PR DESCRIPTION
This adds the enforce-ami-owners.sentinel aws_ami enforcement example
added in hashicorp/terraform-guides#54 to the Sentinel policy examples
list.

For some extra background on the nature of the policy and the reason for
its necessity, see the referenced PR.