### PR TITLE
docs/sentinel: tfstate, fix broken link

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -399,7 +399,7 @@ sources share the same namespace as resources, but need to be loaded with the
 `data` key. For more information, see the
 [synopsis](#namespace-resources-data-sources) for the namespace itself.
 
-[ref-tf-null-data-source]: /docs/providers/null/d/data_source.html
+[ref-tf-null-data-source]: /docs/providers/null/data_source.html
 
 As an example, given the following data source:
 


### PR DESCRIPTION
The link to `null_data_source` was broken - it does not follow the normal
convention that most other Terraform resources/data sources follow.