### PR TITLE
Separate preflight instructions from installation for improved clarity & referenceability

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -120,14 +120,14 @@ The installer can run in two modes, Online or Airgapped. Each of these modes has
 If your instance can access the Internet, use the Online install mode.
 
 1. From a shell on your instance:
-  * To execute the installer directly, run `curl https://install.terraform.io/ptfe/stable | sudo bash`
-	* To inspect the script locally before running, run `curl https://install.terraform.io/ptfe/stable > install.sh` and, once you are satisfied with the script's content, execute it with `sudo bash install.sh`.
+    * To execute the installer directly, run `curl https://install.terraform.io/ptfe/stable | sudo bash`
+    * To inspect the script locally before running, run `curl https://install.terraform.io/ptfe/stable > install.sh` and, once you are satisfied with the script's content, execute it with `sudo bash install.sh`.
 1. The installation will take a few minutes and you'll be presented with a message
-	about how and where to access the rest of the setup via the web. This will be
+    about how and where to access the rest of the setup via the web. This will be
     `https://<TFE HOSTNAME>:8800`.
-  * The installer uses an internal CA to issue bootstrap certificates, so you will
-	see a security warning when first connecting. This is expected and you'll need
-    to proceed with the connection anyway.
+    * The installer uses an internal CA to issue bootstrap certificates, so you will
+      see a security warning when first connecting. This is expected and you'll need
+      to proceed with the connection anyway.
 
 ### Run the Installer - Airgapped
 
@@ -136,8 +136,8 @@ If the instance cannot reach the Internet, follow these steps to begin an Airgap
 #### Prepare the Instance
 
 1. Download the `.airgap` file using the information given to you in your setup email and place that file somewhere on the the instance.
-  * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
-  * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
+    * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
+    * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
 1. [Download the installer bootstrapper](https://s3.amazonaws.com/replicated-airgap-work/replicated.tar.gz) and put it into its own directory on the instance (e.g. `/opt/tfe-installer/`)
 1. Airgap installations require Docker to be pre-installed. Double-check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight-installer.html#software-requirements) for details).
 
@@ -149,9 +149,9 @@ From a shell on your instance, in the directory where you placed the `replicated
 1. Run `sudo ./install.sh airgap`
 1. When asked, select the interface of the primary private network interface used to access the instance.
 1. The software will take a few minutes and you'll be presented with a message about how and where to access the rest of the setup via the web. This will be https://<TFE HOSTNAME>:8800
-  1. The installer uses an internal CA to issue bootstrap certificates, so you will
-     see a security warning when first connecting. This is expected and you'll need
-     to proceed with the connection anyway.
+    * The installer uses an internal CA to issue bootstrap certificates, so you will
+      see a security warning when first connecting. This is expected and you'll need
+      to proceed with the connection anyway.
 
 ### Continue Installation In Browser
 
@@ -159,8 +159,8 @@ From a shell on your instance, in the directory where you placed the `replicated
 1. Upload the license file provided to you in your setup email.
 1. Indicate whether you're doing an Online or Airgapped installation. Choose Online if
    you're not sure.
-	* If you are doing an Airgapped install, provide the path on the the instance
-	  to the `.airgap` file that you downloaded using the initial instructions in
+    * If you are doing an Airgapped install, provide the path on the the instance
+      to the `.airgap` file that you downloaded using the initial instructions in
       your setup email.
 1. Secure access to the installer dashboard. We recommend at least setting up the
    simple password authentication. If you're so inclined, LDAP authentication can also be

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -33,8 +33,8 @@ Before you begin, consult [Preflight](./preflight.html) for pre-requisites. You'
 If your installation requires using a proxy server, you will be asked for the proxy server information when you first
 run the installer via `ssh`. This proxy server will be used for all outbound HTTP and HTTPS connections.
 
-Optionally, if you're running the installer script in an automated manner, you can pass a `http-proxy` flag to set the address of the proxy.
-For example:
+Optionally, if you're running the installer script in an automated manner, you can pass a `http-proxy` flag to set
+the address of the proxy. For example:
 
 ```
 ./install.sh http-proxy=http://internal.mycompany.com:8080
@@ -48,7 +48,7 @@ If certain hostnames should not use the proxy and the instance should connect di
 ./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
 ````
 
-Alternately, if the only hosts you need to add are those that are not used during installation and setup, such as a private VCS instance, you can provide these hosts after installation, on the Settings page (available on port 8800 under `/settings`).
+Alternately, if the only hosts you need to add are those that are not used during installation and setup, such as a private VCS instance, you can provide these hosts after initial installation, on the Settings page (available on port 8800 under `/settings`).
 
 #### Reconfiguring the Proxy
 
@@ -59,7 +59,6 @@ To change the proxy settings after installation, use the Console settings page, 
 On the Console Settings page, there is a section for HTTP Proxy:
 
 ![PTFE HTTP Proxy Settings](./assets/ptfe-http-proxy.png)
-
 
 #### Trusting SSL/TLS Certificates
 
@@ -102,27 +101,37 @@ The UI to upload these certificates looks like:
    the certificate chain for that CA must be included here as well. This allows the instance
    to query itself.
 
+### Operational Mode Decision
+
+Terraform Enterprise can store its state in a few different ways, and you'll
+need to decide which works best for your installation. Each option has a
+different approach to
+[recovering from failures](./reliability-availability.html#recovery-from-failures-1).
+The mode should be selected based on your organization's needs. See
+[Preflight: Operational Mode Decision](./preflight#operational-mode-decision)
+for more details.
+
 ## Installation
 
 The installer can run in two modes, Online or Airgapped. Each of these modes has a different way of executing the installer, but the result is the same.
 
 ### Run the Installer - Online
 
-If your instance can access the internet, you should run the Online install mode.
+If your instance can access the Internet, use the Online install mode.
 
 1. From a shell on your instance:
   * To execute the installer directly, run `curl https://install.terraform.io/ptfe/stable | sudo bash`
 	* To inspect the script locally before running, run `curl https://install.terraform.io/ptfe/stable > install.sh` and, once you are satisfied with the script's content, execute it with `sudo bash install.sh`.
 1. The installation will take a few minutes and you'll be presented with a message
 	about how and where to access the rest of the setup via the web. This will be
-    `https://<YOUR_TFE_HOSTNAME>:8800`
+    `https://<TFE HOSTNAME>:8800`.
   * The installer uses an internal CA to issue bootstrap certificates, so you will
 	see a security warning when first connecting. This is expected and you'll need
     to proceed with the connection anyway.
 
 ### Run the Installer - Airgapped
 
-If the instance cannot reach the internet, then you can follow these steps to begin an Airgapped installation.
+If the instance cannot reach the Internet, follow these steps to begin an Airgapped installation.
 
 #### Prepare the Instance
 
@@ -130,18 +139,18 @@ If the instance cannot reach the internet, then you can follow these steps to be
   * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
   * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
 1. [Download the installer bootstrapper](https://s3.amazonaws.com/replicated-airgap-work/replicated.tar.gz) and put it into its own directory on the instance (e.g. `/opt/tfe-installer/`)
-1. Airgap installations require Docker to be pre-installed. Double check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight.html#software-requirements) above for details).
+1. Airgap installations require Docker to be pre-installed. Double-check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight.html#software-requirements) for details).
 
-#### Execute the Installer:
+#### Execute the Installer
 
 From a shell on your instance, in the directory where you placed the `replicated.tar.gz` installer bootstrapper:
 
 1. Run `tar xzf replicated.tar.gz`
 1. Run `sudo ./install.sh airgap`
 1. When asked, select the interface of the primary private network interface used to access the instance.
-1. The software will take a few minutes and you'll be presented with a message about how and where to access the rest of the setup via the web. This will be https://[<YOUR_TFE_HOSTNAME>:8800
+1. The software will take a few minutes and you'll be presented with a message about how and where to access the rest of the setup via the web. This will be https://<TFE HOSTNAME>:8800
   1. The installer uses an internal CA to issue bootstrap certificates, so you will
-     see a security warning when first connecting. This is expected and you'll need 
+     see a security warning when first connecting. This is expected and you'll need
      to proceed with the connection anyway.
 
 ### Continue Installation In Browser
@@ -153,14 +162,14 @@ From a shell on your instance, in the directory where you placed the `replicated
 	* If you are doing an Airgapped install, provide the path on the the instance
 	  to the `.airgap` file that you downloaded using the initial instructions in
       your setup email.
-1. Secure access to the Admin Console. We recommend at least setting up the
-   simple password auth. If you're so inclined, LDAP authentication can also be
-   configured for the Admin Console.
+1. Secure access to the installer dashboard. We recommend at least setting up the
+   simple password authentication. If you're so inclined, LDAP authentication can also be
+   configured.
 1. The system will now perform a set of pre-flight checks on the instance and
    the configuration up to this point and indicate any failures. You can either fix the issues
    and re-run the checks, or ignore the warnings and proceed. If the system is running behind a proxy and is unable to connect to `releases.hashicorp.com:443`, it is likely safe to proceed; this check does not currently use the proxy. For any other issues, if you proceed despite the warnings, you are assuming the support responsibility.
-1. Set an encryption password used to encrypt the sensitive information at rest. The default value is auto-generated, 
-   but we strongly suggest you create your own password. Be sure to retain the value because you will need to use this 
+1. Set an encryption password used to encrypt the sensitive information at rest. The default value is auto-generated,
+   but we strongly suggest you create your own password. Be sure to retain the value, because you will need to use this
    password to restore access to the data in the event of a reinstall.
 1. Configure the operational mode for this installation. See
    [Preflight: Operational Modes](./preflight.html#operational-mode-decision) for information on what the different values

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -24,7 +24,7 @@ use the instuctions in the [migration guide](./migrate.html).
 
 ## Preflight
 
-Before you begin, consult [Preflight](./preflight.html) for pre-requisites. You'll need to prepare data files and a Linux instance.
+Before you begin, consult [Preflight](./preflight-installer.html) for pre-requisites. You'll need to prepare data files and a Linux instance.
 
 ## Installation
 
@@ -108,7 +108,7 @@ need to decide which works best for your installation. Each option has a
 different approach to
 [recovering from failures](./reliability-availability.html#recovery-from-failures-1).
 The mode should be selected based on your organization's needs. See
-[Preflight: Operational Mode Decision](./preflight#operational-mode-decision)
+[Preflight: Operational Mode Decision](./preflight-installer.html#operational-mode-decision)
 for more details.
 
 ## Installation
@@ -172,8 +172,7 @@ From a shell on your instance, in the directory where you placed the `replicated
    but we strongly suggest you create your own password. Be sure to retain the value, because you will need to use this
    password to restore access to the data in the event of a reinstall.
 1. Configure the operational mode for this installation. See
-   [Preflight: Operational Modes](./preflight.html#operational-mode-decision) for information on what the different values
-   are. Ensure that you've met the relevant preflight requirements for the mode you chose.
+   [Preflight: Operational Modes](./preflight-installer.html#operational-mode-decision) for information on what the different values are. Ensure that you've met the relevant preflight requirements for the mode you chose.
 1. _Optional:_ Adjust the concurrent capacity of the instance. This should
    only be used if the hardware provides more resources than the baseline
    configuration and you wish to increase the work that the instance does

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -48,7 +48,7 @@ If certain hostnames should not use the proxy and the instance should connect di
 ./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
 ````
 
-Alternately, if the only hosts you need to add are those that are not used during installation and setup, such as a private VCS instance, you can provide these hosts after initial installation, on the Settings page (available on port 8800 under `/settings`).
+Passing this option to the installation script is particularly useful if the hostnames that should not use the proxy include services that the instance needs to be able to reach during installation, such as S3. Alternately, if the only hosts you need to add are those that are not used during installation, such as a private VCS instance, you can provide these hosts after initial installation is complete, in the installer settings (available on port 8800 under `/console/settings`).
 
 #### Reconfiguring the Proxy
 

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -24,72 +24,9 @@ use the instuctions in the [migration guide](./migrate.html).
 
 ## Preflight
 
-Before you begin, you'll need to prepare data files and a Linux instance.
+Before you begin, consult [Preflight](./preflight.html) for pre-requisites. You'll need to prepare data files and a Linux instance.
 
-### Data Files
-
-* TLS private key and certificate
-  * The installer allows for using a certificate signed by a public or private CA. If you do not use a trusted certificate, your VCS provider will likely reject that certificate when sending webhooks.
-* License key (provided by HashiCorp)
-
-~> **Note:** If you use a certificate issued by a private Certificate
-   Authority, you must provide the certificate for that CA in the
-   `Certificate Authority (CA) Bundle` section of the installation. This allows services
-   running within PTFE to access each other properly.
-
-### Linux Instance
-
-Install the software on a Linux instance of your choosing.
-You will start and manage this instance like any other server.
-
-The Private Terraform Enterprise Installer currently supports the following
-operating systems:
-
-* Debian 7.7+
-* Ubuntu 14.04 / 16.04 / 18.04
-* Red Hat Enterprise Linux 7.2+
-* CentOS 7+
-* Amazon Linux 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
-* Oracle Linux 7.2+
-
-#### Hardware Requirements
-
-These requirements provide the instance with enough resources to run the
-Terraform Enterprise application as well as the Terraform plans and applies.
-
- * At least 40GB of disk space on the root volume
- * At least 8GB of system memory
- * At least 2 CPU cores
-
-#### Software Requirements
-
-~> RedHat Enterprise Linux (RHEL) has a specific set of requirements. Please see the [RHEL Install Guide](./rhel-install-guide.html) before continuing.
-
-For Linux distributions other than RHEL, check Docker compatibility:
-
-  * The instance should run a supported version of Docker engine (1.7.1 or later, minimum 17.06.2-ce, maximum 17.12.1). This also requires a 64-bit distribution with a minimum Linux Kernel version of 3.10.
-    * At this time, the **18.x and higher Docker versions are not supported**
-    * In Online mode, the installer will install Docker automatically
-    * In Airgapped mode, Docker should be installed before you begin
-  * For _Redhat Enterprise_, _Oracle Linux_, and _SUSE Enterprise_, you **must** pre-install Docker as these distributions are [not officially supported by Docker Community Edition](https://docs.docker.com/engine/installation/#server).
-
-~> **Note**: It is not recommended to run Docker under a 2.x kernel.
-
-#### SELinux
-
-Private Terraform Enterprise does not support SELinux. The host running the installer must be configured in permissive mode by running: `setenforce 0`.
-
-Future releases may add native support for SELinux.
-
-#### Network Requirements
-
-1. Have the following ports available to the Linux instance:
-  * **22** - to access the instance via SSH from your computer
-  * **8800** - to access the Admin Console
-  * **443** and **80** - to access the TFE app (both ports are needed; HTTP will redirect to HTTPS)
-  * **9870-9880 (inclusive)** - for internal communication on the host and its subnet; not publicly accessible
-1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example, to do this with UFW run: `ufw allow in on docker0`. This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
-1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.
+## Installation
 
 ### Proxy Usage
 
@@ -103,8 +40,15 @@ For example:
 ./install.sh http-proxy=http://internal.mycompany.com:8080
 ```
 
-To exclude certain hosts from being accessed through the proxy (for instance, an internal VCS service), you will be
-provided a place on the Settings page available on port 8800 under `/settings` to enter in these exclusions.
+#### Proxy Exclusions (NO\_PROXY)
+
+If certain hostnames should not use the proxy and the instance should connect directly to them (for instance, for S3 or an internal VCS service), then you can pass an additional option to provide a list of domains:
+
+```
+./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
+````
+
+Alternately, you can provide these hosts after installation, on the Settings page (available on port 8800 under `/settings`).
 
 #### Reconfiguring the Proxy
 
@@ -116,13 +60,6 @@ On the Console Settings page, there is a section for HTTP Proxy:
 
 ![PTFE HTTP Proxy Settings](./assets/ptfe-http-proxy.png)
 
-#### Proxy Exclusions (NO\_PROXY)
-
-If certain hostnames should not use the proxy and the instance should connect directly to them (for instance for S3), then you can pass an additional option to provide a list of domains:
-
-```
-./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
-````
 
 #### Trusting SSL/TLS Certificates
 

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -139,7 +139,7 @@ If the instance cannot reach the Internet, follow these steps to begin an Airgap
   * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
   * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
 1. [Download the installer bootstrapper](https://s3.amazonaws.com/replicated-airgap-work/replicated.tar.gz) and put it into its own directory on the instance (e.g. `/opt/tfe-installer/`)
-1. Airgap installations require Docker to be pre-installed. Double-check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight.html#software-requirements) for details).
+1. Airgap installations require Docker to be pre-installed. Double-check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight-installer.html#software-requirements) for details).
 
 #### Execute the Installer
 

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -341,7 +341,7 @@ If the instance cannot reach the Internet, follow these steps to begin an Airgap
   * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
   * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
 1. [Download the installer bootstrapper](https://s3.amazonaws.com/replicated-airgap-work/replicated.tar.gz) and put it into its own directory on the instance (e.g. `/opt/tfe-installer/`)
-1. Airgap installations require Docker to be pre-installed. Double check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight.html#software-requirements) above for details).
+1. Airgap installations require Docker to be pre-installed. Double check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight-installer.html#software-requirements) above for details).
 
 #### Execute the Installer
 

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -65,7 +65,7 @@ If certain hostnames should not use the proxy and the instance should connect di
 ./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
 ````
 
-Passing this option to the installation script is particularly useful if the hostnames that should not use the proxy include services that the instance needs to be able to reach during installation, such as S3. Alternately, if the only hosts you need to add are those that are not used during installation, such as a private VCS instance, you can provide these hosts after initial installation is complete, in the installer settings (available on port 8800 under `/console/settings`)
+Passing this option to the installation script is particularly useful if the hostnames that should not use the proxy include services that the instance needs to be able to reach during installation, such as S3. Alternately, if the only hosts you need to add are those that are not used during installation, such as a private VCS instance, you can provide these hosts after initial installation is complete, in the installer settings (available on port 8800 under `/console/settings`).
 
 #### Reconfiguring the Proxy
 

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -381,7 +381,7 @@ From a shell on your instance, in the directory where you placed the `replicated
    **NOTE**: An instance profile must be previously configured on the instance.
 1. For the Bucket, copy and paste the value that was output by the `migrator` process for _S3 Bucket_.
 1. For the Region, copy and paste the value that was output by the `migrator` process for _S3 Region_.
-1. For the Server-side Encrytion, copy and paste the value that was output by the `migrator` process for the server-side encryption.
+1. For the Server-side Encryption, copy and paste the value that was output by the `migrator` process for the server-side encryption.
 1. For the KMS key, copy and paste the value that was output by the `migrator` process for _Optional KMS key_. **NOTE:** This key is not optional for migration, as it is used to read all the data in S3.
 1. _Optional:_ Adjust the concurrent capacity of the instance. This should
    only be used if the hardware provides more resources than the baseline

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -65,7 +65,7 @@ If certain hostnames should not use the proxy and the instance should connect di
 ./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
 ````
 
-Alternately, if the only hosts you need to add are those that are not used during installation and setup, such as a private VCS instance, you can provide these hosts after initial installation, on the Settings page (available on port 8800 under `/settings`).
+Passing this option to the installation script is particularly useful if the hostnames that should not use the proxy include services that the instance needs to be able to reach during installation, such as S3. Alternately, if the only hosts you need to add are those that are not used during installation, such as a private VCS instance, you can provide these hosts after initial installation is complete, in the installer settings (available on port 8800 under `/console/settings`)
 
 #### Reconfiguring the Proxy
 

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -43,7 +43,7 @@ modify some Terraform modules again to match the modifications you made in the p
 
 ## Preflight
 
-Before you begin, consult [Preflight](./preflight.html) for pre-requisites for the installer setup. You'll need to prepare data files and a Linux instance.
+Before you begin, consult [Preflight](./preflight-installer.html) for pre-requisites for the installer setup. You'll need to prepare data files and a Linux instance.
 
 ### Proxy Usage
 

--- a/content/source/docs/enterprise/private/migrate.html.md
+++ b/content/source/docs/enterprise/private/migrate.html.md
@@ -155,7 +155,7 @@ $ chmod a+x migrator
 
 Next, create a password that will be used to protect the migration data
 as it is passed to the installer. The password is only used for this migration process
-and is not used after the migration is complete. 
+and is not used after the migration is complete.
 
 For this example, we'll use the password `ptfemigrate`, but you must change it to
 a password of your own choosing.
@@ -311,7 +311,7 @@ $ sudo ./migrator -password ptfemigrate
 When prompted, paste the data you previously copied to your computer's clipboard.
 
 The migrator process places the Vault data in the default path for the installer to find,
-and outputs the	values you'll need later in the process for the Installer web interface.
+and outputs the values you'll need later in the process for the Installer web interface.
 
 ## Installing PTFE
 
@@ -322,14 +322,14 @@ The installer can run in two modes, Online or Airgapped. Each of these modes has
 If your instance can access the Internet, use the Online install mode.
 
 1. From a shell on your instance:
-  * To execute the installer directly, run `curl https://install.terraform.io/ptfe/stable | sudo bash`
-	* To inspect the script locally before running, run `curl https://install.terraform.io/ptfe/stable > install.sh` and, once you are satisfied with the script's content, execute it with `sudo bash install.sh`.
+    * To execute the installer directly, run `curl https://install.terraform.io/ptfe/stable | sudo bash`
+    * To inspect the script locally before running, run `curl https://install.terraform.io/ptfe/stable > install.sh` and, once you are satisfied with the script's content, execute it with `sudo bash install.sh`.
 1. The installation will take a few minutes and you'll be presented with a message
-	about how and where to access the rest of the setup via the web. This will be
-    `https://<TFE HOSTNAME>:8800`
-  * The installer uses an internal CA to issue bootstrap certificates, so you will
-	see a security warning when first connecting. This is expected and you'll need
-    to proceed with the connection anyway.
+   about how and where to access the rest of the setup via the web. This will be
+   `https://<TFE HOSTNAME>:8800`
+    * The installer uses an internal CA to issue bootstrap certificates, so you will
+      see a security warning when first connecting. This is expected and you'll need
+      to proceed with the connection anyway.
 
 ### Run the Installer - Airgapped
 
@@ -338,8 +338,8 @@ If the instance cannot reach the Internet, follow these steps to begin an Airgap
 #### Prepare the Instance
 
 1. Download the `.airgap` file using the information given to you in your setup email and place that file somewhere on the the instance.
-  * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
-  * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
+    * If you use are using `wget` to download the file, be sure to use `wget --content-disposition "<url>"` so the downloaded file gets the correct extension.
+    * The url generated for the .airgap file is only valid for a short time, so you may wish to download the file and upload it to your own artifacts repository.
 1. [Download the installer bootstrapper](https://s3.amazonaws.com/replicated-airgap-work/replicated.tar.gz) and put it into its own directory on the instance (e.g. `/opt/tfe-installer/`)
 1. Airgap installations require Docker to be pre-installed. Double check that your instance has a supported version of Docker (see [Preflight: Software Requirements](./preflight-installer.html#software-requirements) above for details).
 
@@ -351,9 +351,9 @@ From a shell on your instance, in the directory where you placed the `replicated
 1. Run `sudo ./install.sh airgap`
 1. When asked, select the interface of the primary private network interface used to access the instance.
 1. The software will take a few minutes and you'll be presented with a message about how and where to access the rest of the setup via the web. This will be https://<TFE HOSTNAME>:8800
-  1. The installer uses an internal CA to issue bootstrap certificates, so you will
-     see a security warning when first connecting. This is expected and you'll need
-     to proceed with the connection anyway.
+    * The installer uses an internal CA to issue bootstrap certificates, so you will
+      see a security warning when first connecting. This is expected and you'll need
+      to proceed with the connection anyway.
 
 ### Continue Installation In Browser
 
@@ -362,9 +362,9 @@ From a shell on your instance, in the directory where you placed the `replicated
 1. Upload your license file, provided to you in your setup email.
 1. Indicate whether you're doing an Online or Airgapped installation. Choose Online if
    you're not sure.
-	* If you are doing an Airgapped install, provide the path on the the instance
-	  to the `.airgap` file that you downloaded using the initial instructions in
-    your setup email.
+    * If you are doing an Airgapped install, provide the path on the the instance
+      to the `.airgap` file that you downloaded using the initial instructions in
+      your setup email.
 1. Secure access to the installer dashboard. We recommend at least setting up the
    simple password authentication. If you're so inclined, LDAP authentication can also be
    configured.
@@ -463,7 +463,7 @@ To move these resources from the state into a new state file for later use, run:
 ```shell
 $ terraform state mv -state-out=terraform.tfstate.installer aws_kms_alias.key aws_kms_alias.key
 $ terraform state mv -state-out=terraform.tfstate.installer aws_kms_key.key aws_kms_key.key
-$ terraform state mv -state-out=terraform.tfstate.installer module.db.aws_db_instance.rds module.db.aws_db_instance.rds 
+$ terraform state mv -state-out=terraform.tfstate.installer module.db.aws_db_instance.rds module.db.aws_db_instance.rds
 $ terraform state mv -state-out=terraform.tfstate.installer module.db.aws_db_subnet_group.rds module.db.aws_db_subnet_group.rds
 $ terraform state mv -state-out=terraform.tfstate.installer module.db.aws_security_group.rds module.db.aws_security_group.rds
 $ terraform state mv -state-out=terraform.tfstate.installer module.instance.aws_s3_bucket.tfe_bucket module.instance.aws_s3_bucket.tfe_bucket

--- a/content/source/docs/enterprise/private/minio-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/minio-setup-guide.html.md
@@ -38,7 +38,7 @@ Begin with an [online installation](./install-installer.html#run-the-installer-o
 ```
 To continue the installation, visit the following URL in your browser:
 
-  https://<this_server_address>:8800
+  https://<TFE HOSTNAME>:8800
 ```
 
 ### Start Minio

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -67,8 +67,8 @@ Future releases may add native support for SELinux.
 
 1. Have the following ports available to the Linux instance:
   * **22** - to access the instance via SSH from your computer
-  * **8800** - to access the Admin Console
-  * **443** and **80** - to access the TFE app (both ports are needed; HTTP will redirect to HTTPS)
+  * **8800** - to access the installer dashboard.
+  * **443** and **80** - to access the TFE app (both ports are needed; HTTP will redirect to HTTPS).
   * **9870-9880 (inclusive)** - for internal communication on the host and its subnet; not publicly accessible
 1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example, to do this with UFW run: `ufw allow in on docker0`. This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
 1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -1,0 +1,74 @@
+---
+layout: "enterprise2"
+page_title: "Private Terraform Enterprise Installation (Preflight)"
+sidebar_current: "docs-enterprise2-private-installer-preflight"
+---
+
+# Private Terraform Enterprise Installation (Preflight Requirements)
+
+Before installing the Private Terraform Enterprise software, you'll need to prepare an appropriate instance and relevant data files. Please make careful note of these requirements, as the installation may not be successful if these requirements are not met.
+
+## Data Files
+
+* TLS private key and certificate
+  * The installer allows for using a certificate signed by a public or private CA. If you do not use a trusted certificate, your VCS provider will likely reject that certificate when sending webhooks.
+* License key (provided by HashiCorp)
+
+~> **Note:** If you use a certificate issued by a private Certificate
+   Authority, you must provide the certificate for that CA in the
+   `Certificate Authority (CA) Bundle` section of the installation. This allows services
+   running within PTFE to access each other properly.
+
+## Linux Instance
+
+Install the software on a Linux instance of your choosing.
+You will start and manage this instance like any other server.
+
+The Private Terraform Enterprise Installer currently supports the following
+operating systems:
+
+* Debian 7.7+
+* Ubuntu 14.04 / 16.04 / 18.04
+* Red Hat Enterprise Linux 7.2+
+* CentOS 7+
+* Amazon Linux 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
+* Oracle Linux 7.2+
+
+### Hardware Requirements
+
+These requirements provide the instance with enough resources to run the
+Terraform Enterprise application as well as the Terraform plans and applies.
+
+ * At least 40GB of disk space on the root volume
+ * At least 8GB of system memory
+ * At least 2 CPU cores
+
+### Software Requirements
+
+~> RedHat Enterprise Linux (RHEL) has a specific set of requirements. Please see the [RHEL Install Guide](./rhel-install-guide.html) before continuing.
+
+For Linux distributions other than RHEL, check Docker compatibility:
+
+  * The instance should run a supported version of Docker engine (1.7.1 or later, minimum 17.06.2-ce, maximum 17.12.1). This also requires a 64-bit distribution with a minimum Linux Kernel version of 3.10.
+    * At this time, the **18.x and higher Docker versions are not supported**
+    * In Online mode, the installer will install Docker automatically
+    * In Airgapped mode, Docker should be installed before you begin
+  * For _Redhat Enterprise_, _Oracle Linux_, and _SUSE Enterprise_, you **must** pre-install Docker as these distributions are [not officially supported by Docker Community Edition](https://docs.docker.com/engine/installation/#server).
+
+~> **Note**: It is not recommended to run Docker under a 2.x kernel.
+
+### SELinux
+
+Private Terraform Enterprise does not support SELinux. The host running the installer must be configured in permissive mode by running: `setenforce 0`.
+
+Future releases may add native support for SELinux.
+
+### Network Requirements
+
+1. Have the following ports available to the Linux instance:
+  * **22** - to access the instance via SSH from your computer
+  * **8800** - to access the Admin Console
+  * **443** and **80** - to access the TFE app (both ports are needed; HTTP will redirect to HTTPS)
+  * **9870-9880 (inclusive)** - for internal communication on the host and its subnet; not publicly accessible
+1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example, to do this with UFW run: `ufw allow in on docker0`. This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
+1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -66,10 +66,10 @@ Future releases may add native support for SELinux.
 ### Network Requirements
 
 1. Have the following ports available to the Linux instance:
-  * **22** - to access the instance via SSH from your computer
+  * **22** - to access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
   * **8800** - to access the installer dashboard.
   * **443** and **80** - to access the TFE app (both ports are needed; HTTP will redirect to HTTPS).
-  * **9870-9880 (inclusive)** - for internal communication on the host and its subnet; not publicly accessible
+  * **9870-9880 (inclusive)** - for internal communication on the host and its subnet; not publicly accessible.
 1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example, to do this with UFW run: `ufw allow in on docker0`. This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
 1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.
 

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -88,7 +88,7 @@ The operational mode is selected at install time and cannot be changed once the 
    stateful data used by the instance in an external PostgreSQL database as
    well as an external S3-compatible endpoint or Azure blob storage. There is still critical data
    stored on the instance that must be managed with snapshots. Be sure to
-   checked the [PostgreSQL Requirements](#postgresql-requirements) for what
+   check the [PostgreSQL Requirements](#postgresql-requirements) for information that
    needs to be present for Terraform Enterprise to work. This option is best
    for users with expertise managing PostgreSQL or users that have access
    to managed PostgreSQL offerings like [AWS RDS](https://aws.amazon.com/rds/).

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -157,7 +157,7 @@ When providing optional extra keyword parameters for the database connection,
 note an additional restriction on the `sslmode` parameter is that only the
 `require`, `verify-full`, `verify-ca`, and `disable` values are allowed.
 
-#### External Vault Option
+### External Vault Option
 
 If you choose to run the instance in the Production operational mode, during the installation, you can also choose to use an external Vault cluster, rather than the default internal Vault provided by PTFE.
 

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -73,7 +73,7 @@ Future releases may add native support for SELinux.
 1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example, to do this with UFW run: `ufw allow in on docker0`. This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
 1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.
 
-### Operational Mode Decision
+## Operational Mode Decision
 
 Terraform Enterprise can store its state in a few different ways, and you'll
 need to decide which works best for your installation. Each option has a
@@ -102,11 +102,11 @@ The operational mode is selected at install time and cannot be changed once the 
 
 The decision you make will be entered during setup.
 
-#### Mounted Disk Guidelines
+### Mounted Disk Guidelines
 
 The mounted disk option provides significant flexibility in how PTFE stores its data. To help narrow down the possibilites, we've provided the following guidelines for mounted disk storage.
 
-##### Supported Mounted Disk Types
+#### Supported Mounted Disk Types
 
 The following are **supported** mounted disk types:
 
@@ -117,13 +117,13 @@ The following are **supported** mounted disk types:
 * SAN
 * Physically connected disks as in non-cloud hardware
 
-###### Disk Resizing
+##### Disk Resizing
 
 Depending on your cloud or storage application, you may need to confirm the disk has been resized to above Private Terraform Enterprise's minimum disk size of 40GB.
 
 For example, with RedHat-flavor (RHEL, CentOS, Oracle Linux) images in Azure Cloud, the storage disk must be resized above the 30GB default after initial boot with `fdisk`, as documented in the Azure knowledge base article [How to: Resize Linux osDisk partition on Azure](https://blogs.msdn.microsoft.com/linuxonazure/2017/04/03/how-to-resize-linux-osdisk-partition-on-azure/).
 
-##### Unsupported Mounted Disk Types
+#### Unsupported Mounted Disk Types
 
 The following are **not** supported mounted disk types:
 
@@ -134,7 +134,7 @@ The supported mounted disk types provide the necessary reliability and performan
 
 If the type of mounted disk you wish to use is not listed, please contact your HashiCorp representative to get clarification on whether that type is supported.
 
-#### PostgreSQL Requirements
+### PostgreSQL Requirements
 
 When Terraform Enterprise uses an external PostgreSQL database, the
 following must be present on it:

--- a/content/source/docs/enterprise/private/reliability-availability.html.md
+++ b/content/source/docs/enterprise/private/reliability-availability.html.md
@@ -208,16 +208,16 @@ provide fast recovery following these steps:
 
 ### Availability During Upgrades
 
-Upgrades for the Installer Architecture utilize the Installer Admin Console.
+Upgrades for the Installer architecture use the Installer dashboard.
 Once an upgrade has been been detected (either online or airgap), the new code
 is imported. Once ready, all services on the instance are restarted running
 the new code. The expected downtime is between 30 seconds and 5 minutes,
 depending on whether database updates have to be applied.
 
 Only application services are changed during the upgrade; data is not backed up
-or restored. The only data changes that may occur during are the application of
+or restored. The only data changes that may occur during upgrade are the application of
 migrations the new version might apply to the _PostgreSQL Database_.
 
 When an upgrade is ready to start the new code, the system waits for all
-terraform runs to finish before continuing. Once the new code has started, the
+Terraform runs to finish before continuing. Once the new code has started, the
 queue of runs is continued in the same order.

--- a/content/source/docs/enterprise/private/upgrades.html.md
+++ b/content/source/docs/enterprise/private/upgrades.html.md
@@ -10,22 +10,19 @@ version. [Learn more about availability during upgrades here](./reliability-avai
 
 ## Online
 
-1. From the admin console dashboard
-(`https://[hostname or ip of your instance]:8800/dashboard`) click the
-"Check Now" button; the new version should be recognized, then click "View
-Update".
-2. Review the release notes and then click "Install Update".
+1. From the installer dashboard (`https://<TFE HOSTNAME>:8800/dashboard`),
+    click the "Check Now" button; the new version should be recognized.
+1. Click "View Update".
+1. Review the release notes and then click "Install Update".
 
 ## Airgapped
 
 1. Determine the update path where the installer will look for new `.airgap`
-packages; you can do this from the console settings of your instance
-(`https://[hostname or ip of your instance]:8800/console/settings`) in the field
-`Update Path`.
-2. Download the new `.airgap` package onto the instance and put it into the
-`Update Path` location.
-3. From the admin console dashboard
-(`https://[hostname or ip of your instance]:8800/dashboard`) click the
-"Check Now" button; the new version should be recognized, then click
-"View Update".
-4. Review the release notes and then click "Install Update".
+    packages. You can do this from the console settings of your instance
+    (`https://<TFE HOSTNAME>:8800/console/settings`) in the field `Update Path`.
+1. Download the new `.airgap` package onto the instance and put it into the
+    `Update Path` location.
+1. From the installer dashboard (`https://<TFE HOSTNAME>:8800/dashboard`) click the
+    "Check Now" button; the new version should be recognized.
+1. Click "View Update".
+1. Review the release notes and then click "Install Update".

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -243,7 +243,7 @@
             <a href="/docs/enterprise/private/install-installer.html">Installation (Installer)</a>
             <ul class="nav">
               <li<%= sidebar_current("docs-enterprise2-private-installer-preflight") %>>
-                <a href="/docs/enterprise/private/install-installer.html">Installer Preflight</a>
+                <a href="/docs/enterprise/private/preflight-installer.html">Installer Preflight</a>
               </li>
               <li<%= sidebar_current("docs-enterprise2-private-installer-install") %>>
                 <a href="/docs/enterprise/private/install-installer.html">Installation</a>

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -242,6 +242,9 @@
           <li<%= sidebar_current("docs-enterprise2-private-installer") %>>
             <a href="/docs/enterprise/private/install-installer.html">Installation (Installer)</a>
             <ul class="nav">
+              <li<%= sidebar_current("docs-enterprise2-private-installer-preflight") %>>
+                <a href="/docs/enterprise/private/install-installer.html">Installer Preflight</a>
+              </li>
               <li<%= sidebar_current("docs-enterprise2-private-installer-install") %>>
                 <a href="/docs/enterprise/private/install-installer.html">Installation</a>
               </li>


### PR DESCRIPTION
Other changes:

* some ordering changes in existing instructions
* consistent references to the hostname of the instance internally & w/rest of the docs
* consistent references to the instance management UI as "installer dashboard" (for now, at least)
* various minor editing cleanups

I'm very interested in feedback on this, especially what to include or exclude from "preflight requirements" or any other sequencing/information highlighting that might improve the installation experience.