### PR TITLE
Explicitly state how to override providers

### DIFF
--- a/content/source/docs/extend/how-terraform-works.html.md
+++ b/content/source/docs/extend/how-terraform-works.html.md
@@ -84,6 +84,9 @@ your user's home directory.
 
 [`terraform init`][3] will search
 this directory for additional plugins during plugin initialization.
+Providers that are distributed by HashiCorp will use the local copy
+in this directory instead of downloading a release copy during 
+`terraform init`. 
 
 The naming scheme for plugins is `terraform-<type>-NAME_vX.Y.Z`, where `type` is
 either `provider` or `provisioner`. Terraform uses the `NAME` to understand the


### PR DESCRIPTION
There may be a better home for this in these docs - just let me know if I should put it elsewhere/I missed documentation that already covers this!

I want to make it more clear how this directory interacts with HashiCorp distributed providers, allowing users to use their development copies instead of release versions if they are present.