### PR TITLE
Add Cloud Foundry provider symbolic links

### DIFF
--- a/content/source/docs/providers/cloudfoundry
+++ b/content/source/docs/providers/cloudfoundry
@@ -1,0 +1,1 @@
+../../../../ext/providers/cloudfoundry/website/docs

--- a/content/source/layouts/cloudfoundry.erb
+++ b/content/source/layouts/cloudfoundry.erb
@@ -1,0 +1,1 @@
+../../../ext/providers/cloudfoundry/website/cloudfoundry.erb


### PR DESCRIPTION
Hi, all

This PR is created to integrate [Cloud Foundry provider](https://github.com/mevansam/terraform-provider-cf) web page to terraform-website. We create symbolic links to our layout file and doc folder. `website-stable` branch is created in our repo but not updated yet. We will update it once this pr is merged.
Thanks.

Xilin