### PR TITLE
Update TFE Team Membership API docs to expect username

### DIFF
--- a/content/source/docs/enterprise/api/team-members.html.md
+++ b/content/source/docs/enterprise/api/team-members.html.md
@@ -26,10 +26,10 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path      | Type   | Default | Description                |
-| ------------- | ------ | ------- | -------------------------- |
-| `data[].type` | string |         | Must be `"users"`.         |
-| `data[].id`   | string |         | The ID of the user to add. |
+| Key path      | Type   | Default | Description                      |
+| ------------- | ------ | ------- | -------------------------------- |
+| `data[].type` | string |         | Must be `"users"`.               |
+| `data[].id`   | string |         | The username of the user to add. |
 
 ### Sample Payload
 
@@ -38,11 +38,11 @@ Properties without a default value are required.
   "data": [
     {
       "type": "users",
-      "id": "user-62goNpx1ThQf689e"
+      "id": "myuser1"
     },
     {
       "type": "users",
-      "id": "user-HqsTTbNYBStkbQBr"
+      "id": "myuser2"
     }
   ]
 }
@@ -75,10 +75,10 @@ This DELETE endpoint requires a JSON object with the following properties as a r
 
 Properties without a default value are required.
 
-| Key path      | Type   | Default | Description                   |
-| ------------- | ------ | ------- | ----------------------------- |
-| `data[].type` | string |         | Must be `"users"`.            |
-| `data[].id`   | string |         | The ID of the user to remove. |
+| Key path      | Type   | Default | Description                         |
+| ------------- | ------ | ------- | ----------------------------------- |
+| `data[].type` | string |         | Must be `"users"`.                  |
+| `data[].id`   | string |         | The username of the user to remove. |
 
 ### Sample Payload
 
@@ -87,11 +87,11 @@ Properties without a default value are required.
   "data": [
     {
       "type": "users",
-      "id": "user-62goNpx1ThQf689e"
+      "id": "myuser1"
     },
     {
       "type": "users",
-      "id": "user-HqsTTbNYBStkbQBr"
+      "id": "myuser2"
     }
   ]
 }


### PR DESCRIPTION
## Context
The docs currently state that the Team Membership API endpoints accept a user ID. The endpoints in fact accept a username, and do not accept a user ID, returning `400 Bad Request` when provided a user ID instead of a username.

## Changes
* Updated the docs to reflect that the API endpoints expect a username in the `data[].id` field.