### PR TITLE
link fixes for preflight change & other small adjustments

### DIFF
--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -29,7 +29,7 @@ architecture.
 Services_ operational mode.
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/install-installer.html#operational-mode-decision),
+mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single AWS EC2 instance
 for demo installations to multiple instances connected to RDS, S3, and an
 external Vault cluster for a stateless production installation.
@@ -236,9 +236,9 @@ cluster endpoint URL.
 
 ### Upgrades
 
-See [the upgrading
-section](https://www.terraform.io/docs/enterprise/private/install-installer.html#upgrading)
-of the installation guide.
+See [the Upgrades
+section](https://www.terraform.io/docs/enterprise/private/upgrades.html)
+of the documentation.
 
 ## High Availability
 

--- a/content/source/docs/enterprise/private/azure-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/azure-setup-guide.html.md
@@ -32,7 +32,7 @@ architecture.
 -> **Note:** This reference architecture focuses on the _Production - External Services_ operational mode.
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/install-installer.html#operational-mode-decision),
+mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single [Azure VM
 instance](https://azure.microsoft.com/en-us/services/virtual-machines/) for
 demo or proof of concept installations, to multiple instances connected to
@@ -218,9 +218,9 @@ can be found on our website.
 
 ### Upgrades
 
-See [the upgrading
-section](https://www.terraform.io/docs/enterprise/private/install-installer.html#upgrading)
-of the installation guide.
+See [the Upgrades
+section](https://www.terraform.io/docs/enterprise/private/upgrades.html)
+of the documentation.
 
 ## High Availability
 

--- a/content/source/docs/enterprise/private/gcp-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/gcp-setup-guide.html.md
@@ -26,7 +26,7 @@ architecture.
 ## Infrastructure Requirements
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/install-installer.html#operational-mode-decision),
+mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single Cloud Compute VM instance
 for demo installations to multiple instances connected to Cloud SQL, Cloud Storage, and an
 external Vault cluster for a stateless production installation.
@@ -180,9 +180,9 @@ cluster endpoint URL.
 
 ### Upgrades
 
-See [the upgrading
-section](https://www.terraform.io/docs/enterprise/private/install-installer.html#upgrading)
-of the installation guide.
+See [the Upgrades
+section](https://www.terraform.io/docs/enterprise/private/upgrades.html)
+of the documentation.
 
 ## High Availability
 

--- a/content/source/docs/enterprise/private/minio-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/minio-setup-guide.html.md
@@ -12,28 +12,28 @@ This document provides an overview for setting up [Minio](https://minio.io) for 
 
 ## Required Reading
 
-- Ensure you are familiar with PTFE's operation and [installation requirements](./installer.html), and especially the [Operational Mode Decision](./install-installer.html#operational-mode-decision).
+- Ensure you are familiar with PTFE's operation and [installation requirements](./installer.html), and especially the [Operational Mode Decision](./preflight-installer.html#operational-mode-decision).
 - Familiarize yourself with [Minio](https://minio.io).
 
 ## Overview
 
-When configured to use external services, PTFE must be connected to a storage service to persist workspace state and other file-based data.  Native support exists for Azure Blob Storage, Amazon S3, and services that are API-compatible with Amazon S3.  If you are not using Azure or a cloud provider with an S3-compatible service, or you are running PTFE in an environment without a storage service, it may be possible to use [Minio](https://minio.io) instead.
+When configured to use external services, PTFE must be connected to a storage service to persist workspace state and other file-based data. Native support exists for Azure Blob Storage, Amazon S3, and services that are API-compatible with Amazon S3. If you are not using Azure or a cloud provider with an S3-compatible service, or you are running PTFE in an environment without a storage service, it may be possible to use [Minio](https://minio.io) instead.
 
 ## Installation
 
 ~> **Note:** This is not a production-ready configuration: it's intended to guide you to a working configuration that can later be automated and hardened.
 
-This guide will walk through installing Minio in a Docker container alongside PTFE on the same host, with PTFE configured in the "Production - External Services" [operational mode](./install-installer.html#operational-mode-decision). Data will not be persisted outside of an ephemeral Docker volume, Minio will not start on system boot, etc.  It is assumed your instance will have access to the Internet and that you will be performing an online install of PTFE.
+This guide will walk through installing Minio in a Docker container alongside PTFE on the same host, with PTFE configured in the "Production - External Services" [operational mode](./preflight-installer.html#operational-mode-decision). Data will not be persisted outside of an ephemeral Docker volume, Minio will not start on system boot, etc. The guide your instance will have access to the Internet and that you will be performing an online install of PTFE.
 
 ### System preparation
 
-Ensure your Linux instance meets the [requirements](./install-installer.html#linux-instance).  You will need [jq](https://stedolan.github.io/jq/) (a command-line JSON processor), and the [AWS CLI](https://aws.amazon.com/cli/).
+Ensure your Linux instance meets the [requirements](./preflight-installer.html#linux-instance). You will need [jq](https://stedolan.github.io/jq/) (a command-line JSON processor), and the [AWS CLI](https://aws.amazon.com/cli/).
 
-You also need a PostgreSQL database that meets the [requirements](./install-installer.html#postgresql-requirements), as this is part of the external services operational mode.
+You also need a PostgreSQL database that meets the [requirements](./preflight-installer.html#postgresql-requirements), as this is part of the external services operational mode.
 
 ### PTFE installation
 
-Begin with an [online installation](./install-installer.html#run-the-installer-online).  Once the installation script has finished and you're presented with the following text, move on to the next section:
+Begin with an [online installation](./install-installer.html#run-the-installer-online). Once the installation script has finished and you're presented with the following text, move on to the next section:
 
 ```
 To continue the installation, visit the following URL in your browser:
@@ -67,7 +67,7 @@ You now need to collect several pieces of information about your running Minio i
 
 ### Create a bucket
 
-Like S3, Minio does not automatically create buckets.  Use the AWS CLI to create a bucket named `ptfe` that will be used to store data:
+Like S3, Minio does not automatically create buckets. Use the AWS CLI to create a bucket named `ptfe` that will be used to store data:
 
 ```bash
 export AWS_ACCESS_KEY_ID="<access key from above>"
@@ -78,7 +78,7 @@ aws --region us-east-1 --endpoint-url http://<ip address from above>:9000 s3 mb 
 
 ### PTFE installation
 
-You may now [continue the installation in the browser](./install-installer.html#continue-installation-in-browser). When you arrive at the Operational Mode choice in the installer then follow these steps:
+You may now [continue the installation in the browser](./install-installer.html#continue-installation-in-browser). When you arrive at the Operational Mode choice in the installer, follow these steps:
 
 1. Choose the "Production" installation type
 2. Choose the "External Services" production type

--- a/content/source/docs/enterprise/private/minio-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/minio-setup-guide.html.md
@@ -23,7 +23,7 @@ When configured to use external services, PTFE must be connected to a storage se
 
 ~> **Note:** This is not a production-ready configuration: it's intended to guide you to a working configuration that can later be automated and hardened.
 
-This guide will walk through installing Minio in a Docker container alongside PTFE on the same host, with PTFE configured in the "Production - External Services" [operational mode](./preflight-installer.html#operational-mode-decision). Data will not be persisted outside of an ephemeral Docker volume, Minio will not start on system boot, etc. The guide your instance will have access to the Internet and that you will be performing an online install of PTFE.
+This guide will walk through installing Minio in a Docker container alongside PTFE on the same host, with PTFE configured in the "Production - External Services" [operational mode](./preflight-installer.html#operational-mode-decision). Data will not be persisted outside of an ephemeral Docker volume, Minio will not start on system boot, etc. The guide assumes your instance will have access to the Internet and that you will be performing an online install of PTFE.
 
 ### System preparation
 

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -81,7 +81,7 @@ different approach to
 [recovering from failures](./reliability-availability.html#recovery-from-failures-1)
 and should be selected based on your organization's preferences. 
 
-~> **Note:** This decision should be made before you begin installation, because some modes have additional preflight requirements. 
+~> **Note:** This decision should be made before you begin installation, because some modes have additional preflight requirements that are detailed below.
 The operational mode is selected at install time and cannot be changed once the install is running.
 
 1. **Production - External Services** - This mode stores the majority of the
@@ -98,7 +98,8 @@ The operational mode is selected at install time and cannot be changed once the 
    etc. This option is best for users with experience mounting performant
    block storage.
 1. **Demo** - This mode stores all data on the instance. The data can be
-   backed up with the snapshot mechanism for restore later.
+   backed up with the snapshot mechanism for restore later. This option is best for initial
+   installation and testing, and is not recommended or supported for true production use.
 
 The decision you make will be entered during setup.
 

--- a/content/source/docs/enterprise/private/vmware-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/vmware-setup-guide.html.md
@@ -26,7 +26,7 @@ architecture.
 ## Infrastructure Requirements
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/install-installer.html#operational-mode-decision),
+mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single virtual machine
 for demo or proof of concept installations, to multiple virtual machines
 hosting the Terraform Enterprise application, PostgreSQL, and external Vault servers for
@@ -184,8 +184,8 @@ can be found on our website.
 ### Upgrades
 
 Please reference the [upgrade
-instructions](https://www.terraform.io/docs/enterprise/private/install-installer.html#upgrading)
-on the deployment documentation website.
+instructions](https://www.terraform.io/docs/enterprise/private/upgrades.html)
+in the documentation.
 
 ## High Availability
 


### PR DESCRIPTION
We've adjusted the organization of the docs the reference architectures were linking to; this gets those up to date and fixes a few other missed links & miscellaneity.