### PR TITLE
Add document symbolic links for oVirt provider

### DIFF
--- a/content/source/docs/providers/ovirt
+++ b/content/source/docs/providers/ovirt
@@ -1,0 +1,1 @@
+../../../../ext/providers/ovirt/website/docs

--- a/content/source/layouts/ovirt.erb
+++ b/content/source/layouts/ovirt.erb
@@ -1,0 +1,1 @@
+../../../ext/providers/ovirt/website/ovirt.erb


### PR DESCRIPTION
hi, currently I'm working on [terraform provider for oVirt](https://github.com/imjoey/terraform-provider-ovirt). While I must say that the provider is **not officially maintained** yet and in heavy work in progress, I am still want to offer supports for accessing documents locally by running `make website` command, 😄 . This pr includes new two symbolic links for oVirt documents. Great thanks.