### PR TITLE
Reconcile docs about plugin discovery and downloading

### DIFF
--- a/content/source/docs/extend/how-terraform-works.html.md
+++ b/content/source/docs/extend/how-terraform-works.html.md
@@ -84,6 +84,9 @@ your user's home directory.
 
 [`terraform init`][3] will search
 this directory for additional plugins during plugin initialization.
+Providers that are distributed by HashiCorp will use the local copy
+in this directory instead of downloading a release copy during 
+`terraform init`. 
 
 The naming scheme for plugins is `terraform-<type>-NAME_vX.Y.Z`, where `type` is
 either `provider` or `provisioner`. Terraform uses the `NAME` to understand the

--- a/content/source/docs/extend/writing-custom-providers.html.md
+++ b/content/source/docs/extend/writing-custom-providers.html.md
@@ -264,12 +264,13 @@ a `main.tf` in the working directory (the same place where the plugin exists).
 resource "example_server" "my-server" {}
 ```
 
-Terraform automatically discovers the Providers when it parses configuration
-files. This only occurs when the `init` command is executed. Terraform will
-search for matching Providers via a
-[**Discovery**](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery)
-process, including the current local directory. Run `terraform init` to discover
-our newly compiled Provider:
+When `terraform init` is run, Terraform parses configuration files and
+searches for providers in several locations. For the convenience of plugin
+developers, this search includes the current working directory. (For full
+details, see
+[How Terraform Works: Plugin Discovery](/docs/extend/how-terraform-works.html#discovery).)
+
+Run `terraform init` to discover our newly compiled provider:
 
 ```text
 $ terraform init


### PR DESCRIPTION
I'm attempting to keep things simple for normal users while making sure we've
got the full behavior written down somewhere for plugin developers.

This PR doesn't stand alone; it's paired with a PR in the
terraform repo, to deal with a bunch of related content: https://github.com/hashicorp/terraform/pull/18973