### PR TITLE
Remove latest_run, which has been deprecated from the API

### DIFF
--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -93,8 +93,8 @@ This GET endpoint can optionally return related resources, if requested with [th
 Resource Name      | Description
 -------------------|------------
 `organization`     | The full organization record.
-`latest_run`       | Additional information about the last run.
-`latest_run.plan ` | The plan used in the last run.
+`current_run`      | Additional information about the current run.
+`current_run.plan` | The plan used in the current run.
 
 
 ### Sample Payload

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -908,10 +908,6 @@ $ curl \
 The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
 
 * `organization` - The full organization record.
-* `latest_run` - Additional information about the last run.
-* `latest_run.plan` - The plan used in the last run.
-* `latest_run.configuration_version` - The configuration used in the last run.
-* `latest_run.configuration_version.ingress_attributes` - The commit information used in the last run.
 * `current_run` - Additional information about the current run.
 * `current_run.plan` - The plan used in the current run.
 * `current_run.configuration_version` - The configuration used in the current run.


### PR DESCRIPTION
It hasn't actually been removed, but aliased to its replacement, current_run.
There's no need to ever use latest_run at this point, use current_run instead.