### PR TITLE
Fix broken link released in binary.

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -187,3 +187,6 @@
 /docs/providers/aws/r/alb.html                         /docs/providers/aws/r/lb.html
 /docs/providers/aws/r/code_commit_repository.html      /docs/providers/aws/r/codecommit_repository.html
 /docs/providers/aws/r/code_commit_trigger.html         /docs/providers/aws/r/codecommit_trigger.html
+
+# Fixing terraform-provider-google#2197
+/docs/provider/google/provider_versions.html          /docs/providers/google/provider_versions.html


### PR DESCRIPTION
Add a redirect for the typo'd version of the provider versioning page
that was released with the terraform-provider-google 1.19.0 binary.
1.19.1 has a fixed URL, but this redirect should catch users that are
working with a stale binary.