### PR TITLE
docs/sentinel: Update limitation docs for all mocks

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
@@ -22,9 +22,11 @@ documentation][ref-official-sentinel-documentation].
 [ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
 [ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
 
--> **NOTE:** As functions cannot be mocked in the current Sentinel testing
-framework, the [module()][ref-module] function is not available. As a result,
-only root module data can be mocked at this time.
+#### Current mock limitations
+
+As functions cannot be mocked in the current Sentinel testing framework, the
+[module()][ref-module] function is not available. As a result, only root module
+data can be mocked at this time.
 
 [ref-module]: /docs/enterprise/sentinel/import/tfconfig.html#function-module-
 

--- a/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
@@ -24,7 +24,7 @@ documentation][ref-official-sentinel-documentation].
 
 #### Current mock limitations
 
-As functions cannot be mocked in the current Sentinel testing framework, the
+* As functions cannot be mocked in the current Sentinel testing framework, the
 [module()][ref-module] function is not available. As a result, only root module
 data can be mocked at this time.
 

--- a/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
@@ -42,7 +42,7 @@ issues will be fixed in future releases of the import and core runtime.
 
 * [Resource and data source][resource-and-data-source] count keys (`NUMBER` in
   `TYPE.NAME[NUMBER]`), which are actually represented as integers, cannot be
-  represented accurately JSON and as a result, mocks that depend on count keys
+  represented accurately in JSON, and as a result, mocks that depend on count keys
   explicitly (example: `tfplan.resources.null_resource.foo[0]`) will not work
   properly with mocks.
 

--- a/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
@@ -29,11 +29,24 @@ mock][ref-tfconfig-mock] and the [`tfstate` mock][ref-tfstate-mock].
 [ref-tfconfig-mock]: /docs/enterprise/sentinel/import/mock-tfconfig.html
 [ref-tfstate-mock]: /docs/enterprise/sentinel/import/mock-tfstate.html
 
--> **NOTE:** As functions cannot be mocked in the current Sentinel testing
-framework, the [module()][ref-module] function is not available. As a result,
-only root module data can be mocked at this time.
+#### Current mock limitations
+
+There are currently some limitations mocking `tfplan` data in Sentinel. These
+issues will be fixed in future releases of the import and core runtime.
+
+* As functions cannot be mocked in the current Sentinel testing framework, the
+  [module()][ref-module] function is not available. As a result, only root
+  module data can be mocked at this time.
 
 [ref-module]: /docs/enterprise/sentinel/import/tfplan.html#function-module-
+
+* [Resource and data source][resource-and-data-source] count keys (`NUMBER` in
+  `TYPE.NAME[NUMBER]`), which are actually represented as integers, cannot be
+  represented accurately JSON and as a result, mocks that depend on count keys
+  explicitly (example: `tfplan.resources.null_resource.foo[0]`) will not work
+  properly with mocks.
+
+[resource-and-data-source]: /docs/enterprise/sentinel/import/tfplan.html#namespace-resources-data-sources
 
 ```json
 {

--- a/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
@@ -35,9 +35,9 @@ issues will be fixed in future releases of the import and core runtime.
 
 * [Resource and data source][resource-and-data-source] count keys (`NUMBER` in
   `TYPE.NAME[NUMBER]`), which are actually represented as integers, cannot be
-  represented accurately JSON and as a result, mocks that depend on count keys
-  explicitly (example: `tfstate.resources.null_resource.foo[0]`) will not work
-  properly with mocks.
+  represented accurately in JSON and as a result, mocks that depend on count
+  keys explicitly (example: `tfstate.resources.null_resource.foo[0]`) will not
+  work properly with mocks.
 
 [resource-and-data-source]: /docs/enterprise/sentinel/import/tfstate.html#namespace-resources-data-sources
 

--- a/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
@@ -22,11 +22,24 @@ documentation][ref-official-sentinel-documentation].
 [ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
 [ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
 
--> **NOTE:** As functions cannot be mocked in the current Sentinel testing
-framework, the [module()][ref-module] function is not available. As a result,
-only root module data can be mocked at this time.
+#### Current mock limitations
+
+There are currently some limitations mocking `tfstate` data in Sentinel. These
+issues will be fixed in future releases of the import and core runtime.
+
+* As functions cannot be mocked in the current Sentinel testing framework, the
+  [module()][ref-module] function is not available. As a result, only root
+  module data can be mocked at this time.
 
 [ref-module]: /docs/enterprise/sentinel/import/tfstate.html#function-module-
+
+* [Resource and data source][resource-and-data-source] count keys (`NUMBER` in
+  `TYPE.NAME[NUMBER]`), which are actually represented as integers, cannot be
+  represented accurately JSON and as a result, mocks that depend on count keys
+  explicitly (example: `tfstate.resources.null_resource.foo[0]`) will not work
+  properly with mocks.
+
+[resource-and-data-source]: /docs/enterprise/sentinel/import/tfstate.html#namespace-resources-data-sources
 
 ```json
 {


### PR DESCRIPTION
We've discovered that we overlooked the fact that mock count indexes are
represented as strings in the JSON, even though the indexes are integers
in practice.

This can't be necessarily worked around, unfortunately; removing the
indexes and moving the resource objects to an array, for example, will
create edge cases in testing if someone is using a singular-context for
or any/all loop. Hence, we are keeping the mocks the way that they are,
and just noting the limitations.

I've also revised the limitations so that they are not info boxes, but
but rather simple bullet points. tfconfig, even though it's not affected
by this, has been re-formatted as well to stay consistent.