### PR TITLE
Website: add announcement banner style with new content to homepage hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 node_modules
 vendor
 .idea*
+*.DS_Store

--- a/content/source/assets/stylesheets/_notification.scss
+++ b/content/source/assets/stylesheets/_notification.scss
@@ -1,0 +1,55 @@
+.notification {
+  background: #f7f7fd;
+  border-radius: 3px;
+  color: $black;
+  display: inline-block;
+  font-size: 1.4rem;
+  padding: 7px 6px 6px;
+  line-height: 1.7;
+  transition: all 0.3s ease-in-out;
+
+  &:hover {
+    background: #f1f1fe;
+    color: $black;
+    text-decoration: none;
+  }
+
+  @media (min-width: 768px) {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  @media (min-width: 992px) {
+    line-height: 1.4;
+
+    .notification-details{
+      display: flex;
+    }
+  }
+
+  .notification-tag {
+    border: 1px solid $terraform-purple;
+    background-color: $white;
+    border-radius: 3px;
+    color: $terraform-purple;
+    display: inline-block;
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin-top: -1px;
+    margin-right: 4px;
+    padding: 2px 9px;
+    text-transform: uppercase;
+
+    @media (min-width: 992px) {
+      float: left;
+      margin-right: 8px;
+    }
+  }
+
+  svg {
+    margin-left: 4px;
+    margin-right: 6px;
+    align-self: center;
+  }
+}

--- a/content/source/assets/stylesheets/application.scss
+++ b/content/source/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@
 @import '_buttons';
 @import '_syntax';
 @import '_logos';
+@import '_notification';
 
 // Pages
 @import '_community';

--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -7,6 +7,17 @@ description: |-
 ---
 
 <header>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-10">
+      <a class="notification" href='https://www.hashicorp.com/blog/terraform-collaboration-for-everyone'>
+        <span class="notification-tag">News</span>
+          Free Terraform Enteprise tier for practitioners and small teams, affordable paid tiers for businesses. Read more
+          <svg width="15" height="9" viewBox="0 0 15 9" fill="none" xmlns="http://www.w3.org/2000/svg"><line x1="0.5" y1="4.5" x2="13.5" y2="4.5" stroke="#5147CD" stroke-linecap="round"></line><path d="M10.3536 0.646447C10.1583 0.451184 9.84171 0.451184 9.64645 0.646447C9.45118 0.841709 9.45118 1.15829 9.64645 1.35355L10.3536 0.646447ZM13.5 4.5L13.8536 4.85355L14.2071 4.5L13.8536 4.14645L13.5 4.5ZM9.64645 7.64645C9.45118 7.84171 9.45118 8.15829 9.64645 8.35355C9.84171 8.54882 10.1583 8.54882 10.3536 8.35355L9.64645 7.64645ZM9.64645 1.35355L13.1464 4.85355L13.8536 4.14645L10.3536 0.646447L9.64645 1.35355ZM13.1464 4.14645L9.64645 7.64645L10.3536 8.35355L13.8536 4.85355L13.1464 4.14645Z" fill="#5147CD"></path></svg>
+      </a>
+      </div>
+    </div>
+  </div>
   <div class="container hero">
     <div class="row">
       <div class="col-md-offset-2 col-md-8">
@@ -17,6 +28,7 @@ description: |-
         <a class="button primary" href="/intro/index.html">Get Started</a>
         <a class="button" href="/downloads.html">Download <%= latest_version %></a>
         <a class="button" href="https://registry.terraform.io/">Find Modules</a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Purpose**
Adds announcement component. New announcement linking to free tier blog post

**UI Screenshots (Desktop / Mobile):**
<img width="1030" alt="screenshot 2018-10-23 14 02 22" src="https://user-images.githubusercontent.com/438899/47390664-c0bbb680-d6cc-11e8-8498-0ced3500ddad.png">

<img width="415" alt="screenshot 2018-10-23 14 06 23" src="https://user-images.githubusercontent.com/438899/47390709-d7faa400-d6cc-11e8-9a9e-703a9d511e53.png">

