### PR TITLE
link to correct naming scheme for providers

### DIFF
--- a/content/source/docs/enterprise/run/index.html.md
+++ b/content/source/docs/enterprise/run/index.html.md
@@ -158,7 +158,7 @@ Terraform only automatically installs plugins from [the main list of providers](
 
 Currently, there are two ways to use custom provider plugins with TFE.
 
-- Add the provider binary to the VCS repo (or manually-uploaded configuration version) for any workspace that uses it. Place the compiled `linux_amd64` version of the plugin at `terraform.d/plugins/linux_amd64/<PLUGIN NAME>` (as a relative path from the root of the working directory).
+- Add the provider binary to the VCS repo (or manually-uploaded configuration version) for any workspace that uses it. Place the compiled `linux_amd64` version of the plugin at `terraform.d/plugins/linux_amd64/<PLUGIN NAME>` (as a relative path from the root of the working directory). The plugin name should follow the [naming scheme](https://www.terraform.io/docs/configuration/providers.html#plugin-names-and-versions). (Third-party plugins are often distributed with an appropriate filename already set in the distribution archive.)
 
     You can add plugins directly to a configuration repo, or you can add them as Git submodules and symlink the files into `terraform.d/plugins/linux_amd64/`. Submodules are a good choice when many workspaces use the same custom provider, since they keep your repos smaller. If using submodules, enable the ["Include submodules on clone" setting](../workspaces/settings.html#include-submodules-on-clone) on any affected workspace.
 


### PR DESCRIPTION
Provides a reference to the expected provider filename, in case users may not be familiar with the convention.