### PR TITLE
website: make announcement banner full 12 col on desktop

### DIFF
--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -9,7 +9,7 @@ description: |-
 <header>
   <div class="container">
     <div class="row">
-      <div class="col-md-10">
+      <div class="col-md-12">
       <a class="notification" href='https://www.hashicorp.com/blog/terraform-collaboration-for-everyone'>
         <span class="notification-tag">News</span>
           Free Terraform Enteprise tier for practitioners and small teams, affordable paid tiers for businesses. Read more


### PR DESCRIPTION
Issue was arrow falling to new line, by itself, spotted in firefox. This fix addresses based on current content. I've tested and it doesn't appear to occur in any browsers on desktop.

**Issue:**
https://files.slack.com/files-pri/T024UT03C-FDLMXUF3N/2018-10-23_at_5.20_pm.png
![image](https://user-images.githubusercontent.com/438899/47522974-c390e580-d84b-11e8-8796-674d7dd3537d.png)


**Fixed:**
<img width="1020" alt="screenshot 2018-10-25 11 45 33" src="https://user-images.githubusercontent.com/438899/47522887-8af10c00-d84b-11e8-8af2-2eb02ba6eda8.png">
