### PR TITLE
Add API links on UI docs, where applicable

### DIFF
--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -17,7 +17,10 @@ sidebar_current: "docs-enterprise2-api-state-versions"
 | `:workspace_id` | The workspace ID to create the new state version. |
 
 Creates a state version and sets it as the current state version for the given
-workspace.
+workspace. This is most useful for migrating existing state from open source
+Terraform into a new TFE workspace.
+
+!> **Warning:** Use caution when uploading state to workspaces that have already performed Terraform runs. Replacing state improperly can result in orphaned or duplicated infrastructure resources.
 
 -> **Note:** This endpoint cannot be accessed with [organization tokens](../users-teams-organizations/service-accounts.html#organization-service-accounts). You must access it with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/service-accounts.html#team-service-accounts).
 

--- a/content/source/docs/enterprise/migrate/index.html.md
+++ b/content/source/docs/enterprise/migrate/index.html.md
@@ -15,6 +15,8 @@ If you already use Terraform to manage infrastructure, you're probably managing 
 
 ~> **Important:** These instructions are for migrating state in a basic working directory that only uses the `default` workspace. If you use multiple [workspaces][cli-workspaces] in one working directory, the instructions are different; see [Migrating State from Multiple Terraform Workspaces](./workspaces.html) instead.
 
+-> **API:** See the [State Versions API](../api/state-versions.html). This API can be a faster way to import existing state into TFE workspaces, but many of the warnings in the manual process below still apply; in particular, be sure to only import state into TFE workspaces that have never performed a run.
+
 ## Step 1: Gather Credentials, Data, and Code
 
 Make sure you have all of the following:

--- a/content/source/docs/enterprise/migrate/index.html.md
+++ b/content/source/docs/enterprise/migrate/index.html.md
@@ -15,7 +15,7 @@ If you already use Terraform to manage infrastructure, you're probably managing 
 
 ~> **Important:** These instructions are for migrating state in a basic working directory that only uses the `default` workspace. If you use multiple [workspaces][cli-workspaces] in one working directory, the instructions are different; see [Migrating State from Multiple Terraform Workspaces](./workspaces.html) instead.
 
--> **API:** See the [State Versions API](../api/state-versions.html). This API can be a faster way to import existing state into TFE workspaces, but many of the warnings in the manual process below still apply; in particular, be sure to only import state into TFE workspaces that have never performed a run.
+-> **API:** See the [State Versions API](../api/state-versions.html). Be sure to stop Terraform runs before migrating state to TFE, and only import state into TFE workspaces that have never performed a run.
 
 ## Step 1: Gather Credentials, Data, and Code
 

--- a/content/source/docs/enterprise/migrate/workspaces.html.md
+++ b/content/source/docs/enterprise/migrate/workspaces.html.md
@@ -13,11 +13,13 @@ sidebar_current: "docs-enterprise2-migrating-workspaces"
 
 Terraform can manage multiple groups of infrastructure in one working directory by [switching workspaces][cli-workspaces].
 
-These workspaces, managed with the `terraform workspace` command, aren't the same thing as TFE's workspaces. TFE workspaces act more like completely separate working directories; CLI workspaces are just alternate state files.
+These workspaces, managed with the `terraform workspace` command, aren't the same thing as Terraform Enterprise (TFE)'s workspaces. TFE workspaces act more like completely separate working directories; CLI workspaces are just alternate state files.
 
 If you use multiple workspaces, you'll need to migrate each one to a separate TFE workspace.
 
 Migrating multiple workspaces is similar to [migrating a single workspace](./index.html), but it requires some extra steps.
+
+-> **API:** See the [State Versions API](../api/state-versions.html). This API can be a faster way to import existing state into TFE workspaces, but many of the warnings in the manual process below still apply; in particular, be sure to only import state into TFE workspaces that have never performed a run.
 
 ## Step 1: Gather Credentials, Data, and Code
 

--- a/content/source/docs/enterprise/migrate/workspaces.html.md
+++ b/content/source/docs/enterprise/migrate/workspaces.html.md
@@ -19,7 +19,7 @@ If you use multiple workspaces, you'll need to migrate each one to a separate TF
 
 Migrating multiple workspaces is similar to [migrating a single workspace](./index.html), but it requires some extra steps.
 
--> **API:** See the [State Versions API](../api/state-versions.html). This API can be a faster way to import existing state into TFE workspaces, but many of the warnings in the manual process below still apply; in particular, be sure to only import state into TFE workspaces that have never performed a run.
+-> **API:** See the [State Versions API](../api/state-versions.html). Be sure to stop Terraform runs before migrating state to TFE, and only import state into TFE workspaces that have never performed a run.
 
 ## Step 1: Gather Credentials, Data, and Code
 

--- a/content/source/docs/enterprise/private/admin/general.html.md
+++ b/content/source/docs/enterprise/private/admin/general.html.md
@@ -10,7 +10,7 @@ General settings control global behavior in Private Terraform Enterprise. To acc
 
 ![screenshot: the Settings admin page](./images/admin-general.png)
 
--> **API:** See the [PTFE Settings API](../../api/admin/settings.html).
+-> **API:** See the [Admin Settings API](../../api/admin/settings.html).
 
 ## Contact Info
 

--- a/content/source/docs/enterprise/private/admin/general.html.md
+++ b/content/source/docs/enterprise/private/admin/general.html.md
@@ -10,6 +10,8 @@ General settings control global behavior in Private Terraform Enterprise. To acc
 
 ![screenshot: the Settings admin page](./images/admin-general.png)
 
+-> **API:** See the [PTFE Settings API](../../api/admin/settings.html).
+
 ## Contact Info
 
 The support email address is used in system emails and other contact details. It defaults to support@hashicorp.com. If you'd like  users of your instance to reach out to a specific person or team when they have issues, it can be changed to a local email address.

--- a/content/source/docs/enterprise/private/admin/integration.html.md
+++ b/content/source/docs/enterprise/private/admin/integration.html.md
@@ -14,7 +14,7 @@ At this time, the available site-wide integrations are:
 - SMTP
 - Twilio
 
--> **API:** See the [PTFE Settings API](../../api/admin/settings.html).
+-> **API:** See the [Admin Settings API](../../api/admin/settings.html).
 
 ## SAML Integration
 

--- a/content/source/docs/enterprise/private/admin/integration.html.md
+++ b/content/source/docs/enterprise/private/admin/integration.html.md
@@ -14,6 +14,8 @@ At this time, the available site-wide integrations are:
 - SMTP
 - Twilio
 
+-> **API:** See the [PTFE Settings API](../../api/admin/settings.html).
+
 ## SAML Integration
 
 The SAML integration settings allow configuration of a SAML Single Sign-On integration for Terraform Enterprise. To access the SAML settings, click **SAML** in the left menu.

--- a/content/source/docs/enterprise/private/admin/resources.html.md
+++ b/content/source/docs/enterprise/private/admin/resources.html.md
@@ -14,6 +14,8 @@ Each type of account or resource is initally presented as a searchable list, acc
 
 ## Managing Users
 
+-> **API:** See the [PTFE Users API](../../api/admin/users.html).
+
 To access the list of all users in the Terraform Enterprise instance, click **Users** in the left menu.
 
 ![screenshot: the Users admin page](./images/admin-users.png)
@@ -52,6 +54,8 @@ Impersonation can be performed from multiple places:
 
 ## Managing Organizations
 
+-> **API:** See the [PTFE Organizations API](../../api/admin/organizations.html).
+
 If your institution uses multiple organizations in Terraform Enterprise, you can view the details of each organization by clicking it in the admin list of organizations. From the details page, you can impersonate an owner or delete an organization (using the red **Delete this organization** button at the bottom of the details page).
 
 Typically, in private installations, all organizations will be granted "Premium" plan status for the purpose of providing access to all available features. However, it's also possible to set other statuses. An organization whose trial period is expired will be unable to make use of features in Terraform Enterprise.
@@ -59,6 +63,8 @@ Typically, in private installations, all organizations will be granted "Premium"
 ![screenshot: an organization details admin page](./images/admin-organization-details.png)
 
 ## Managing Workspaces and Runs
+
+-> **API:** See the [PTFE Workspaces API](../../api/admin/workspaces.html) and [PTFE Runs API](../../api/admin/runs.html).
 
 The administrative view of workspaces and runs provides limited detail (name, status, and IDs) to avoid exposing sensitive data when it isn't needed. Site administrators can view and investigate workspaces and runs more deeply by impersonating a user with full access to the desired resource. (See [Impersonating a User](#impersonating-a-user) above.)
 
@@ -87,6 +93,8 @@ If history migration initially fails, the migration will be retried periodically
 A future version of Terraform Enterprise will remove Legacy environment data and code completely. Be sure to review release notes and wait to upgrade to that version until migration of desired data is complete.
 
 ## Managing Terraform Versions
+
+-> **API:** See the [PTFE Terraform Versions API](../../api/admin/terraform-versions.html).
 
 Private Terraform Enterprise ships with a default list of Terraform versions. However, the addition of new versions after installation is the responsibility of site administrators.
 

--- a/content/source/docs/enterprise/private/admin/resources.html.md
+++ b/content/source/docs/enterprise/private/admin/resources.html.md
@@ -14,7 +14,7 @@ Each type of account or resource is initally presented as a searchable list, acc
 
 ## Managing Users
 
--> **API:** See the [PTFE Users API](../../api/admin/users.html).
+-> **API:** See the [Admin Users API](../../api/admin/users.html).
 
 To access the list of all users in the Terraform Enterprise instance, click **Users** in the left menu.
 
@@ -54,7 +54,7 @@ Impersonation can be performed from multiple places:
 
 ## Managing Organizations
 
--> **API:** See the [PTFE Organizations API](../../api/admin/organizations.html).
+-> **API:** See the [Admin Organizations API](../../api/admin/organizations.html).
 
 If your institution uses multiple organizations in Terraform Enterprise, you can view the details of each organization by clicking it in the admin list of organizations. From the details page, you can impersonate an owner or delete an organization (using the red **Delete this organization** button at the bottom of the details page).
 
@@ -64,7 +64,7 @@ Typically, in private installations, all organizations will be granted "Premium"
 
 ## Managing Workspaces and Runs
 
--> **API:** See the [PTFE Workspaces API](../../api/admin/workspaces.html) and [PTFE Runs API](../../api/admin/runs.html).
+-> **API:** See the [Admin Workspaces API](../../api/admin/workspaces.html) and [Admin Runs API](../../api/admin/runs.html).
 
 The administrative view of workspaces and runs provides limited detail (name, status, and IDs) to avoid exposing sensitive data when it isn't needed. Site administrators can view and investigate workspaces and runs more deeply by impersonating a user with full access to the desired resource. (See [Impersonating a User](#impersonating-a-user) above.)
 
@@ -94,7 +94,7 @@ A future version of Terraform Enterprise will remove Legacy environment data and
 
 ## Managing Terraform Versions
 
--> **API:** See the [PTFE Terraform Versions API](../../api/admin/terraform-versions.html).
+-> **API:** See the [Admin Terraform Versions API](../../api/admin/terraform-versions.html).
 
 Private Terraform Enterprise ships with a default list of Terraform versions. However, the addition of new versions after installation is the responsibility of site administrators.
 

--- a/content/source/docs/enterprise/run/index.html.md
+++ b/content/source/docs/enterprise/run/index.html.md
@@ -120,6 +120,8 @@ Since force-canceling can have dangerous side-effects (including loss of state a
 
 ## Locking Workspaces (Preventing Runs)
 
+-> **API:** See the [Lock a Workspace endpoint](../api/workspaces.html#lock-a-workspace).
+
 If you need to temporarily stop runs from being queued, you can lock the workspace.
 
 A lock prevents TFE from performing any plans or applies in the workspace. This includes automatic runs due to new commits in the VCS repository, manual runs queued via the UI, and runs created with the API or the TFE CLI tool. New runs remain in the "Pending" state until the workspace is unlocked.
@@ -165,6 +167,8 @@ Currently, there are two ways to use custom provider plugins with TFE.
 - **Private TFE only:** Use [the `terraform-bundle` tool][bundle] to add custom providers to a custom Terraform version. This keeps custom providers out of your configuration repos entirely, and is easier to update when many workspaces use the same provider.
 
 ## Terraform State in TFE
+
+-> **API:** See the [State Versions API](../api/state-versions.html).
 
 Each TFE workspace has its own separate state data. In order to read and write state for the correct workspace, TFE overrides any configured [backend](/docs/backends/index.html) when running Terraform.
 

--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -15,7 +15,7 @@ Private Terraform Enterprise (PTFE) is configured as the Service Provider.
 
 -> **Note:** For instructions for specific IdPs, see [Identity Provider Configuration](./identity-provider-configuration.html).
 
--> **API:** See the [PTFE Settings API](../api/admin/settings.html).
+-> **API:** See the [Admin Settings API](../api/admin/settings.html).
 
 ## Terraform Enterprise (Service Provider)
 

--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -15,6 +15,8 @@ Private Terraform Enterprise (PTFE) is configured as the Service Provider.
 
 -> **Note:** For instructions for specific IdPs, see [Identity Provider Configuration](./identity-provider-configuration.html).
 
+-> **API:** See the [PTFE Settings API](../api/admin/settings.html).
+
 ## Terraform Enterprise (Service Provider)
 
 ~> **Important:** Only PTFE users with the site-admin permission can modify SAML settings. For more information about site admins, see [Administering Private Terraform Enterprise][admin].

--- a/content/source/docs/enterprise/sentinel/manage-policies.html.md
+++ b/content/source/docs/enterprise/sentinel/manage-policies.html.md
@@ -6,6 +6,8 @@ sidebar_current: "docs-enterprise2-sentinel-manage-policies"
 
 # Managing Policies
 
+-> **API:** See the [Policies API](../api/policies.html).
+
 Sentinel Policies are rules which are enforced on every workspace run to validate the terraform plan and corresponding resources are in compliance with company policies. Policies are made up of a sentinel policy file, a name, and an enforcement level. They are managed at an organization level and a user must be in the organization's owners team to create, edit or delete policies.
 
 To view the policies navigate to the organization's settings page under "Sentinel Policy". From the "Sentinel Policy" section you can view, list, edit, create and delete the policies.

--- a/content/source/docs/enterprise/upgrade/batch.html.md
+++ b/content/source/docs/enterprise/upgrade/batch.html.md
@@ -12,7 +12,7 @@ the easiest way to migrate a legacy environment to a workspace; however, if your
 organization has many environments in need of migration this process may be
 laborious to perform in the UI.
 
-The [TFE workspace creation API](https://www.terraform.io/docs/enterprise/api/workspaces.html)
+The [TFE workspace creation API](/docs/enterprise/api/workspaces.html)
 can be used to perform the migration, which automaticaly locks the legacy
 environment and migrates the data to the new workspace. This API can be called
 using standard tools like curl, [tfe-cli tool](https://github.com/hashicorp/tfe-cli),
@@ -32,7 +32,7 @@ This guide requires the [tfe-cli tool](https://github.com/hashicorp/tfe-cli).
 
 ## Step 1: Identify OAuth Token ID
 
--> You can skip to **Step 2** if only one VCS connection is configured or if no
+-> **Note:** You can skip to **Step 2** if only one VCS connection is configured or if no
 VCS connection is needed. The `tfe` tool will automatically use the VCS
 connection if only one exists.
 

--- a/content/source/docs/enterprise/upgrade/index.html.md
+++ b/content/source/docs/enterprise/upgrade/index.html.md
@@ -10,6 +10,8 @@ If you used the legacy version of Terraform Enterprise (TFE), you probably have 
 
 Follow these steps to migrate your old TFE environments to new TFE workspaces.
 
+-> **API:** See the [Create a Workspace endpoint](../api/workspaces.html#create-a-workspace); the `data.attributes.migration-environment` property enables migration from legacy environments. For end-to-end instructions for migrating many legacy environments, see [Batch Migration](./batch.html).
+
 ## Step 1: Create a New Organization
 
 You can't use the current version of TFE with a legacy organization because the internals are too different. If you don't already have an organization in the new TFE, do the following:

--- a/content/source/docs/enterprise/users-teams-organizations/organizations.html.md
+++ b/content/source/docs/enterprise/users-teams-organizations/organizations.html.md
@@ -11,6 +11,8 @@ sidebar_current: "docs-enterprise2-users-teams-organizations-organizations"
 
 Organizations are a shared space for [teams][] to collaborate on workspaces in Terraform Enterprise (TFE).
 
+-> **API:** See the [Organizations API](../api/organizations.html).
+
 ## Selecting Organizations
 
 On most pages within TFE, the top navigation bar displays the name of the selected organization. Clicking the name reveals the organization switcher menu, which lists all of the organizations you belong to. You can switch to another organization by clicking its name, or you can create a new organization with the "Create new organization" button.
@@ -36,8 +38,6 @@ Once you have created an organization, you can add other [users][] by adding the
 -> **Note:** On the SaaS version of TFE, any user can create a new organization. On private installs of TFE, the administrators can restrict this ability, so that only site admins can create organizations. See [Administration: General Settings](../private/admin/general.html#organization-creation) for more details.
 
 ## Organization Settings
-
--> **API:** See the [Organizations API](../api/organizations.html).
 
 You can view and manage an organization's settings by clicking the "Settings" link in the top navigation bar.
 

--- a/content/source/docs/enterprise/workspaces/creating.html.md
+++ b/content/source/docs/enterprise/workspaces/creating.html.md
@@ -21,7 +21,7 @@ You must fill out several fields to configure your new workspace:
 - **Workspace name** (required) — A name for the workspace, which must be unique in the organization. Names can include letters, numbers, `_`, and `-`. [See more advice about workspace names here](./naming.html).
 - **Source** (required; list of buttons) — Which [connected VCS provider](../vcs/index.html) the workspace should pull configurations from. If you've configured multiple VCS providers, there is a button for each of them.
 
-    If you select "None," the workspace cannot pull configurations automatically, but you can upload configurations with [the run API](../run/api.html) or the optional [TFE CLI client](https://github.com/hashicorp/tfe-cli/).
+    If you select "None," the workspace cannot pull configurations automatically, but you can upload configurations with [the remote backend](../run/cli.html), [the run API](../run/api.html), or the optional [TFE CLI client](https://github.com/hashicorp/tfe-cli/).
 - **Repository** — The VCS repository that contains the Terraform configuration for this workspace. This field is hidden when creating a workspace without a VCS source.
 
     Repository identifiers are determined by your VCS provider, and use a format like `<ORGANIZATION>/<REPO NAME>` or `<PROJECT KEY>/<REPO NAME>`.

--- a/content/source/docs/enterprise/workspaces/index.html.md
+++ b/content/source/docs/enterprise/workspaces/index.html.md
@@ -17,6 +17,8 @@ A workspace consists of:
 
 ## Listing and Filtering Workspaces
 
+-> **API:** See the [Workspaces API](../api/workspaces.html).
+
 TFE's top navigation bar includes a "Workspaces" link, which takes you to the list of workspaces in the current  organization.
 
 ![Screenshot: the list of workspaces](./images/index-list.png)

--- a/content/source/docs/enterprise/workspaces/ssh-keys.html.md
+++ b/content/source/docs/enterprise/workspaces/ssh-keys.html.md
@@ -10,13 +10,15 @@ Terraform configurations can pull in Terraform modules from [a variety of differ
 
 To access a private Git repository, Terraform either needs login credentials (for HTTPS access) or an SSH key. Terraform Enterprise (TFE) can store private SSH keys centrally, and you can easily use them in any workspace that clones modules from a Git server.
 
-~> **Note:** SSH keys for cloning Terraform modules from Git repos are only used during Terraform runs. They are managed separately from any [keys used for bringing VCS content into TFE](../vcs/index.html#ssh-keys).
+-> **Note:** SSH keys for cloning Terraform modules from Git repos are only used during Terraform runs. They are managed separately from any [keys used for bringing VCS content into TFE](../vcs/index.html#ssh-keys).
 
 TFE manages SSH keys used to clone Terraform modules at the organization level, and allows multiple keys to be added for the organization. You can add or delete keys via the organization's settings. Once a key is uploaded, the text of the key is not displayed to users.
 
 To assign a key to a workspace, go to its settings and choose a previously added key from the drop-down menu on Integrations under "SSH Key". Each workspace can only use one SSH key.
 
 ## Adding and Deleting Keys
+
+-> **API:** See the [SSH Keys API](../api/ssh-keys.html).
 
 To add or delete an SSH private key, use the main menu to go to your organization's settings and choose "Manage SSH Keys" from the navigation sidebar. This page has a form for adding new keys and a list of existing keys.
 
@@ -38,6 +40,8 @@ To delete a key, find it in the list of keys and click its "Delete" button. Befo
 ~> **Important:** If any workspaces are still using a key when you delete it, they will be unable to clone modules from private repos until you assign them a new key. This might cause Terraform runs to fail.
 
 ## Assigning Keys to Workspaces
+
+-> **API:** See the [Assign an SSH Key to a Workspace endpoint](../api/workspaces.html#assign-an-ssh-key-to-a-workspace).
 
 To assign a key to a workspace, navigate to that workspace's page and click the "Settings" link.
 

--- a/content/source/docs/enterprise/workspaces/variables.html.md
+++ b/content/source/docs/enterprise/workspaces/variables.html.md
@@ -15,7 +15,7 @@ Terraform Enterprise (TFE) workspaces can set values for two kinds of variables:
 
 You can edit a workspace's variables via the UI or the API. All runs in a workspace use its variables.
 
--> **API:** See the [variables API](../api/variables.html).
+-> **API:** See the [Variables API](../api/variables.html).
 
 ## Loading Variables from Files
 


### PR DESCRIPTION
I think I finally got 'em all! These links are meant to raise the profile of
our API docs and break down walls between categories of content, and putting
them in a callout box makes it so readers can instantly recognize them (and then
either ignore or navigate through, depending) without having to parse text out
of a paragraph of semi-related info.