### PR TITLE
Kill off the standalone terraform terraform provider submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -246,10 +246,6 @@
 	path = ext/providers/template
 	url = https://github.com/terraform-providers/terraform-provider-template
 	branch = stable-website
-[submodule "ext/providers/terraform"]
-	path = ext/providers/terraform
-	url = https://github.com/terraform-providers/terraform-provider-terraform
-	branch = stable-website
 [submodule "ext/providers/tls"]
 	path = ext/providers/tls
 	url = https://github.com/terraform-providers/terraform-provider-tls

--- a/content/source/layouts/terraform.erb
+++ b/content/source/layouts/terraform.erb
@@ -1,1 +1,1 @@
-../../../ext/providers/terraform/website/terraform.erb
+../../../ext/terraform/website/layouts/terraform.erb


### PR DESCRIPTION
See the readme at https://github.com/terraform-providers/terraform-provider-terraform for context. 

https://github.com/hashicorp/terraform-website/pull/538 knocked out the main content symlink to that repo; this commit takes care of the sidebar nav symlink, and deletes the submodule.