### PR TITLE
Clarify that custom Sentinel imports are not available in TFE

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -11,8 +11,10 @@ language](https://docs.hashicorp.com/sentinel/language/). A policy can include
 [imports](https://docs.hashicorp.com/sentinel/concepts/imports) which enable a
 policy to access reusable libraries, external data and functions. Terraform
 Enterprise provides three imports to define policy rules for the configuration,
-state and plan. 
+state and plan.
 
 - [tfplan](./tfplan.html) - This provides access to a Terraform plan, the file created as a result of `terraform plan`.  The plan represents the changes that Terraform needs to make to infrastructure to reach the desired state represented by the configuration.
 - [tfconfig](./tfconfig.html) - This provides access to a Terraform configuration, the set of "tf" files that are used to describe the desired infrastructure state.
 - [tfstate](./tfstate.html) - This provides access to the Terraform state, the file used by Terraform to map real world resources to your configuration.
+
+-> **Note:** Terraform Enterprise does not currently support custom imports.

--- a/content/source/docs/enterprise/sentinel/manage-policies.html.md
+++ b/content/source/docs/enterprise/sentinel/manage-policies.html.md
@@ -17,7 +17,6 @@ To create a new policy navigate to "Create Policy". Sentinel is designed to enab
   - **hard-mandatory (cannot override)**: This policy is required on all terraform runs. It cannot be overridden by any users.
   - **soft-mandatory (can override)**: This policy is required. If a terraform plan fails to comply, it can be overridden by a member of the organization owners team.
   - **advisory (logging only)**: This policy will allow the run to continue to an apply in both pass and failures of the policy check.
-- **Policy Code**: The [Terraform compatible sentinel](https://docs.hashicorp.com/sentinel/app/terraform/) policy which defines the rules for the terraform configurations, states and plans. 
+- **Policy Code**: The [Terraform compatible sentinel](https://docs.hashicorp.com/sentinel/app/terraform/) policy which defines the rules for the terraform configurations, states and plans. Please note that custom imports are not available for use in Terraform Enterprise at this time.
 
 Consider integrating with the Terraform Enterprise API in CI to test and upload policy files. In the future, Terraform Enterprise will integrate directly with VCS providers for the Sentinel workflow.
-


### PR DESCRIPTION
Custom imports for Sentinel policies aren't available in TFE yet, but we don't document this anywhere. This should clarify things! I added the note in two places that made sense to me, but feel free to either suggest different places or ixnay one of them!