### PR TITLE
Corrects spelling of "Enterprise" on home page banner

### DIFF
--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -12,7 +12,7 @@ description: |-
       <div class="col-md-12">
       <a class="notification" href='https://www.hashicorp.com/blog/terraform-collaboration-for-everyone'>
         <span class="notification-tag">News</span>
-          Free Terraform Enteprise tier for practitioners and small teams, affordable paid tiers for businesses. Read more
+          Free Terraform Enterprise tier for practitioners and small teams, affordable paid tiers for businesses. Read more
           <svg width="15" height="9" viewBox="0 0 15 9" fill="none" xmlns="http://www.w3.org/2000/svg"><line x1="0.5" y1="4.5" x2="13.5" y2="4.5" stroke="#5147CD" stroke-linecap="round"></line><path d="M10.3536 0.646447C10.1583 0.451184 9.84171 0.451184 9.64645 0.646447C9.45118 0.841709 9.45118 1.15829 9.64645 1.35355L10.3536 0.646447ZM13.5 4.5L13.8536 4.85355L14.2071 4.5L13.8536 4.14645L13.5 4.5ZM9.64645 7.64645C9.45118 7.84171 9.45118 8.15829 9.64645 8.35355C9.84171 8.54882 10.1583 8.54882 10.3536 8.35355L9.64645 7.64645ZM9.64645 1.35355L13.1464 4.85355L13.8536 4.14645L10.3536 0.646447L9.64645 1.35355ZM13.1464 4.14645L9.64645 7.64645L10.3536 8.35355L13.8536 4.85355L13.1464 4.14645Z" fill="#5147CD"></path></svg>
       </a>
       </div>


### PR DESCRIPTION
The small banner on the home page was missing an _r_. This corrects it.

<img width="352" alt="screen shot 2018-11-07 at 1 13 30 pm" src="https://user-images.githubusercontent.com/26/48161475-7ff89b80-e28f-11e8-8e6f-68edabfee20a.png">
