### PR TITLE
Update Bitbucket Server version support note w/ Atlassian EOL policy

### DIFF
--- a/content/source/docs/enterprise/vcs/bitbucket-server.html.md
+++ b/content/source/docs/enterprise/vcs/bitbucket-server.html.md
@@ -11,7 +11,7 @@ These instructions are for using Bitbucket Server for Terraform Enterprise (TFE)
 
 Note that Bitbucket Server requires both OAuth authentication and an SSH key. The instructions below include SSH key configuration.
 
--> **Version note:** TFE supports Bitbucket Server versions 4.9.1 and newer. We do not test older versions of Bitbucket Server with TFE, and they might not work as expected.
+-> **Version note:** TFE supports Bitbucket Server versions 4.9.1 and newer. HashiCorp does not test older versions of Bitbucket Server with TFE, and they might not work as expected. Also note that, although we do not deliberately remove support for versions that have reached end of life (per the [Atlassian Support End of Life Policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html)), our ability to resolve customer issues with end of life versions might be limited.
 
 ~> **Important:** TFE needs to contact your Bitbucket Server instance during setup and during normal operation. For the SaaS version of TFE, this means Bitbucket Server must be internet-accessible; for private installs of TFE, you must have network connectivity between your TFE and Bitbucket Server instances over HTTP or HTTPS and SSH. Bitbucket Server repository clone operations are performed over SSH on the port the Bitbucket Server instance uses.
 


### PR DESCRIPTION
(My memory might be flaking on me, but I think @rkst was the one who had the most input on this in the sync?) 

Context for this is that we have specific customer reasons for not eagerly moving that support bar up to 4.11 today (or 4.12 tomorrow, lol), but it's worth reminding people that you're taking a loan out from your future self whenever you continue using EOLed software. 

Anyway, how's that wording? 