### PR TITLE
Link to the `tfe` Terraform provider from various places

### DIFF
--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -13,6 +13,8 @@ Terraform Enterprise (TFE) provides an API for a subset of its features. If you 
 
 See the navigation sidebar for the list of available endpoints.
 
+-> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](/docs/providers/tfe/index.html) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
+
 ## Authentication
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, TFE responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.
@@ -226,9 +228,11 @@ Status  | Response                                     | Reason
 }
 ```
 
-## Community client libraries and tools
+## Client libraries and tools
 
-The community client libraries and tools listed below have been built by the community of Terraform Enterprise users and vendors. These client libraries and tools are not tested nor officially maintained by HashiCorp, and are listed here in order to help users find them easily.
+HashiCorp maintains [go-tfe](https://github.com/hashicorp/go-tfe), a Go client for TFE's API.
+
+Additionally, the community of Terraform Enterprise users and vendors have built client libraries in other languages. These client libraries and tools are not tested nor officially maintained by HashiCorp, but are listed below in order to help users find them easily.
 
 If you have built a client library and would like to add it to this community list, please [contribute](https://github.com/hashicorp/terraform-website#contributions-welcome) to [this page](https://github.com/hashicorp/terraform-website/blob/master/content/source/docs/enterprise/api/index.html.md).
 

--- a/content/source/docs/enterprise/users-teams-organizations/organizations.html.md
+++ b/content/source/docs/enterprise/users-teams-organizations/organizations.html.md
@@ -11,7 +11,9 @@ sidebar_current: "docs-enterprise2-users-teams-organizations-organizations"
 
 Organizations are a shared space for [teams][] to collaborate on workspaces in Terraform Enterprise (TFE).
 
--> **API:** See the [Organizations API](../api/organizations.html).
+-> **API:** See the [Organizations API](../api/organizations.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_organization` resource](/docs/providers/tfe/r/organization.html).
+
 
 ## Selecting Organizations
 

--- a/content/source/docs/enterprise/users-teams-organizations/teams.html.md
+++ b/content/source/docs/enterprise/users-teams-organizations/teams.html.md
@@ -48,7 +48,9 @@ Only organization owners can manage teams or view the full list of teams. Other 
 
 ### Creating and Deleting Teams
 
--> **API:** See the [Teams API](../api/teams.html).
+-> **API:** See the [Teams API](../api/teams.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_team` resource](/docs/providers/tfe/r/team.html).
+
 
 Organization owners can create new teams from the teams page, using the controls under the "Create a New Team" header.
 
@@ -58,7 +60,8 @@ To delete a team, go to the target team's settings page and click the "Delete TE
 
 ### Managing Team Membership
 
--> **API:** See the [Team Members API](../api/team-members.html).
+-> **API:** See the [Team Members API](../api/team-members.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_team_member` resource](/docs/providers/tfe/r/team_member.html) or [`tfe_team_members` resource](/docs/providers/tfe/r/team_members.html).
 
 Organization owners can use a team's settings page to add and remove users from the team.
 
@@ -76,7 +79,8 @@ Each team can have a special service account API token that is not associated wi
 
 ## Managing Workspace Access
 
--> **API:** See the [Team Access API](../api/team-access.html).
+-> **API:** See the [Team Access API](../api/team-access.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_team_access` resource](/docs/providers/tfe/r/team_access.html).
 
 A team can be given read, write, or admin permissions on one or more workspaces.
 

--- a/content/source/docs/enterprise/workspaces/access.html.md
+++ b/content/source/docs/enterprise/workspaces/access.html.md
@@ -21,7 +21,8 @@ For more information see:
 
 ## Managing Workspace Access Permissions
 
--> **API:** See the [Team Access APIs](../api/team-access.html).
+-> **API:** See the [Team Access APIs](../api/team-access.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_team_access` resource](/docs/providers/tfe/r/team_access.html).
 
 When a workspace is created, the only team able to access it is the owners team, with full admin permissions. The owners team can never be removed from a workspace.
 

--- a/content/source/docs/enterprise/workspaces/creating.html.md
+++ b/content/source/docs/enterprise/workspaces/creating.html.md
@@ -8,7 +8,8 @@ sidebar_current: "docs-enterprise2-workspaces-creating"
 
 ~> **Important:** Only [organization owners](../users-teams-organizations/teams.html#the-owners-team) can create new workspaces.
 
--> **API:** See the [Create a Workspace endpoint](../api/workspaces.html#create-a-workspace) (`POST /organizations/:organization/workspaces`).
+-> **API:** See the [Create a Workspace endpoint](../api/workspaces.html#create-a-workspace) (`POST /organizations/:organization/workspaces`). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_workspace` resource](/docs/providers/tfe/r/workspace.html).
 
 Create new Terraform Enterprise (TFE) workspaces with the "+ New Workspace" button, which appears on the list of workspaces. If you're not already viewing the workspace list, you can get there with the "Workspaces" button in the top navigation bar.
 

--- a/content/source/docs/enterprise/workspaces/ssh-keys.html.md
+++ b/content/source/docs/enterprise/workspaces/ssh-keys.html.md
@@ -18,7 +18,8 @@ To assign a key to a workspace, go to its settings and choose a previously added
 
 ## Adding and Deleting Keys
 
--> **API:** See the [SSH Keys API](../api/ssh-keys.html).
+-> **API:** See the [SSH Keys API](../api/ssh-keys.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_ssh_key` resource](/docs/providers/tfe/r/ssh_key.html).
 
 To add or delete an SSH private key, use the main menu to go to your organization's settings and choose "Manage SSH Keys" from the navigation sidebar. This page has a form for adding new keys and a list of existing keys.
 

--- a/content/source/docs/enterprise/workspaces/variables.html.md
+++ b/content/source/docs/enterprise/workspaces/variables.html.md
@@ -15,7 +15,8 @@ Terraform Enterprise (TFE) workspaces can set values for two kinds of variables:
 
 You can edit a workspace's variables via the UI or the API. All runs in a workspace use its variables.
 
--> **API:** See the [Variables API](../api/variables.html).
+-> **API:** See the [Variables API](../api/variables.html). <br/>
+**Terraform:** See the `tfe` provider's [`tfe_variable` resource](/docs/providers/tfe/r/variable.html).
 
 ## Loading Variables from Files
 


### PR DESCRIPTION
The `tfe` provider is great, let's tell more people about it.

- **About those br tags:** The `->` callout syntax doesn't create its own block element; it's just attached to a single `<p>` element, which means there's no "pure" way to do a multi-line callout. But a line break looks fine and isn't _that_ dirty, IMO. 
- **Notable omission:** Sentinel policies. I'm going to revisit that as soon as a version of the provider with David's PR gets released. 
- **Notable bafflement:** I don't fully understand the use case for the team token and org token resources (given that the token is only readable once), and so I don't know whether linking to those is actually a good idea. Are you supposed to create a resource in the Vault provider (or something) with with the value, during the single run when it'll be available?
- **Misc:** I went ahead and linked to hashicorp/go-tfe in the API index page, because why not. 
