### PR TITLE
Mention upload limits on Sentinel policy uploads

### DIFF
--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -205,6 +205,8 @@ This endpoint uploads code to an existing Sentinel policy.
 
 -> **Note**: This endpoint does not use JSON-API's conventions for HTTP headers and body serialization.
 
+-> **Note**: This endpoint limits the size of uploaded policies to 10MB. If a larger payload is uploaded, an HTTP 413 error will be returned, and the policy will not be saved. Consider refactoring policies into multiple smaller, more concise documents if you reach this limit.
+
 ### Request Body
 
 This PUT endpoint requires the text of a valid Sentinel policy, with a `Content-Type` of `application/octet-stream`.


### PR DESCRIPTION
Adds mention of the new limitations on policy upload sizes. This is purposely not mentioned in the UI-level docs, because right now the UI is a text box that a user would have to copy/paste more than 10mb of text to in order to exceed the limit. If you think it should still be mentioned anyways just let me know!