### PR TITLE
Remove stateless reference in external Vault docs

### DIFF
--- a/content/source/docs/enterprise/private/vault.html.md
+++ b/content/source/docs/enterprise/private/vault.html.md
@@ -13,10 +13,6 @@ encrypt sensitive information such as variables and states.
 An external Vault cluster allows the customer to have full control over how
 the Vault cluster is managed, for example how it is sealed and unsealed, replicated, etc.
 
-When an external Vault cluster is configured along with the External Services installation mode,
-Private Terraform Enterprise becomes fully stateless and can be run in a hot-standby
-configuration to provide failover.
-
 -> **NOTE:** The external Vault option must be selected at initial installation, and cannot be changed later.
 Do not attempt to migrate an existing Terraform Enterprise instance between internal and external
 Vault options.


### PR DESCRIPTION
In response to 
![2018-11-14 at 12 58 pm](https://user-images.githubusercontent.com/1085/48502200-f3a92400-e80c-11e8-992c-460d0232ee72.png)

https://hashicorp.slack.com/archives/C1UJDFJEP/p1541693037878100?thread_ts=1541692236.873100&cid=C1UJDFJEP

Note: EA team is currently updating reference architectures to remove external Vault as well (ex: https://www.terraform.io/docs/enterprise/private/gcp-setup-guide.html) 
