### PR TITLE
add note about internal monitoring and how to disable

### DIFF
--- a/content/source/docs/enterprise/private/monitoring.html.md
+++ b/content/source/docs/enterprise/private/monitoring.html.md
@@ -28,6 +28,11 @@ Beginning in version 201811-1, PTFE includes internal monitoring of critical app
 Error starting userland proxy: listen udp 0.0.0.0:8125: bind: address already in use
 ```
 
-To prevent this conflict, disable metrics collection by PTFE. Access the installer dashboard on port 8800 of your instance and locate **Advanced Configuration** on the configuration page under **Terraform Build Worker image**, and uncheck "Enable metrics collection". Then, restart the application from the dashboard if it does not restart automatically.
+To prevent this conflict, disable metrics collection by PTFE:
+
+1. Access the installer dashboard on port 8800 of your instance.
+2. Locate **Advanced Configuration** on the configuration page under **Terraform Build Worker image**.
+3. Uncheck "Enable metrics collection".
+4. Restart the application from the dashboard if it does not restart automatically.
 
 We recommend that internal monitoring only be disabled if it is causing issues, as it otherwise provides useful detail in diagnosing issues.

--- a/content/source/docs/enterprise/private/monitoring.html.md
+++ b/content/source/docs/enterprise/private/monitoring.html.md
@@ -19,3 +19,15 @@ In addition to health-check monitoring, we recommend monitoring standard server 
 - I/O
 - CPU
 - Disk
+
+## Internal Monitoring
+
+Beginning in version 201811-1, PTFE includes internal monitoring of critical application metrics using a statsd collector on port 8125. The resulting metrics are included with the [diagnostic bundles provided to HashiCorp Support](./diagnostics.html). If the PTFE instance is already running a collector on this port, PTFE may not start up correctly due to the conflict, and logs will indicate:
+
+```
+Error starting userland proxy: listen udp 0.0.0.0:8125: bind: address already in use
+```
+
+To prevent this conflict, disable metrics collection by PTFE. Access the installer dashboard on port 8800 of your instance and locate **Advanced Configuration** on the configuration page under **Terraform Build Worker image**, and uncheck "Enable metrics collection". Then, restart the application from the dashboard if it does not restart automatically.
+
+We recommend that internal monitoring only be disabled if it is causing issues, as it otherwise provides useful detail in diagnosing issues.


### PR DESCRIPTION
I didn't find an ideal place to put this (it might be nice to at some point have a configuration page that included details of post-install config adjustments?) but this seemed reasonably related, and I want to make sure that people have the information they need on this functionality.

This can be updated if we adjust the port we're running on.