### PR TITLE
advise local admin before SAML enable

### DIFF
--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -23,8 +23,8 @@ Private Terraform Enterprise (PTFE) is configured as the Service Provider.
 
 Prior to activating SAML, we recommend that you create a TFE user who has:
 
-* the site-admin permission
-* an email address that will never be used for any SAML user
+* The site-admin permission
+* An email address that will never be used for any SAML user
 
 In case of any issues during SAML configuration, this ensures that there will be an admin able to log in and make necessary adjustments.
 

--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -21,6 +21,13 @@ Private Terraform Enterprise (PTFE) is configured as the Service Provider.
 
 ~> **Important:** Only PTFE users with the site-admin permission can modify SAML settings. For more information about site admins, see [Administering Private Terraform Enterprise][admin].
 
+Prior to activating SAML, we recommend that you create a TFE user who has:
+
+* the site-admin permission
+* an email address that will never be used for any SAML user
+
+In case of any issues during SAML configuration, this ensures that there will be an admin able to log in and make necessary adjustments.
+
 [admin]: ../private/admin/index.html
 
 Go to the SAML section of the site admin pages. You can use the "Site Admin" link in the upper-right user icon menu, or go directly to `https://<TFE HOSTNAME>/app/admin/saml`.


### PR DESCRIPTION
This additional suggested step greatly simplifies the process of correcting any issues with permissions management through SAML.