### PR TITLE
Successful POST to `run/` returns 201 not 200

### DIFF
--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -42,12 +42,12 @@ Key path                    | Type   | Default | Description
 
 Status  | Response                               | Reason
 --------|----------------------------------------|-------
-[200][] | [JSON API document][] (`type: "runs"`) | Successfully created a run
+[201][] | [JSON API document][] (`type: "runs"`) | Successfully created a run
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]              | Malformed request body (missing attributes, wrong types, etc.)
 
 [JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 


### PR DESCRIPTION
If merged, will fix documentation for the `Create run` endpoint success response status.

![image](https://user-images.githubusercontent.com/11620582/48578269-317a7b00-e8e7-11e8-8ce1-746b4f2e0b7b.png)
