### PR TITLE
Fix generic titles in Sentinel import pages

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "Defining Policies - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports"
 ---
 

--- a/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "Mocking tfconfig Data - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports-tfconfig-mock"
 description: |-
     This page provides a mock for the tfconfig Sentinel import.

--- a/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "Mocking tfplan Data - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports-tfplan-mock"
 description: |-
     This page provides a mock for the tfplan Sentinel import.

--- a/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "Mocking tfstate Data - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports-tfstate-mock"
 description: |-
     This page provides a mock for the tfstate Sentinel import.

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "tfconfig - Imports - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports-tfconfig"
 description: |-
   The tfconfig import provides access to a Terraform configuration.
@@ -272,7 +272,7 @@ resource "null_resource" "foo" {
   triggers = {
     foo = "one"
   }
-  
+
   triggers = {
     bar = "two"
   }
@@ -367,7 +367,7 @@ resource "null_resource" "foo" {
 }
 ```
 
-The following policy would evaluate to `true`: 
+The following policy would evaluate to `true`:
 
 ```python
 import "tfconfig"

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "tfplan - Imports - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports-tfplan"
 description: |-
     The tfplan import provides access to a Terraform plan. A Terraform plan is the file created as a result of `terraform plan` and is the input to `terraform apply`. The plan represents the changes that Terraform needs to make to infrastructure to reach the desired state represented by the configuration.
@@ -350,7 +350,7 @@ resource or data source had a `count` value in it) in the syntax
 you did not use `count` in the resource.
 
 In addition, each of these namespace levels is a map, allowing you to filter
-based on type and name. 
+based on type and name.
 
 -> The (somewhat strange) notation here of `TYPE.NAME[NUMBER]` may imply that
 the inner resource index map is actually a list, but it's not - using the square

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -1,6 +1,6 @@
 ---
 layout: enterprise2
-page_title: "Sentinel - Terraform Enterprise"
+page_title: "tfstate - Imports - Sentinel - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-sentinel-imports-tfstate"
 description: |-
   The tfstate import provides access to a Terraform state.
@@ -292,7 +292,7 @@ resource or data source had a `count` value in it) in the syntax
 you did not use `count` in the resource.
 
 In addition, each of these namespace levels is a map, allowing you to filter
-based on type and name. 
+based on type and name.
 
 -> The (somewhat strange) notation here of `TYPE.NAME[NUMBER]` may imply that
 the inner resource index map is actually a list, but it's not - using the square
@@ -325,7 +325,7 @@ mentioned, when operating on data sources, use the same syntax, except with
 
 The `attr` value within the [resource
 namespace](#namespace-resources-data-sources) is a direct mapping to the state
-of the resource. 
+of the resource.
 
 The map is a complex representation of these values with data going as far down
 as needed to represent any state values such as maps, lists, and sets.


### PR DESCRIPTION
This bit me when I was trying to read these docs - they all have
the same title, so I couldn't tell which tab was which. 😩
I fixed the stuff in the top level of the Sentinel folder a while back,
but missed these.