### PR TITLE
Locking Updates

### DIFF
--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -589,6 +589,18 @@ This endpoint locks a workspace.
 | --------------- | ----------------------------------------------------------------------------------------------------------- |
 | `:workspace_id` | The workspace ID to lock. Obtain this from the [workspace settings](../workspaces/settings.html) or the [Show Workspace](#show-workspace) endpoint. |
 
+Status  | Response                                     | Reason(s)
+--------|----------------------------------------------|----------
+[200][] | [JSON API document][] (`type: "workspaces"`) | Successfully locked the workspace
+[404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
+[409][] | [JSON API error object][]                    | Workspace already locked by another entity
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 ### Request Body
 
 This POST endpoint requires a JSON object with the following properties as a request payload.
@@ -675,6 +687,16 @@ This endpoint unlocks a workspace.
 | --------------- | ------------------------------------------------------------------------------------------------------------- |
 | `:workspace_id` | The workspace ID to unlock. Obtain this from the [workspace settings](../workspaces/settings.html) or the [Show Workspace](#show-workspace) endpoint. |
 
+Status  | Response                                     | Reason(s)
+--------|----------------------------------------------|----------
+[200][] | [JSON API document][] (`type: "workspaces"`) | Successfully unlocked the workspace
+[404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 ### Sample Request
 
 ```shell
@@ -720,6 +742,73 @@ $ curl \
   }
 }
 ```
+
+## Force Unlock a workspace
+
+This endpoint force unlocks a workspace. Only users with admin access are authorized to force unlock a workspace.
+
+`POST /workspaces/:workspace_id/actions/force-unlock`
+
+| Parameter       | Description                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `:workspace_id` | The workspace ID to force unlock. Obtain this from the [workspace settings](../workspaces/settings.html) or the [Show Workspace](#show-workspace) endpoint. |
+
+Status  | Response                                     | Reason(s)
+--------|----------------------------------------------|----------
+[200][] | [JSON API document][] (`type: "workspaces"`) | Successfully force unlocked the workspace
+[404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/workspaces/ws-SihZTyXKfNXUWuUa/actions/force-unlock
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "auto-apply": false,
+      "can-queue-destroy-plan": false,
+      "created-at": "2017-11-02T23:23:53.765Z",
+      "environment": "default",
+      "locked": false,
+      "name": "workspace-2",
+      "permissions": {
+        "can-destroy": true,
+        "can-lock": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-update": true,
+        "can-update-variable": true
+      },
+      "terraform-version": "0.10.8",
+      "vcs-repo": {
+        "branch": "",
+        "identifier": "my-organization/my-repository",
+        "ingress-submodules": false,
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ"
+      },
+      "working-directory": null
+    },
+    "id": "ws-SihZTyXKfNXUWuUa",
+    "type": "workspaces"
+  }
+}
+```
+
 
 ## Assign an SSH key to a workspace
 

--- a/content/source/docs/enterprise/workspaces/settings.html.md
+++ b/content/source/docs/enterprise/workspaces/settings.html.md
@@ -73,6 +73,8 @@ After changing this setting, you must click the "Update SSH key" button below it
 
 If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents users with write access from manually queueing runs, prevents automatic runs due to changes to the backing VCS repo, and prevents the creation of runs via the API. To enable runs again, a user must unlock the workspace.
 
+Users with write access are permitted to lock an unlocked workspace; however, they are not allowed to unlock a workspace if another user locked it. Users with admin privileges are able to force unlock a workspace if another user has locked it.
+
 Locks are managed with a single "Lock/Unlock `<WORKSPACE NAME>`" button. TFE asks for confirmation when unlocking.
 
 ~> **Important:** Locking a workspace prevents runs within TFE, but it **does not** prevent state from being updated. This means a user with write access can still modify the workspace's resources by running Terraform outside TFE with [the `atlas` remote backend](/docs/backends/types/terraform-enterprise.html). To prevent confusion and accidents, avoid using the `atlas` backend in normal workflows; to perform runs from the command line, see [TFE's CLI-driven workflow](../run/cli.html).

--- a/content/source/docs/enterprise/workspaces/settings.html.md
+++ b/content/source/docs/enterprise/workspaces/settings.html.md
@@ -73,7 +73,7 @@ After changing this setting, you must click the "Update SSH key" button below it
 
 If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents users with write access from manually queueing runs, prevents automatic runs due to changes to the backing VCS repo, and prevents the creation of runs via the API. To enable runs again, a user must unlock the workspace.
 
-Users with write access are permitted to lock an unlocked workspace; however, they are not allowed to unlock a workspace if another user locked it. Users with admin privileges are able to force unlock a workspace if another user has locked it.
+Users with write access are permitted to lock and unlock a workspace. However, they can't unlock a workspace which was locked by another user. Users with admin privileges can force unlock a workspace even if another user has locked it.
 
 Locks are managed with a single "Lock/Unlock `<WORKSPACE NAME>`" button. TFE asks for confirmation when unlocking.
 

--- a/content/source/docs/enterprise/workspaces/settings.html.md
+++ b/content/source/docs/enterprise/workspaces/settings.html.md
@@ -73,9 +73,9 @@ After changing this setting, you must click the "Update SSH key" button below it
 
 If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents users with write access from manually queueing runs, prevents automatic runs due to changes to the backing VCS repo, and prevents the creation of runs via the API. To enable runs again, a user must unlock the workspace.
 
-Users with write access are permitted to lock and unlock a workspace. However, they can't unlock a workspace which was locked by another user. Users with admin privileges can force unlock a workspace even if another user has locked it.
+Users with write access can lock and unlock a workspace, but can't unlock a workspace which was locked by another user. Users with admin privileges can force unlock a workspace even if another user has locked it.
 
-Locks are managed with a single "Lock/Unlock `<WORKSPACE NAME>`" button. TFE asks for confirmation when unlocking.
+Locks are managed with a single "Lock/Unlock/Force unlock `<WORKSPACE NAME>`" button. TFE asks for confirmation when unlocking.
 
 ~> **Important:** Locking a workspace prevents runs within TFE, but it **does not** prevent state from being updated. This means a user with write access can still modify the workspace's resources by running Terraform outside TFE with [the `atlas` remote backend](/docs/backends/types/terraform-enterprise.html). To prevent confusion and accidents, avoid using the `atlas` backend in normal workflows; to perform runs from the command line, see [TFE's CLI-driven workflow](../run/cli.html).
 


### PR DESCRIPTION
[This TFE PR](https://github.com/hashicorp/atlas/pull/7106) adds force unlocking to the UI and alters some permissions around locking. More locking changes are coming soon, but this documentation update matches the above TFE PR.

Updated description for workspace settings related to locking:
<img width="916" alt="screen shot 2018-11-28 at 3 48 26 pm" src="https://user-images.githubusercontent.com/1569876/49181332-16672c80-f325-11e8-9c10-695c102484b5.png">

Added response details for the `lock` endpoint:
![screenshot-localhost-4567-2018 11 28-12-49-20](https://user-images.githubusercontent.com/1569876/49171577-d300c400-f30c-11e8-95ef-09f36d357703.png)

Added response details for the `unlock` endpoint:
![screenshot-localhost-4567-2018 11 28-12-50-57](https://user-images.githubusercontent.com/1569876/49171597-dbf19580-f30c-11e8-99eb-d30a4df25c65.png)

Added the `force-unlock` endpoint:
![screenshot-localhost-4567-2018 11 28-12-51-51](https://user-images.githubusercontent.com/1569876/49171609-e1e77680-f30c-11e8-8028-d1a2d5233cc5.png)
