### PR TITLE
Add 409 response to unlock endpoint

### DIFF
--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -691,9 +691,11 @@ Status  | Response                                     | Reason(s)
 --------|----------------------------------------------|----------
 [200][] | [JSON API document][] (`type: "workspaces"`) | Successfully unlocked the workspace
 [404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
+[409][] | [JSON API error object][]                    | Unable to unlock workspace
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
 [JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 


### PR DESCRIPTION
[This TFE PR](https://github.com/hashicorp/atlas/pull/7119) adjusts the unlock endpoint so that it responds `409 CONFLICT` if a user who doesn't hold the lock tries to use the `/unlock` endpoint.

Added 409 response:
![screenshot-localhost-4567-2018 11 28-17-19-14](https://user-images.githubusercontent.com/1569876/49186148-c93d8780-f331-11e8-91b8-686b3402df07.png)
