### PR TITLE
Add note for replicatedctl location

### DIFF
--- a/content/source/docs/enterprise/private/automated-recovery.html.md
+++ b/content/source/docs/enterprise/private/automated-recovery.html.md
@@ -48,7 +48,7 @@ as the snapshots contain only configuration data, not application data.
 
 ## Version Checking
 
-> Note: replicatedctl is located at `/usr/local/bin/replicatedctl`. On some operating systems, `/usr/local/bin` is not part of the local shell. In these cases, you should either add `/usr/local/bin` to your path or refer to `replicatedctl` with the full path
+-> **Note**: `replicatedctl` is located at `/usr/local/bin/replicatedctl`. On some operating systems, `/usr/local/bin` is not in the user's `$PATH`. In these cases, either add `/usr/local/bin` to the path or refer to `replicatedctl` with the full path.
 
 Using the restore mechanism requires Replicated version 2.17.0 or greater.
 You can check the version using `replicatedctl version`.

--- a/content/source/docs/enterprise/private/automated-recovery.html.md
+++ b/content/source/docs/enterprise/private/automated-recovery.html.md
@@ -48,6 +48,8 @@ as the snapshots contain only configuration data, not application data.
 
 ## Version Checking
 
+> Note: replicatedctl is located at `/usr/local/bin/replicatedctl`. On some operating systems, `/usr/local/bin` is not part of the local shell. In these cases, you should either add `/usr/local/bin` to your path or refer to `replicatedctl` with the full path
+
 Using the restore mechanism requires Replicated version 2.17.0 or greater.
 You can check the version using `replicatedctl version`.
 

--- a/content/source/docs/enterprise/private/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/private/automating-the-installer.html.md
@@ -45,6 +45,9 @@ The settings file is JSON formatted. All values must be strings.  The example be
 
 One the easiest ways to get the settings is to [perform a manual install](./install-installer.html#installation) and configure all the settings how you want them. Then you can ssh in and request the settings in JSON format and use that file in a future automated install.
 
+
+> Note: replicatedctl is located at `/usr/local/bin/replicatedctl`. On some operating systems, `/usr/local/bin` is not part of the local shell. In these cases, you should either add `/usr/local/bin` to your path or refer to `replicatedctl` with the full path
+
 To extract the settings as JSON, run via ssh on the instance:
 
 ```

--- a/content/source/docs/enterprise/private/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/private/automating-the-installer.html.md
@@ -45,8 +45,7 @@ The settings file is JSON formatted. All values must be strings.  The example be
 
 One the easiest ways to get the settings is to [perform a manual install](./install-installer.html#installation) and configure all the settings how you want them. Then you can ssh in and request the settings in JSON format and use that file in a future automated install.
 
-
-> Note: replicatedctl is located at `/usr/local/bin/replicatedctl`. On some operating systems, `/usr/local/bin` is not part of the local shell. In these cases, you should either add `/usr/local/bin` to your path or refer to `replicatedctl` with the full path
+-> **Note**: `replicatedctl` is located at `/usr/local/bin/replicatedctl`. On some operating systems, `/usr/local/bin` is not in the user's `$PATH`. In these cases, either add `/usr/local/bin` to the path or refer to `replicatedctl` with the full path.
 
 To extract the settings as JSON, run via ssh on the instance:
 


### PR DESCRIPTION
* it’s happened enough times that we might
as well put it in the docs :dancer: