### PR TITLE
Update RHEL Guide to Include a warning about 1.13.1

### DIFF
--- a/content/source/docs/enterprise/private/rhel-install-guide.html.md
+++ b/content/source/docs/enterprise/private/rhel-install-guide.html.md
@@ -21,6 +21,16 @@ This install guide is specifically for users of Private Terraform Enterprise ins
    * A system capable of using overlay2. The requires at least kernel version 3.10.0-693 and, if XFS is being used, the flag ftype=1. The full documentation on this configuration is at: https://docs.docker.com/storage/storagedriver/overlayfs-driver/
    * If using Docker from RHEL Extras, storage can be configured using the `docker-storage-setup` command
 
+**Note:** Using `docker-1.13.1-84.git07f3374.el7.x86_64` will result in an RPC error as well as 502 errors and inability to use the application. 
+
+#### Pinning the Docker Version
+
+If docker-1.13.1-84.git07f3374.el7.x86_64 is already installed, first run:
+
+```sudo yum downgrade docker docker-client docker-common docker-rhel-push-plugin```
+
+Then, restart Docker and ensure the installed version changes to 1.13.1-72.git6f36bd4el7.x86_64. To pin the version and prevent an inadvertent upgrade, follow [this guide](https://access.redhat.com/solutions/98873)from RedHat.
+
 ## Mandatory Configuration
 
 If you opt to use Docker from RHEL extras, then you must make a change to its default configuration to avoid hitting an out of memory bug.

--- a/content/source/docs/enterprise/private/rhel-install-guide.html.md
+++ b/content/source/docs/enterprise/private/rhel-install-guide.html.md
@@ -23,7 +23,6 @@ This install guide is specifically for users of Private Terraform Enterprise ins
 
 **Note:** Using `docker-1.13.1-84.git07f3374.el7.x86_64` will result in an RPC error as well as 502 errors and inability to use the application. 
 
-<<<<<<< HEAD
 #### Pinning the Docker Version
 
 If docker-1.13.1-84.git07f3374.el7.x86_64 is already installed, first run:
@@ -31,25 +30,6 @@ If docker-1.13.1-84.git07f3374.el7.x86_64 is already installed, first run:
 ```sudo yum downgrade docker docker-client docker-common docker-rhel-push-plugin```
 
 Then, restart Docker and ensure the installed version changes to 1.13.1-72.git6f36bd4el7.x86_64. To pin the version and prevent an inadvertent upgrade, follow [this guide](https://access.redhat.com/solutions/98873)from RedHat.
-=======
-
-#### Workaround
-
-To work around the issue, we recommend running the following on the PTFE server to downgrade docker and related packages to `1.13.1-72.git6f36bd4el7.x86_64`: 
-
-
-```sudo yum downgrade docker docker-client docker-common docker-rhel-push-plugin```
-
-
-Once the above command is run the customer should restart Docker, restart PTFE and be back up and running. 
-
-
-#### Prevention
-
-To avoid the issue or prevent a recurrence, follow [this guide](https://access.redhat.com/solutions/98873) from RedHat to pin the Docker package versions so that they are not inadvertently upgraded.
-
-
->>>>>>> 36ce8acaf... include warning for docker bug
 
 ## Mandatory Configuration
 

--- a/content/source/docs/enterprise/private/rhel-install-guide.html.md
+++ b/content/source/docs/enterprise/private/rhel-install-guide.html.md
@@ -23,6 +23,7 @@ This install guide is specifically for users of Private Terraform Enterprise ins
 
 **Note:** Using `docker-1.13.1-84.git07f3374.el7.x86_64` will result in an RPC error as well as 502 errors and inability to use the application. 
 
+<<<<<<< HEAD
 #### Pinning the Docker Version
 
 If docker-1.13.1-84.git07f3374.el7.x86_64 is already installed, first run:
@@ -30,6 +31,25 @@ If docker-1.13.1-84.git07f3374.el7.x86_64 is already installed, first run:
 ```sudo yum downgrade docker docker-client docker-common docker-rhel-push-plugin```
 
 Then, restart Docker and ensure the installed version changes to 1.13.1-72.git6f36bd4el7.x86_64. To pin the version and prevent an inadvertent upgrade, follow [this guide](https://access.redhat.com/solutions/98873)from RedHat.
+=======
+
+#### Workaround
+
+To work around the issue, we recommend running the following on the PTFE server to downgrade docker and related packages to `1.13.1-72.git6f36bd4el7.x86_64`: 
+
+
+```sudo yum downgrade docker docker-client docker-common docker-rhel-push-plugin```
+
+
+Once the above command is run the customer should restart Docker, restart PTFE and be back up and running. 
+
+
+#### Prevention
+
+To avoid the issue or prevent a recurrence, follow [this guide](https://access.redhat.com/solutions/98873) from RedHat to pin the Docker package versions so that they are not inadvertently upgraded.
+
+
+>>>>>>> 36ce8acaf... include warning for docker bug
 
 ## Mandatory Configuration
 


### PR DESCRIPTION
We learned this yesterday that there is a blocking issue for customers who may upgrade the Docker version on their RHEL installations of PTFE or install on a new instance with the latest version. 

This update publishes a workaround and prevention steps for this issue. 
