### PR TITLE
Redirects for the old AzureRM auth pages

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -129,5 +129,10 @@
 /docs/providers/aws/r/code_commit_repository.html      /docs/providers/aws/r/codecommit_repository.html
 /docs/providers/aws/r/code_commit_trigger.html         /docs/providers/aws/r/codecommit_trigger.html
 
+# Azure Provider
+/docs/providers/azurerm/authenticating_via_service_principal.html /docs/providers/azurerm/auth/service_principal_client_secret.html
+/docs/providers/azurerm/authenticating_via_azure_cli.html         /docs/providers/azurerm/auth/azure_cli.html
+/docs/providers/azurerm/authenticating_via_msi.html               /docs/providers/azurerm/auth/managed_service_identity.html
+
 # Fixing terraform-provider-google#2197
 /docs/provider/google/provider_versions.html          /docs/providers/google/provider_versions.html


### PR DESCRIPTION
Needs to be merged after https://github.com/terraform-providers/terraform-provider-azurerm/pull/2471 / AzureRM 1.20 has shipped