### PR TITLE
Update docs for state uploads with locked workspaces

### DIFF
--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -16,9 +16,7 @@ sidebar_current: "docs-enterprise2-api-state-versions"
 | --------------- | --------------------------------------------------------- |
 | `:workspace_id` | The workspace ID to create the new state version in. Obtain this from the [workspace settings](../workspaces/settings.html) or the [Show Workspace](./workspaces.html#show-workspace) endpoint. |
 
-Creates a state version and sets it as the current state version for the given
-workspace. This is most useful for migrating existing state from open source
-Terraform into a new TFE workspace.
+Creates a state version and sets it as the current state version for the given workspace. The workspace must be locked by the user creating a state version. This is most useful for migrating existing state from open source Terraform into a new TFE workspace.
 
 !> **Warning:** Use caution when uploading state to workspaces that have already performed Terraform runs. Replacing state improperly can result in orphaned or duplicated infrastructure resources.
 

--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -16,7 +16,7 @@ sidebar_current: "docs-enterprise2-api-state-versions"
 | --------------- | --------------------------------------------------------- |
 | `:workspace_id` | The workspace ID to create the new state version in. Obtain this from the [workspace settings](../workspaces/settings.html) or the [Show Workspace](./workspaces.html#show-workspace) endpoint. |
 
-Creates a state version and sets it as the current state version for the given workspace. The workspace must be locked by the user creating a state version. This is most useful for migrating existing state from open source Terraform into a new TFE workspace.
+Creates a state version and sets it as the current state version for the given workspace. The workspace must be locked by the user creating a state version. The workspace may be locked [with the API](./workspaces.html#lock-a-workspace) or [with the UI](../workspaces/settings.html#workspace-lock). This is most useful for migrating existing state from open source Terraform into a new TFE workspace.
 
 !> **Warning:** Use caution when uploading state to workspaces that have already performed Terraform runs. Replacing state improperly can result in orphaned or duplicated infrastructure resources.
 

--- a/content/source/docs/enterprise/workspaces/settings.html.md
+++ b/content/source/docs/enterprise/workspaces/settings.html.md
@@ -73,13 +73,15 @@ After changing this setting, you must click the "Update SSH key" button below it
 
 If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents users with write access from manually queueing runs, prevents automatic runs due to changes to the backing VCS repo, and prevents the creation of runs via the API. To enable runs again, a user must unlock the workspace.
 
-Locking a workspace also restricts state uploads. In order to upload state, the workspace must be locked by the user who is uploading state. Note that the atlas backend does not respect this restriction, so state uploads when using the atlas backend are still allowed when the workspace is locked.
+Locking a workspace also restricts state uploads. In order to upload state, the workspace must be locked by the user who is uploading state. 
+
+~> **Important:** [The `atlas` backend][atlas-backend] ignores this restriction, and allows users with write access to modify state when the workspace is locked. To prevent confusion and accidents, avoid using the `atlas` backend in normal workflows and use the `remote` backend instead; see [TFE's CLI-driven workflow](../run/cli.html) for details.
+
+[atlas-backend]: /docs/backends/types/terraform-enterprise.html
 
 Users with write access can lock and unlock a workspace, but can't unlock a workspace which was locked by another user. Users with admin privileges can force unlock a workspace even if another user has locked it.
 
 Locks are managed with a single "Lock/Unlock/Force unlock `<WORKSPACE NAME>`" button. TFE asks for confirmation when unlocking.
-
-~> **Important:** Locking a workspace prevents runs within TFE, but it **does not** prevent state from being updated when using the atlas backend. This means a user with write access can still modify the workspace's resources by running Terraform outside TFE with [the `atlas` remote backend](/docs/backends/types/terraform-enterprise.html). To prevent confusion and accidents, avoid using the `atlas` backend in normal workflows; to perform runs from the command line, see [TFE's CLI-driven workflow](../run/cli.html).
 
 ### Workspace Delete
 

--- a/content/source/docs/enterprise/workspaces/settings.html.md
+++ b/content/source/docs/enterprise/workspaces/settings.html.md
@@ -73,11 +73,13 @@ After changing this setting, you must click the "Update SSH key" button below it
 
 If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents users with write access from manually queueing runs, prevents automatic runs due to changes to the backing VCS repo, and prevents the creation of runs via the API. To enable runs again, a user must unlock the workspace.
 
+Locking a workspace also restricts state uploads. In order to upload state, the workspace must be locked by the user who is uploading state. Note that the atlas backend does not respect this restriction, so state uploads when using the atlas backend are still allowed when the workspace is locked.
+
 Users with write access can lock and unlock a workspace, but can't unlock a workspace which was locked by another user. Users with admin privileges can force unlock a workspace even if another user has locked it.
 
 Locks are managed with a single "Lock/Unlock/Force unlock `<WORKSPACE NAME>`" button. TFE asks for confirmation when unlocking.
 
-~> **Important:** Locking a workspace prevents runs within TFE, but it **does not** prevent state from being updated. This means a user with write access can still modify the workspace's resources by running Terraform outside TFE with [the `atlas` remote backend](/docs/backends/types/terraform-enterprise.html). To prevent confusion and accidents, avoid using the `atlas` backend in normal workflows; to perform runs from the command line, see [TFE's CLI-driven workflow](../run/cli.html).
+~> **Important:** Locking a workspace prevents runs within TFE, but it **does not** prevent state from being updated when using the atlas backend. This means a user with write access can still modify the workspace's resources by running Terraform outside TFE with [the `atlas` remote backend](/docs/backends/types/terraform-enterprise.html). To prevent confusion and accidents, avoid using the `atlas` backend in normal workflows; to perform runs from the command line, see [TFE's CLI-driven workflow](../run/cli.html).
 
 ### Workspace Delete
 


### PR DESCRIPTION
State uploads via the v2 api now require that the workspace be locked by the user requesting state upload.

See: https://github.com/hashicorp/atlas/pull/7155