### PR TITLE
Switch Google docs to google-beta repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,7 +100,7 @@
 	branch = stable-website
 [submodule "ext/providers/google"]
 	path = ext/providers/google
-	url = https://github.com/terraform-providers/terraform-provider-google
+	url = https://github.com/terraform-providers/terraform-provider-google-beta
 	branch = stable-website
 [submodule "ext/providers/grafana"]
 	path = ext/providers/grafana


### PR DESCRIPTION
Because of the way autogeneration works, the most complete version of
the docs are held in the terraform-provider-google-beta repository, but
we want them published _as if_ they were in the
terraform-provider-google repository.

The most straightforward way to do this is to just change the source
repo for the submodule.

We know this won't work forever, and the providers in the registry phase
3 (when partner providers are moved over) will require this strategy to
be shifted, but this is the most straightforward path until that
happens, and we can pick a new path when it does.