### PR TITLE
Switch to recommended filter action.

### DIFF
--- a/content/source/docs/github-actions/directories.html.md
+++ b/content/source/docs/github-actions/directories.html.md
@@ -19,8 +19,8 @@ workflow "terraform-dir1" {
 }
 
 action "filter-to-pr-open-synced" {
-  uses = "docker://superbbears/filter:0.2.0"
-  args = ["action", "opened|synchronize"]
+  uses = "actions/bin/filter@master"
+  args = ["action", "'opened|synchronize'"]
 }
 
 action "terraform-fmt-dir1" {

--- a/content/source/docs/github-actions/getting-started/index.html.md
+++ b/content/source/docs/github-actions/getting-started/index.html.md
@@ -38,8 +38,8 @@ Terraform's GitHub Actions on new and updated pull requests.
     }
 
     action "filter-to-pr-open-synced" {
-      uses = "docker://superbbears/filter:0.2.0"
-      args = ["action", "opened|synchronize"]
+      uses = "actions/bin/filter@master"
+      args = ["action", "'opened|synchronize'"]
     }
 
     action "terraform-fmt" {

--- a/content/source/docs/github-actions/workspaces.html.md
+++ b/content/source/docs/github-actions/workspaces.html.md
@@ -25,8 +25,8 @@ workflow "terraform-workspace2" {
 }
 
 action "filter-to-pr-open-synced" {
-  uses = "docker://superbbears/filter:0.2.0"
-  args = ["action", "opened|synchronize"]
+  uses = "actions/bin/filter@master"
+  args = ["action", "'opened|synchronize'"]
 }
 
 action "terraform-fmt" {


### PR DESCRIPTION
The superbbears/filter action was created before GitHub actions launched
and that Docker image is no longer published. Also change the arguments
to add single quotes as that is now required.