### PR TITLE
reconcile the two descriptions of non-SSO admins for SAML

### DIFF
--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -21,10 +21,7 @@ Private Terraform Enterprise (PTFE) is configured as the Service Provider.
 
 ~> **Important:** Only PTFE users with the site-admin permission can modify SAML settings. For more information about site admins, see [Administering Private Terraform Enterprise][admin].
 
-Prior to activating SAML, we recommend that you create a TFE user who has:
-
-* The site-admin permission
-* An email address that will never be used for any SAML user
+Prior to activating SAML, we recommend that you create a [non-SSO admin account for recovery](./troubleshooting.html#create-a-non-sso-admin-account-for-recovery).
 
 In case of any issues during SAML configuration, this ensures that there will be an admin able to log in and make necessary adjustments.
 

--- a/content/source/docs/enterprise/saml/troubleshooting.html.md
+++ b/content/source/docs/enterprise/saml/troubleshooting.html.md
@@ -14,7 +14,9 @@ Before starting, disable SAML SSO by going to `https://<TFE HOSTNAME>/app/admin/
 
 ## Create a non-SSO admin account for recovery
 
-Before proceeding with troubleshooting, create a non-SSO admin account that can be used to log in if admin access gets revoked for other admins. Open `https://<TFE HOSTNAME>/account/new` to create the account. Make sure to grant admin access to this user and verify they can log in at `https://<TFE HOSTNAME>/`.
+Before proceeding with troubleshooting, create a non-SSO admin account that can be used to log in if admin access gets revoked for other admins. The email address assigned to this user should not be one that will be used for SAML.
+
+Open `https://<TFE HOSTNAME>/account/new` to create the account. Make sure to grant admin access to this user and verify they can log in at `https://<TFE HOSTNAME>/`.
 
 ## Enable SAML SSO and SAML debugging
 


### PR DESCRIPTION
I vaguely knew we had something about this when I added the more recent one on the setup page, but I haven't got around to unifying them til now.