### PR TITLE
Updates around external vault

### DIFF
--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -164,7 +164,8 @@ note an additional restriction on the `sslmode` parameter is that only the
 
 ### External Vault Option
 
-If you choose to run the instance in the Production operational mode, during the installation, you can also choose to use an external Vault cluster, rather than the default internal Vault provided by PTFE.
+If you already manage your own Vault cluster, you can choose to use it in Production 
+operational mode, rather than the default internal Vault provided by PTFE.
 
 ~> **Note:** This option is also selected at initial installation, and cannot be changed later.
 

--- a/content/source/docs/enterprise/private/reliability-availability.html.md
+++ b/content/source/docs/enterprise/private/reliability-availability.html.md
@@ -147,7 +147,7 @@ of the user.
 |-------------------|---------------|-------|------------|--------------|
 | Demo              | PTFE          | PTFE  | PTFE       | PTFE         |
 | Mounted Disk      | PTFE          | PTFE  | User       | User         |
-| External Services | PTFE          | User  | User       | User         |
+| External Services | PTFE          | PTFE  | User       | User         |
 | External Vault    | -             | User  | -          | -            |
 
 ### Demo
@@ -171,9 +171,13 @@ _PostgreSQL Database_ and _Blob Storage_ use mounted disks for their
 data. Backup and restore of those volumes is the responsibility of the user, and
 is not managed by PTFE's built-in systems.
 
-_Configuration Data_ and _Vault Data_ for the installation are stored in Docker
+_Vault Data_ is stored in PostgreSQL and accordingly lives on the mounted disk. As
+long as the user has restored the mounted disk successively, the built-in restore 
+mechanism will restore Vault operations in the event of a failure.
+
+_Configuration Data_ for the installation is stored in Docker
 volumes on the instance. The built-in snapshot mechanism can package up the
-Configuration and Vault data and store it off the instance, and the built-in restore
+Configuration data and store it off the instance, and the built-in restore
 mechanism can recover the configuration data and restore
 operation in the event of a failure.
 Configure snapshot and restore by following the [automated recovery instructions](./automated-recovery.html).
@@ -186,21 +190,26 @@ means no state data is lost.
 In the External Services mode of the Installer Architecture, the
 **Application Layer** and **Coordination Layer** execute on a Linux instance,
 but the **Storage Layer** is configured to use external services in the form of
-a PostgreSQL server, an S3-compatible Blob Storage, and optionally an
-[external Vault](./vault.html).
+a PostgreSQL server and an S3-compatible Blob Storage.
 
-The maintenance of PostgreSQL, Blob Storage, and Vault are handled by the user,
+The maintenance of PostgreSQL and Blob Storage are handled by the user,
 which includes backing up and restoring if necessary.
+
+_Vault Data_ is stored in PostgreSQL. As long as PostgreSQL has been restored
+successively by the user, the built-in restore mechanism will restore Vault 
+operations in the event of a failure.
 
 _Configuration Data_ for the installation is stored in Docker
 volumes on the instance. The built-in snapshot mechanism can package up the
-Configuration and Vault data and store it off the instance, and the built-in restore
-mechanism can recover the configuration data and restore
-operation in the event of a failure.
+data and store it off the instance, and the built-in restore
+mechanism can recover the data and restore operation in the event of a failure.
 Configure snapshot and restore by following the [automated recovery instructions](./automated-recovery.html).
 
 If the instance running Terraform Enterprise is lost, the use of
 external services means no state data is lost.
+
+-> **NOTE:** Customers running an [optional external vault cluster](./vault.html) are 
+responsible for backing up the data and restoring it if necessary. 
 
 ### Availability During Upgrades
 

--- a/content/source/docs/enterprise/private/vault.html.md
+++ b/content/source/docs/enterprise/private/vault.html.md
@@ -6,24 +6,21 @@ sidebar_current: "docs-enterprise2-private-installer-vault"
 
 # Private Terraform Enterprise Externally Managed Vault
 
-Private Terraform Enterprise (PTFE) can be configured to use an external Vault cluster
-rather than the internal Vault instance. Within PTFE, Vault is used to
-encrypt sensitive information such as variables and states.
+For enhanced security, Private Terraform Enterprise (PTFE) can be configured to use an external 
+Vault cluster rather than the internal Vault instance. Within PTFE, Vault is 
+used to encrypt sensitive information such as variables and states.
 
-An external Vault cluster allows the customer to have full control over how
-the Vault cluster is managed, for example how it is sealed and unsealed, replicated, etc.
+!> **Warning**: This is only recommended if you currently run your own Vault cluster in production. Choosing this option means you assume full responsibility for how the Vault cluster is managed, 
+for example how it is sealed and unsealed, replicated, etc.
 
-When an external Vault cluster is configured along with the External Services installation mode,
-Private Terraform Enterprise becomes fully stateless and can be run in a hot-standby
-configuration to provide failover.
-
--> **NOTE:** The external Vault option must be selected at initial installation, and cannot be changed later.
-Do not attempt to migrate an existing Terraform Enterprise instance between internal and external
-Vault options.
 
 ## Setup
 
 Use the following as a guide to configure an external Vault instance:
+
+-> **Note:** The external Vault option must be selected at initial installation, and cannot be changed later.
+Do not attempt to migrate an existing Terraform Enterprise instance between internal and external
+Vault options.
 
 1. Enable AppRole: `vault auth enable approle`
 1. Enable transit: `vault secrets enable transit`


### PR DESCRIPTION
We no longer need external Vault for reliability, so downplaying it through the docs. This update:

- removes mentions of needing external vault for stateless installation
- adds warning to external vault page so casual users don't follow the path
- updates out of date docs around backup/restore responsibilities 