### PR TITLE
Add `terraform-init` action to credential configuration

### DIFF
--- a/content/source/docs/github-actions/actions/init.html.md
+++ b/content/source/docs/github-actions/actions/init.html.md
@@ -48,6 +48,12 @@ The `GITHUB_TOKEN` secret is required for posting a comment back to the pull req
 
 If you have set `TF_ACTION_COMMENT = "false"`, then `GITHUB_TOKEN` is not required.
 
+* You may also need to add secrets for your providers, like `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` or `GOOGLE_CREDENTIALS`,
+if you're using a Terraform feature that uses them during `init` (such as Remote State).
+
+  !> **⚠️ WARNING ⚠️** These secrets could be exposed if the `plan` action is run on a malicious Terraform file.
+  To avoid this, we recommend you do not use this action on public repos or repos where untrusted users can submit pull requests.
+
 ## Arguments
 
 Arguments to `init` will be appended to the `terraform init` command:
@@ -58,4 +64,3 @@ action "terraform init" {
   args = ["-lock=false"]
 }
 ```
-

--- a/content/source/docs/github-actions/getting-started/index.html.md
+++ b/content/source/docs/github-actions/getting-started/index.html.md
@@ -107,17 +107,18 @@ Terraform's GitHub Actions on new and updated pull requests.
     If you have multiple workspaces, see [Workspaces](../workspaces.html).
 
 1. **Credentials** — If you're using a Terraform provider that requires
-    credentials to run `terraform plan` (like AWS or Google Cloud Platform)
-    then you need to add those credentials as secrets to the `terraform-plan` action.
-    Secrets can only be added from the **Visual Editor,** so switch to that tab.
+    credentials to run `terraform init` and `terraform plan` (like AWS or Google Cloud Platform)
+    then you need to add those credentials as secrets to the `terraform-init` and `terraform-plan`
+    actions. Secrets can be added from the **Visual Editor,** so switch to that tab.
 
     ![Visual Editor](./images/visual-editor.png)
 
-    Scroll down to the `terraform-plan` action and click **Edit**.
+    Scroll down to the `terraform-init` or `terraform-plan` actions and click **Edit**.
     This will open the action editor on the right side, where you'll be able
     to add your secrets as environment variables, like `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
     See your [provider documentation](https://www.terraform.io/docs/providers/)
-    for the specific environment variables your provider needs.
+    for the specific environment variables your provider needs. If you've already added 
+    these secrets to the repository, they will be available for selection.
 
     ![Add Secrets](./images/add-secrets.png)
 


### PR DESCRIPTION
My initial tests of the TF GitHub Actions against AWS required the credentials to be present in both the `terraform-init` and `terraform-plan` actions. Also removed "only" from the statement about adding Secrets because they can be added in the repository's settings.