### PR TITLE
add 'plan' as a valid option for TFE team access to workspace

### DIFF
--- a/content/source/docs/enterprise/api/team-access.html.md
+++ b/content/source/docs/enterprise/api/team-access.html.md
@@ -86,7 +86,7 @@ Properties without a default value are required.
 Key path                                 | Type   | Default | Description
 -----------------------------------------|--------|---------|------------
 `data.type`                              | string |         | Must be `"team-workspaces"`.
-`data.attributes.access`                 | string |         | The type of access to grant. Valid values are `read`, `write`, or `admin`.
+`data.attributes.access`                 | string |         | The type of access to grant. Valid values are `read`, `plan`, `write`, or `admin`.
 `data.relationships.workspace.data.type` | string |         | Must be `workspaces`.
 `data.relationships.workspace.data.id`   | string |         | The workspace ID to which the team is to be added.
 `data.relationships.team.data.type`      | string |         | Must be `teams`.


### PR DESCRIPTION
Update TFE API doc to include 'plan' access level as a valid option for adding team access. The [TFE Permissions](https://www.terraform.io/docs/enterprise/users-teams-organizations/permissions.html) documentation includes this option, and I've successfully tested an API call to grant a team this permission on a workspace (pTFE v201812-1).