### PR TITLE
add base software used in PTFE worker containers

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -127,6 +127,10 @@ FROM ubuntu:xenial
 
 # Inject the ssl certificates
 ADD ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Install software used by TFE
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sudo unzip daemontools git-core ssh wget curl psmisc iproute2 openssh-client redis-tools netcat-openbsd
 ```
 
 ## Operational Mode Decision


### PR DESCRIPTION
This adds the software we install to the sample Dockerfile, and should help people avoid non-starter runs on custom images.

I know from testing that the first four are definitely required for even the most basic runs; if there's some of the others that aren't absolutely necessary, I can remove those.