### PR TITLE
add instructions for proxy setting in replicated files

### DIFF
--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -58,6 +58,12 @@ On the Console Settings page, there is a section for HTTP Proxy:
 
 ![PTFE HTTP Proxy Settings](./assets/ptfe-http-proxy.png)
 
+This change updates the proxy settings for the PTFE application services. To update the proxy settings for the installer (for example, to handle configuration tests correctly), additional steps are necessary:
+
+1. Locate the Replicated configuration files on the instance under either `/etc/sysconfig/` or `/etc/default`: `replicated` and `replicated-operator`:
+1. Open the files for editing. On the line that includes `REPLICATED_OPTS`, add `-e HTTP_PROXY=<your proxy url> -e NO_PROXY=<list of no_proxy hosts>` (see above for formatting of the `NO_PROXY` hosts).
+1. Restart the replicated services following [the instructions for your distribution](https://help.replicated.com/docs/native/customer-installations/installing-via-script/#restarting-replicated).
+
 ## Trusting SSL/TLS Certificates
 
 There are two primary areas for SSL configuration in the installer.

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -60,8 +60,8 @@ On the Console Settings page, there is a section for HTTP Proxy:
 
 This change updates the proxy settings for the PTFE application services. To update the proxy settings for the installer (for example, to handle configuration tests correctly), additional steps are necessary:
 
-1. Locate the Replicated configuration files on the instance under either `/etc/sysconfig/` or `/etc/default`: `replicated` and `replicated-operator`:
-1. Open the files for editing. On the line that includes `REPLICATED_OPTS`, add `-e HTTP_PROXY=<your proxy url> -e NO_PROXY=<list of no_proxy hosts>` (see above for formatting of the `NO_PROXY` hosts).
+1. Locate the Replicated configuration files on the instance under either `/etc/sysconfig/` or `/etc/default`: `replicated` and `replicated-operator`.
+1. Open the files for editing. On the line that includes `REPLICATED_OPTS`, add `-e HTTP_PROXY=<your proxy url> -e NO_PROXY=<list of no_proxy hosts>` (see above for formatting of the `NO_PROXY` hosts) to the existing command options.
 1. Restart the replicated services following [the instructions for your distribution](https://help.replicated.com/docs/native/customer-installations/installing-via-script/#restarting-replicated).
 
 ## Trusting SSL/TLS Certificates


### PR DESCRIPTION
This has been a useful addition to provide to proxy users, so it's helpful to have it directly available.