### PR TITLE
sentinel: Update mocks to new >= v0.8.x format

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
@@ -22,115 +22,235 @@ documentation][ref-official-sentinel-documentation].
 [ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
 [ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
 
-#### Current mock limitations
+## Configuring Sentinel Simulator for Terraform Mocks
 
-* As functions cannot be mocked in the current Sentinel testing framework, the
-[module()][ref-module] function is not available. As a result, only root module
-data can be mocked at this time.
+Terraform mocks make use of the ability to provide mocks as Sentinel code,
+which requires Sentinel Simulator 0.8.0 or higher to use. To get the latest
+version of the simulator, see the [downloads page][ref-downloads-page].
 
-[ref-module]: /docs/enterprise/sentinel/import/tfconfig.html#function-module-
+[ref-downloads-page]: https://docs.hashicorp.com/sentinel/downloads
+
+These mocks are configured differently than JSON mocks: 
+
+* Save the contents below to a `.sentinel` file within your project directory.
+   The example below uses `mock-tfconfig.sentinel`.
+* Add the following to your Sentinel configuration file, example
+   `sentinel.json`:
 
 ```json
 {
   "mock": {
-    "tfconfig": {
-      "module_paths": [
-        [],
-        [
-          "foo"
-        ]
-      ],
-      "data": {
-        "null_data_source": {
-          "baz": {
-            "config": {
-              "inputs": [
-                {
-                  "bar_id": "${null_resource.bar.id}",
-                  "foo_id": "${null_resource.foo.id}"
-                }
-              ]
-            },
-            "provisioners": []
-          }
-        }
-      },
-      "modules": {
-        "foo": {
-          "config": {
-            "bar": "baz"
-          },
-          "source": "./foo"
-        }
-      },
-      "providers": {
-        "aws": {
-          "config": {},
-          "version": "~\u003e 1.34",
-          "alias": {
-            "east": {
-              "config": {
-                "region": "us-east-1"
-              },
-              "version": ""
-            }
-          }
-        },
-        "null": {
-          "config": {},
-          "version": "",
-          "alias": {}
-        }
-      },
-      "resources": {
-        "null_resource": {
-          "bar": {
-            "config": {
-              "triggers": [
-                {
-                  "foo_id": "${null_resource.foo.id}"
-                }
-              ]
-            },
-            "provisioners": []
-          },
-          "foo": {
-            "config": {
-              "triggers": [
-                {
-                  "foo": "bar"
-                }
-              ]
-            },
-            "provisioners": [
-              {
-                "config": {
-                  "command": "echo hello"
-                },
-                "type": "local-exec"
-              }
-            ]
-          }
-        }
-      },
-      "variables": {
-        "foo": {
-          "default": "bar",
-          "description": "foobar"
-        },
-        "map": {
-          "default": {
-            "foo": "bar",
-            "number": 42
-          },
-          "description": ""
-        },
-        "number": {
-          "default": "42",
-          "description": ""
-        }
-      }
-    }
+    "tfconfig": "mock-tfconfig.sentinel"
   }
 }
+```
+
+* Run the Sentinel Simulator:
+
+```
+sentinel apply -config=sentinel.json policy.sentinel
+```
+
+The above can be adjusted for use with `sentinel test` as well. As an example,
+assuming you save the mock to `test/shared/mock-tfconfig.sentinel`, and you are
+editing a `test/policy/pass.json` test case:
+
+```json
+{
+  "mock": {
+    "tfconfig": "../shared/mock-tfconfig.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+```
+
+More information on configuring mocks using Sentinel code can be found
+[here][ref-sentinel-mocking-with-sentinel-code].
+
+[ref-sentinel-mocking-with-sentinel-code]: https://docs.hashicorp.com/sentinel/commands/config#mocking-with-sentinel-code
+
+## Mock File Contents
+
+```python
+_root = {
+  "data": {
+    "null_data_source": {
+      "baz": {
+        "config": {
+          "inputs": [
+            {
+              "bar_id": "${null_resource.bar.id}",
+              "foo_id": "${null_resource.foo.id}",
+            },
+          ],
+        },
+        "provisioners": null,
+      },
+    },
+  },
+  "modules": {
+    "foo": {
+      "config": {
+        "bar": "baz",
+      },
+      "source":  "./foo",
+      "version": "",
+    },
+  },
+  "outputs": {
+    "foo": {
+      "depends_on":  [],
+      "description": "",
+      "sensitive":   true,
+      "value":       "bar",
+    },
+    "list": {
+      "depends_on":  [],
+      "description": "",
+      "sensitive":   false,
+      "value": [
+        "foo",
+        "bar",
+      ],
+    },
+    "map": {
+      "depends_on":  [],
+      "description": "",
+      "sensitive":   false,
+      "value": [
+        {
+          "foo":    "bar",
+          "number": 42,
+        },
+      ],
+    },
+    "string": {
+      "depends_on":  [],
+      "description": "",
+      "sensitive":   false,
+      "value":       "foo",
+    },
+  },
+  "providers": {
+    "aws": {
+      "alias": {
+        "east": {
+          "config": {
+            "region": "us-east-1",
+          },
+          "version": "",
+        },
+      },
+      "config":  {},
+      "version": "~> 1.34",
+    },
+    "null": {
+      "alias":   {},
+      "config":  {},
+      "version": "",
+    },
+  },
+  "resources": {
+    "null_resource": {
+      "bar": {
+        "config": {
+          "triggers": [
+            {
+              "foo_id": "${null_resource.foo.id}",
+            },
+          ],
+        },
+        "provisioners": null,
+      },
+      "foo": {
+        "config": {
+          "triggers": [
+            {
+              "foo": "bar",
+            },
+          ],
+        },
+        "provisioners": [
+          {
+            "config": {
+              "command": "echo hello",
+            },
+            "type": "local-exec",
+          },
+        ],
+      },
+    },
+  },
+  "variables": {
+    "foo": {
+      "default":     "bar",
+      "description": "foobar",
+    },
+    "map": {
+      "default": {
+        "foo":    "bar",
+        "number": 42,
+      },
+      "description": "",
+    },
+    "number": {
+      "default":     "42",
+      "description": "",
+    },
+  },
+}
+
+module_foo = {
+  "data":      {},
+  "modules":   {},
+  "outputs":   {},
+  "providers": {},
+  "resources": {
+    "null_resource": {
+      "foo": {
+        "config": {
+          "triggers": [
+            {
+              "foo": "bar",
+            },
+          ],
+        },
+        "provisioners": null,
+      },
+    },
+  },
+  "variables": {
+    "bar": {
+      "default":     null,
+      "description": "",
+    },
+  },
+}
+
+module_paths = [
+  [],
+  [
+    "foo",
+  ],
+]
+
+module = func(path) {
+  if length(path) == 0 {
+    return _root
+  }
+  if length(path) == 1 and path[0] is "foo" {
+    return module_foo
+  }
+
+  return undefined
+}
+
+data = _root.data
+modules = _root.modules
+providers = _root.providers
+resources = _root.resources
+variables = _root.variables
+outputs = _root.outputs
 ```

--- a/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfconfig.html.md
@@ -30,26 +30,26 @@ version of the simulator, see the [downloads page][ref-downloads-page].
 
 [ref-downloads-page]: https://docs.hashicorp.com/sentinel/downloads
 
-These mocks are configured differently than JSON mocks: 
+These mocks are configured differently than JSON mocks:
 
-* Save the contents below to a `.sentinel` file within your project directory.
-   The example below uses `mock-tfconfig.sentinel`.
+* Save the mock file contents below to a `.sentinel` file within your project
+  directory. The example below uses `mock-tfconfig.sentinel`.
 * Add the following to your Sentinel configuration file, example
-   `sentinel.json`:
+  `sentinel.json`:
 
-```json
-{
-  "mock": {
-    "tfconfig": "mock-tfconfig.sentinel"
-  }
-}
-```
+    ```json
+    {
+      "mock": {
+        "tfconfig": "mock-tfconfig.sentinel"
+      }
+    }
+    ```
 
 * Run the Sentinel Simulator:
 
-```
-sentinel apply -config=sentinel.json policy.sentinel
-```
+    ```
+    sentinel apply -config=sentinel.json policy.sentinel
+    ```
 
 The above can be adjusted for use with `sentinel test` as well. As an example,
 assuming you save the mock to `test/shared/mock-tfconfig.sentinel`, and you are

--- a/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
@@ -29,139 +29,223 @@ mock][ref-tfconfig-mock] and the [`tfstate` mock][ref-tfstate-mock].
 [ref-tfconfig-mock]: /docs/enterprise/sentinel/import/mock-tfconfig.html
 [ref-tfstate-mock]: /docs/enterprise/sentinel/import/mock-tfstate.html
 
-#### Current mock limitations
+## Configuring Sentinel Simulator for Terraform Mocks
 
-There are currently some limitations mocking `tfplan` data in Sentinel. These
-issues will be fixed in future releases of the import and core runtime.
+Terraform mocks make use of the ability to provide mocks as Sentinel code,
+which requires Sentinel Simulator 0.8.0 or higher to use. To get the latest
+version of the simulator, see the [downloads page][ref-downloads-page].
 
-* As functions cannot be mocked in the current Sentinel testing framework, the
-  [module()][ref-module] function is not available. As a result, only root
-  module data can be mocked at this time.
+[ref-downloads-page]: https://docs.hashicorp.com/sentinel/downloads
 
-[ref-module]: /docs/enterprise/sentinel/import/tfplan.html#function-module-
+These mocks are configured differently than JSON mocks: 
 
-* [Resource and data source][resource-and-data-source] count keys (`NUMBER` in
-  `TYPE.NAME[NUMBER]`), which are actually represented as integers, cannot be
-  represented accurately in JSON, and as a result, mocks that depend on count keys
-  explicitly (example: `tfplan.resources.null_resource.foo[0]`) will not work
-  properly with mocks.
-
-[resource-and-data-source]: /docs/enterprise/sentinel/import/tfplan.html#namespace-resources-data-sources
+* Save the contents below to a `.sentinel` file within your project directory.
+   The example below uses `mock-tfplan.sentinel`.
+* Add the following to your Sentinel configuration file, example
+   `sentinel.json`:
 
 ```json
 {
   "mock": {
-    "tfplan": {
-      "terraform_version": "0.11.7",
-      "variables": {
-        "foo": "bar",
-        "map": {
-          "foo": "bar",
-          "number": 42
-        },
-        "number": "42"
-      },
-      "module_paths": [
-        [],
-        [
-          "foo"
-        ]
-      ],
-      "path": [],
-      "data": {
-        "null_data_source": {
-          "baz": {
-            "0": {
-              "diff": {
-                "has_computed_default": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                },
-                "id": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                },
-                "inputs.%": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                },
-                "outputs.%": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                },
-                "random": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                }
-              },
-              "applied": {
-                "has_computed_default": "74D93920-ED26-11E3-AC10-0800200C9A66",
-                "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
-                "inputs": {},
-                "outputs": {},
-                "random": "74D93920-ED26-11E3-AC10-0800200C9A66"
-              }
-            }
-          }
-        }
-      },
-      "resources": {
-        "null_resource": {
-          "bar": {
-            "0": {
-              "diff": {
-                "id": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                },
-                "triggers.%": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                }
-              },
-              "applied": {
-                "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
-                "triggers": {}
-              }
-            }
-          },
-          "foo": {
-            "0": {
-              "diff": {
-                "id": {
-                  "old": "",
-                  "new": "",
-                  "computed": true
-                },
-                "triggers.%": {
-                  "old": "",
-                  "new": "1",
-                  "computed": false
-                },
-                "triggers.foo": {
-                  "old": "",
-                  "new": "bar",
-                  "computed": false
-                }
-              },
-              "applied": {
-                "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
-                "triggers": {
-                  "foo": "bar"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    "tfplan": "mock-tfplan.sentinel"
   }
 }
+```
+
+* Run the Sentinel Simulator:
+
+```
+sentinel apply -config=sentinel.json policy.sentinel
+```
+
+The above can be adjusted for use with `sentinel test` as well. As an example,
+assuming you save the mock to `test/shared/mock-tfplan.sentinel`, and you are
+editing a `test/policy/pass.json` test case:
+
+```json
+{
+  "mock": {
+    "tfplan": "../shared/mock-tfplan.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+```
+
+More information on configuring mocks using Sentinel code can be found
+[here][ref-sentinel-mocking-with-sentinel-code].
+
+[ref-sentinel-mocking-with-sentinel-code]: https://docs.hashicorp.com/sentinel/commands/config#mocking-with-sentinel-code
+
+## Mock File Contents
+
+```python
+_root = {
+  "data": {
+    "null_data_source": {
+      "baz": {
+        0: {
+          "applied": {
+            "has_computed_default": "74D93920-ED26-11E3-AC10-0800200C9A66",
+            "id":      "74D93920-ED26-11E3-AC10-0800200C9A66",
+            "inputs":  {},
+            "outputs": {},
+            "random":  "74D93920-ED26-11E3-AC10-0800200C9A66",
+          },
+          "diff": {
+            "has_computed_default": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "id": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "inputs.%": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "outputs.%": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "random": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+          },
+        },
+      },
+    },
+  },
+  "path": [],
+  "resources": {
+    "null_resource": {
+      "bar": {
+        0: {
+          "applied": {
+            "id":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+            "triggers": {},
+          },
+          "diff": {
+            "id": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "triggers.%": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+          },
+        },
+      },
+      "foo": {
+        0: {
+          "applied": {
+            "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+            "triggers": {
+              "foo": "bar",
+            },
+          },
+          "diff": {
+            "id": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "triggers.%": {
+              "computed": false,
+              "new":      "1",
+              "old":      "",
+            },
+            "triggers.foo": {
+              "computed": false,
+              "new":      "bar",
+              "old":      "",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+module_foo = {
+  "data": {},
+  "path": [
+    "foo",
+  ],
+  "resources": {
+    "null_resource": {
+      "foo": {
+        0: {
+          "applied": {
+            "id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+            "triggers": {
+              "foo": "bar",
+            },
+          },
+          "diff": {
+            "id": {
+              "computed": true,
+              "new":      "",
+              "old":      "",
+            },
+            "triggers.%": {
+              "computed": false,
+              "new":      "1",
+              "old":      "",
+            },
+            "triggers.foo": {
+              "computed": false,
+              "new":      "bar",
+              "old":      "",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+module_paths = [
+  [],
+  [
+    "foo",
+  ],
+]
+
+terraform_version = "0.11.11"
+
+variables = {
+  "foo": "bar",
+  "map": {
+    "foo":    "bar",
+    "number": 42,
+  },
+  "number": "42",
+}
+
+module = func(path) {
+  if length(path) == 0 {
+    return _root
+  }
+  if length(path) == 1 and path[0] is "foo" {
+    return module_foo
+  }
+
+  return undefined
+}
+
+data = _root.data
+path = _root.path
+resources = _root.resources
 ```

--- a/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfplan.html.md
@@ -37,26 +37,26 @@ version of the simulator, see the [downloads page][ref-downloads-page].
 
 [ref-downloads-page]: https://docs.hashicorp.com/sentinel/downloads
 
-These mocks are configured differently than JSON mocks: 
+These mocks are configured differently than JSON mocks:
 
-* Save the contents below to a `.sentinel` file within your project directory.
-   The example below uses `mock-tfplan.sentinel`.
-* Add the following to your Sentinel configuration file, example
-   `sentinel.json`:
+* Save the mock file contents below to a `.sentinel` file within your project
+  directory. The example below uses `mock-tfplan.sentinel`.
+* Add the following to your Sentinel configuration file (for example,
+  `sentinel.json`):
 
-```json
-{
-  "mock": {
-    "tfplan": "mock-tfplan.sentinel"
-  }
-}
-```
+    ```json
+    {
+      "mock": {
+        "tfplan": "mock-tfplan.sentinel"
+      }
+    }
+    ```
 
 * Run the Sentinel Simulator:
 
-```
-sentinel apply -config=sentinel.json policy.sentinel
-```
+    ```
+    sentinel apply -config=sentinel.json policy.sentinel
+    ```
 
 The above can be adjusted for use with `sentinel test` as well. As an example,
 assuming you save the mock to `test/shared/mock-tfplan.sentinel`, and you are

--- a/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
@@ -30,26 +30,26 @@ version of the simulator, see the [downloads page][ref-downloads-page].
 
 [ref-downloads-page]: https://docs.hashicorp.com/sentinel/downloads
 
-These mocks are configured differently than JSON mocks: 
+These mocks are configured differently than JSON mocks:
 
-* Save the contents below to a `.sentinel` file within your project directory.
-   The example below uses `mock-tfstate.sentinel`.
+* Save the mock file contents below to a `.sentinel` file within your project
+  directory. The example below uses `mock-tfstate.sentinel`.
 * Add the following to your Sentinel configuration file, example
-   `sentinel.json`:
+  `sentinel.json`:
 
-```json
-{
-  "mock": {
-    "tfstate": "mock-tfstate.sentinel"
-  }
-}
-```
+    ```json
+    {
+      "mock": {
+        "tfstate": "mock-tfstate.sentinel"
+      }
+    }
+    ```
 
 * Run the Sentinel Simulator:
 
-```
-sentinel apply -config=sentinel.json policy.sentinel
-```
+    ```
+    sentinel apply -config=sentinel.json policy.sentinel
+    ```
 
 The above can be adjusted for use with `sentinel test` as well. As an example,
 assuming you save the mock to `test/shared/mock-tfstate.sentinel`, and you are

--- a/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/mock-tfstate.html.md
@@ -22,127 +22,195 @@ documentation][ref-official-sentinel-documentation].
 [ref-mocking-imports]: https://docs.hashicorp.com/sentinel/writing/imports#mocking-imports
 [ref-official-sentinel-documentation]: https://docs.hashicorp.com/sentinel/
 
-#### Current mock limitations
+## Configuring Sentinel Simulator for Terraform Mocks
 
-There are currently some limitations mocking `tfstate` data in Sentinel. These
-issues will be fixed in future releases of the import and core runtime.
+Terraform mocks make use of the ability to provide mocks as Sentinel code,
+which requires Sentinel Simulator 0.8.0 or higher to use. To get the latest
+version of the simulator, see the [downloads page][ref-downloads-page].
 
-* As functions cannot be mocked in the current Sentinel testing framework, the
-  [module()][ref-module] function is not available. As a result, only root
-  module data can be mocked at this time.
+[ref-downloads-page]: https://docs.hashicorp.com/sentinel/downloads
 
-[ref-module]: /docs/enterprise/sentinel/import/tfstate.html#function-module-
+These mocks are configured differently than JSON mocks: 
 
-* [Resource and data source][resource-and-data-source] count keys (`NUMBER` in
-  `TYPE.NAME[NUMBER]`), which are actually represented as integers, cannot be
-  represented accurately in JSON and as a result, mocks that depend on count
-  keys explicitly (example: `tfstate.resources.null_resource.foo[0]`) will not
-  work properly with mocks.
-
-[resource-and-data-source]: /docs/enterprise/sentinel/import/tfstate.html#namespace-resources-data-sources
+* Save the contents below to a `.sentinel` file within your project directory.
+   The example below uses `mock-tfstate.sentinel`.
+* Add the following to your Sentinel configuration file, example
+   `sentinel.json`:
 
 ```json
 {
   "mock": {
-    "tfstate": {
-      "module_paths": [
-        [],
-        [
-          "foo"
-        ]
-      ],
-      "terraform_version": "0.11.7",
-      "data": {
-        "null_data_source": {
-          "baz": {
-            "0": {
-              "depends_on": [
-                "null_resource.bar",
-                "null_resource.foo"
-              ],
-              "id": "static",
-              "attr": {
-                "has_computed_default": "default",
-                "id": "static",
-                "inputs": {
-                  "bar_id": "5511801804920420639",
-                  "foo_id": "3332481276939020374"
-                },
-                "outputs": {
-                  "bar_id": "5511801804920420639",
-                  "foo_id": "3332481276939020374"
-                },
-                "random": "1637775805155379683"
-              },
-              "tainted": false
-            }
-          }
-        }
-      },
-      "path": [
-        "root"
-      ],
-      "outputs": {
-        "foo": {
-          "sensitive": true,
-          "type": "string",
-          "value": "bar"
-        },
-        "list": {
-          "sensitive": false,
-          "type": "list",
-          "value": [
-            "foo",
-            "bar"
-          ]
-        },
-        "map": {
-          "sensitive": false,
-          "type": "map",
-          "value": {
-            "foo": "bar",
-            "number": 42
-          }
-        },
-        "string": {
-          "sensitive": false,
-          "type": "string",
-          "value": "foo"
-        }
-      },
-      "resources": {
-        "null_resource": {
-          "bar": {
-            "0": {
-              "depends_on": [
-                "null_resource.foo"
-              ],
-              "id": "5511801804920420639",
-              "attr": {
-                "id": "5511801804920420639",
-                "triggers": {
-                  "foo_id": "3332481276939020374"
-                }
-              },
-              "tainted": false
-            }
-          },
-          "foo": {
-            "0": {
-              "depends_on": null,
-              "id": "3332481276939020374",
-              "attr": {
-                "id": "3332481276939020374",
-                "triggers": {
-                  "foo": "bar"
-                }
-              },
-              "tainted": false
-            }
-          }
-        }
-      }
-    }
+    "tfstate": "mock-tfstate.sentinel"
   }
 }
+```
+
+* Run the Sentinel Simulator:
+
+```
+sentinel apply -config=sentinel.json policy.sentinel
+```
+
+The above can be adjusted for use with `sentinel test` as well. As an example,
+assuming you save the mock to `test/shared/mock-tfstate.sentinel`, and you are
+editing a `test/policy/pass.json` test case:
+
+```json
+{
+  "mock": {
+    "tfstate": "../shared/mock-tfstate.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+```
+
+More information on configuring mocks using Sentinel code can be found
+[here][ref-sentinel-mocking-with-sentinel-code].
+
+[ref-sentinel-mocking-with-sentinel-code]: https://docs.hashicorp.com/sentinel/commands/config#mocking-with-sentinel-code
+
+## Mock File Contents
+
+```python
+_root = {
+  "data": {
+    "null_data_source": {
+      "baz": {
+        0: {
+          "attr": {
+            "has_computed_default": "default",
+            "id": "static",
+            "inputs": {
+              "bar_id": "5511801804920420639",
+              "foo_id": "3332481276939020374",
+            },
+            "outputs": {
+              "bar_id": "5511801804920420639",
+              "foo_id": "3332481276939020374",
+            },
+            "random": "4165965928584338859",
+          },
+          "depends_on": [
+            "null_resource.bar",
+            "null_resource.foo",
+          ],
+          "id":      "static",
+          "tainted": false,
+        },
+      },
+    },
+  },
+  "outputs": {
+    "foo": {
+      "sensitive": true,
+      "type":      "string",
+      "value":     "bar",
+    },
+    "list": {
+      "sensitive": false,
+      "type":      "list",
+      "value": [
+        "foo",
+        "bar",
+      ],
+    },
+    "map": {
+      "sensitive": false,
+      "type":      "map",
+      "value": {
+        "foo":    "bar",
+        "number": 42,
+      },
+    },
+    "string": {
+      "sensitive": false,
+      "type":      "string",
+      "value":     "foo",
+    },
+  },
+  "path": [],
+  "resources": {
+    "null_resource": {
+      "bar": {
+        0: {
+          "attr": {
+            "id": "5511801804920420639",
+            "triggers": {
+              "foo_id": "3332481276939020374",
+            },
+          },
+          "depends_on": [
+            "null_resource.foo",
+          ],
+          "id":      "5511801804920420639",
+          "tainted": false,
+        },
+      },
+      "foo": {
+        0: {
+          "attr": {
+            "id": "3332481276939020374",
+            "triggers": {
+              "foo": "bar",
+            },
+          },
+          "depends_on": [],
+          "id":         "3332481276939020374",
+          "tainted":    false,
+        },
+      },
+    },
+  },
+}
+
+module_foo = {
+  "data":    {},
+  "outputs": {},
+  "path": [
+    "foo",
+  ],
+  "resources": {
+    "null_resource": {
+      "foo": {
+        0: {
+          "attr": {
+            "id": "7102772838417697789",
+            "triggers": {
+              "foo": "bar",
+            },
+          },
+          "depends_on": [],
+          "id":         "7102772838417697789",
+          "tainted":    false,
+        },
+      },
+    },
+  },
+}
+
+module_paths = [
+  [],
+  [
+    "foo",
+  ],
+]
+
+terraform_version = "0.11.7"
+
+module = func(path) {
+  if length(path) == 0 {
+    return _root
+  }
+  if length(path) == 1 and path[0] is "foo" {
+    return module_foo
+  }
+
+  return undefined
+}
+
+data = _root.data
+outputs = _root.outputs
+path = _root.path
 ```


### PR DESCRIPTION
This updates the mocks for the three TFE imports to use Sentinel code.

Note that this requires version 0.8.0 or higher of the simulator. For
instructions on how to use them, see:
https://docs.hashicorp.com/sentinel/commands/config#mocking-with-sentinel-code

The runtime docs referenced in the individual pages will be updated
with this information as well.