### PR TITLE
Update organization create API attributes for TFE

### DIFF
--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -152,11 +152,15 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-Key path                    | Type   | Default | Description
-----------------------------|--------|---------|------------
-`data.type`                 | string |         | Must be `"organizations"`
-`data.attributes.name`      | string |         | Name of the organization
-`data.attributes.email`     | string |         | Admin email address
+Key path                                   | Type    | Default  | Description
+-------------------------------------------|---------|----------|------------
+`data.type`                                | string  |          | Must be `"organizations"`
+`data.attributes.name`                     | string  |          | Name of the organization
+`data.attributes.email`                    | string  |          | Admin email address
+`data.attributes.session-timeout`          | integer |    20160 | Session timeout after inactivity (minutes)
+`data.attributes.session-remember`         | integer |    20160 | Session expiration (minutes)
+`data.attributes.collaborator-auth-policy` | string  | password | Authentication policy (`password` or `two_factor_mandatory`)
+`data.attributes.owners-team-saml-role-id` | string  |   owners | **SAML only** The name of the ["owners" team](../saml/team-membership.html#managing-membership-of-the-owners-team)
 
 ### Sample Payload
 


### PR DESCRIPTION
It is possible to specify more attributes when creating an organization through the API than is currently documented. This change brings it up to date with what one can do through the API.