### PR TITLE
Auto-apply API - clarification on token requirement

### DIFF
--- a/content/source/docs/enterprise/run/api.html.md
+++ b/content/source/docs/enterprise/run/api.html.md
@@ -95,7 +95,9 @@ UPLOAD_URL=($(curl \
 
 Next, upload the configuration version `tar.gz` file to the upload URL extracted from the previous step. If a file is not uploaded, the configuration version will not be usable, since it will have no Terraform configuration files.
 
-Terraform Enterprise automatically creates a new run with a plan once the new file is uploaded. If the workspace is configured to auto-apply, it will also apply if the plan succeeds; otherwise, an apply can be triggered via the [Run Apply API](../api/run.html#apply).
+Terraform Enterprise automatically creates a new run with a plan once the new file is uploaded. If the workspace is configured to [auto-apply](../workspaces/settings.html#auto-apply-and-manual-apply), it will also apply if the plan succeeds; otherwise, an apply can be triggered via the [Run Apply API](../api/run.html#apply).
+
+In order for the auto-apply to be executed, you need to use a user token for the API call. You could read more about user tokens [here](../users-teams-organizations/users.html#api-tokens)
 
 ```bash
 curl \


### PR DESCRIPTION
User token is required to use auto-apply over API. However this is not cristal clear on the documentation.

We have a few support tickets from people trying auto-apply with organisational tokens, which prevents auto-apply from running; this note might help people that are trying to use auto-apply over API to use the right token.