### PR TITLE
DON'T MERGE: Add required symlinks for Terraform 0.12 language documentation

### DIFF
--- a/content/source/docs/configuration-0-11
+++ b/content/source/docs/configuration-0-11
@@ -1,0 +1,1 @@
+../../../ext/terraform/website/docs/configuration-0-11

--- a/content/source/layouts/commands-providers.erb
+++ b/content/source/layouts/commands-providers.erb
@@ -1,0 +1,1 @@
+../../../ext/terraform/website/layouts/commands-providers.erb

--- a/content/source/layouts/functions.erb
+++ b/content/source/layouts/functions.erb
@@ -1,0 +1,1 @@
+../../../ext/terraform/website/layouts/functions.erb


### PR DESCRIPTION
I don't know how widely this is already known, but:

- Content from the other repos that make up this website (like hashicorp/terraform) is shimmied into place for the build via symlinks. 
- That means whenever we add content in one of those repos somewhere _other_ than one of the already symlinked directories, we need to add a new symlink before it'll appear on the site. 
- For the 0.12 changes in the Terraform repo, we have a new subdirectory in /docs/ and a new layout file for the functions. 

This commit straightens that all out, so we should merge it right before we do a website build for the 0.12 release. 

Also, the branch is convenient for previewing the 0.12 content, if you go into the submodule and manually check out `origin/master`. 