### PR TITLE
Update vault key info

### DIFF
--- a/content/source/docs/enterprise/private/data-security.html.md
+++ b/content/source/docs/enterprise/private/data-security.html.md
@@ -26,7 +26,10 @@ seriously. This table lists which parts of the PTFE app can contain sensitive da
 | Twilio Account Configuration         | PostgreSQL    | Vault Transit Encryption              |
 | SMTP Configuration                   | PostgreSQL    | Vault Transit Encryption              |
 | SAML Configuration                   | PostgreSQL    | Vault Transit Encryption              |
-| Vault Unseal Key                     | Host          | No                                    |
+| Vault Unseal Key                     | PostgreSQL    | [Encryption password][]               |
+
+[Encryption password]: ./encryption-password.html
 
 ## Vault Transit Encryption
+
 The [Vault Transit Secret Engine](https://www.vaultproject.io/docs/secrets/transit/index.html) handles encryption for data in-transit and is used when encrypting data from the application to the applicable [storage layer](https://www.terraform.io/docs/enterprise/private/reliability-availability.html#components).

--- a/content/source/docs/enterprise/private/encryption-password.md
+++ b/content/source/docs/enterprise/private/encryption-password.md
@@ -1,25 +1,21 @@
 ---
 layout: "enterprise2"
 page_title: "Private Terraform Enterprise Encryption Password"
-sidebar_current: "docs-enterprise2-private-encryption-password"
+sidebar_current: "docs-enterprise2-private-installer-encryption-password"
 ---
 
 # Private Terraform Enterprise Encryption Password
 
-During the installation of Private Terraform Enterprise,
-a password is used to encrypt sensitive information at
-rest. The default value is auto-generated, but we
-strongly suggest you create your own password.
+During the installation of Private Terraform Enterprise (PTFE),
+a password is used to encrypt Vault's unseal key and root token at
+rest. The encrypted Vault credentials are stored in PostgreSQL,
+so they are included in normal backups and can be recovered with the password.
 
-Be sure to retain the value, because you will need
-to use this password to restore access to the data
-in the event of a reinstall.
+The default password is auto-generated, but we
+strongly suggest you create your own.
 
-The Encryption Password is used to protect the vault unseal
-key and root token when the internal Vault is used.
-It allows us to store those details in PostgreSQL,
-which means that Vault is only dependent on the
-encryption password itself and details in PostgreSQL.
+Be sure to retain the password, because it is necessary for
+restoring access to PTFE's data in the event of a reinstall.
 
 ## Specifying the Encryption Password
 

--- a/content/source/docs/enterprise/private/monitoring.html.md
+++ b/content/source/docs/enterprise/private/monitoring.html.md
@@ -1,14 +1,14 @@
 ---
 layout: "enterprise2"
 page_title: "Monitoring Private Terraform Enterprise"
-sidebar_current: "docs-enterprise2-private-installer-monitoring"
+sidebar_current: "docs-enterprise2-private-monitoring"
 ---
 
 # Monitoring a Private Terraform Enterprise Instance
 
 This document outlines best practices for monitoring a Private Terraform Enterprise (PTFE) instance.
 
-## Health Check 
+## Health Check
 
 PTFE provides a `/_health_check` endpoint on the instance. If PTFE is up, the health check will return a `200 OK`.
 

--- a/content/source/docs/enterprise/private/reliability-availability.html.md
+++ b/content/source/docs/enterprise/private/reliability-availability.html.md
@@ -136,19 +136,21 @@ of the user.
 
 |  | Configuration | Vault | PostgreSQL | Blob Storage |
 |-------------------|--------------------------------------|----------------------------------------------------------------------------------------------|--------------------------------------|--------------------------------------|
-| Demo | Stored in Docker volumes on instance | Key material is stored in Docker volumes on instance, storage backend is internal PostgreSQL | Stored in Docker volumes on instance | Stored in Docker volumes on instance |
-| Mounted Disk | Stored in Docker volumes on instance | Key material on host in `/var/lib/tfe-vault`, storage backend is mounted disk PostgreSQL | Stored in mounted disks | Stored in mounted disks |
-| External Services | Stored in Docker volumes on instance | Key material on host in `/var/lib/tfe-vault`, storage backend is external PostgreSQL | Stored in external service | Stored in external service |
+| Demo | Stored in Docker volumes on instance | Key material stored in Docker volumes on instance; storage backend is internal PostgreSQL | Stored in Docker volumes on instance | Stored in Docker volumes on instance |
+| Mounted Disk | Stored in Docker volumes on instance | Key material encrypted with [encryption password][] and stored in PostgreSQL; storage backend is mounted disk PostgreSQL | Stored in mounted disks | Stored in mounted disks |
+| External Services | Stored in Docker volumes on instance | Key material encrypted with [encryption password][] and stored in PostgreSQL; storage backend is external PostgreSQL | Stored in external service | Stored in external service |
 | External Vault | - | Key material in external Vault with user-defined storage backend | - | - |
+
+[Encryption password]: ./encryption-password.html
 
 *Backup and Restore Responsibility*
 
-|                   | Configuration | Vault | PostgreSQL | Blob Storage |
-|-------------------|---------------|-------|------------|--------------|
-| Demo              | PTFE          | PTFE  | PTFE       | PTFE         |
-| Mounted Disk      | PTFE          | PTFE  | User       | User         |
-| External Services | PTFE          | PTFE  | User       | User         |
-| External Vault    | -             | User  | -          | -            |
+|                   | Configuration | Vault | Password | PostgreSQL | Blob Storage |
+|-------------------|---------------|-------|----------|------------|--------------|
+| Demo              | PTFE          | PTFE  | -        | PTFE       | PTFE         |
+| Mounted Disk      | PTFE          | PTFE  | User     | User       | User         |
+| External Services | PTFE          | PTFE  | User     | User       | User         |
+| External Vault    | -             | User  | -        | -          | -            |
 
 ### Demo
 

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -361,6 +361,9 @@
               <li<%= sidebar_current("docs-enterprise2-private-installer-vault") %>>
                 <a href="/docs/enterprise/private/vault.html">External Vault</a>
               </li>
+              <li<%= sidebar_current("docs-enterprise2-private-installer-encryption-password") %>>
+                <a href="/docs/enterprise/private/vault.html">Encryption Password</a>
+              </li>
               <li<%= sidebar_current("docs-enterprise2-private-installer-automated-recovery") %>>
                 <a href="/docs/enterprise/private/automated-recovery.html">Automated Recovery</a>
               </li>


### PR DESCRIPTION
I'm pretty sure about the stuff I've got in here now (Thanks @armchairlinguist!), but have two questions about possible updates in other spots:

- In [the last section of the install page](https://terraform.io/docs/enterprise/private/install-installer.html#continue-installation-in-browser), we have this:

    > 1. _Optional:_ Adjust the path used to store the vault files that are used to encrypt
    >    sensitive data. This is a path on the host system, which allows you
    >    to store these files outside of the product to enhance security. Additionally,
    >    you can configure the system not to store the vault files within any snapshots,
    >    giving you full custody of these files. These files will need to be provided before
    >    any snapshot restore process is performed, and should be placed into the path configured.

    Does that need an update too? 
- Do we need to update any info about the restore process? My expectation would be that snapshot restores wouldn't be affected, but that this changes the procedure for rebuilding an instance from scratch (which I don't think we have any specific info about, since it's basically just installation?). Is that guess right, or is there something that needs adjustment? 