### PR TITLE
Remove incorrect default for owners-team-saml-role-id

### DIFF
--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -160,7 +160,7 @@ Key path                                   | Type    | Default  | Description
 `data.attributes.session-timeout`          | integer |    20160 | Session timeout after inactivity (minutes)
 `data.attributes.session-remember`         | integer |    20160 | Session expiration (minutes)
 `data.attributes.collaborator-auth-policy` | string  | password | Authentication policy (`password` or `two_factor_mandatory`)
-`data.attributes.owners-team-saml-role-id` | string  |   owners | **SAML only** The name of the ["owners" team](../saml/team-membership.html#managing-membership-of-the-owners-team)
+`data.attributes.owners-team-saml-role-id` | string  |          | **SAML only** The name of the ["owners" team](../saml/team-membership.html#managing-membership-of-the-owners-team)
 
 ### Sample Payload
 
@@ -253,7 +253,7 @@ Key path                                   | Type    | Default  | Description
 `data.attributes.session-timeout`          | integer |    20160 | Session timeout after inactivity (minutes)
 `data.attributes.session-remember`         | integer |    20160 | Session expiration (minutes)
 `data.attributes.collaborator-auth-policy` | string  | password | Authentication policy (`password` or `two_factor_mandatory`)
-`data.attributes.owners-team-saml-role-id` | string  |   owners | **SAML only** The name of the ["owners" team](../saml/team-membership.html#managing-membership-of-the-owners-team)
+`data.attributes.owners-team-saml-role-id` | string  |          | **SAML only** The name of the ["owners" team](../saml/team-membership.html#managing-membership-of-the-owners-team)
 
 ### Sample Payload
 


### PR DESCRIPTION
The default is actually `null` and "owners" is not needed and potentially misleading or confusing.

Related docs:
https://www.terraform.io/docs/enterprise/saml/team-membership.html#managing-membership-of-the-owners-team

Relevant code:
https://github.com/hashicorp/atlas/blob/f9e69f199c562ba0de7fa8e46865918033233fcb/app/interactors/saml/manage_team_membership.rb#L54-L71