### PR TITLE
Remove Bitbucket Cloud Exception for Private Modules

### DIFF
--- a/content/source/docs/enterprise/registry/index.html.md
+++ b/content/source/docs/enterprise/registry/index.html.md
@@ -10,5 +10,5 @@ Terraform Enterprise (TFE)'s private module registry helps you share [Terraform 
 
 By design, the private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already used the public registry, TFE's registry will feel familiar.
 
--> **Note:** Currently, the private module registry works with all supported VCS providers except Bitbucket Cloud; however, the private module registry does not support [GitLab subgroups](https://about.gitlab.com/features/subgroups/).
+-> **Note:** Currently, the private module registry works with all supported VCS providers; however, the private module registry does not support [GitLab subgroups](https://about.gitlab.com/features/subgroups/).
 

--- a/content/source/docs/enterprise/registry/publish.html.md
+++ b/content/source/docs/enterprise/registry/publish.html.md
@@ -8,7 +8,7 @@ sidebar_current: "docs-enterprise2-registry-publish"
 
 # Publishing Modules to the Terraform Enterprise Private Module Registry
 
--> **Note:** Currently, the private module registry works with all supported VCS providers except Bitbucket Cloud; however, the private module registry does not support [GitLab subgroups](https://about.gitlab.com/features/subgroups/).
+-> **Note:** Currently, the private module registry works with all supported VCS providers; however, the private module registry does not support [GitLab subgroups](https://about.gitlab.com/features/subgroups/).
 
 Terraform Enterprise (TFE)'s private module registry lets you publish Terraform modules to be consumed by users across your organization. It works much like the public [Terraform Registry](/docs/registry/index.html), except that it uses your configured [VCS integrations][vcs] instead of requiring public GitHub repositories.
 

--- a/content/source/docs/enterprise/registry/using.html.md
+++ b/content/source/docs/enterprise/registry/using.html.md
@@ -6,8 +6,6 @@ sidebar_current: "docs-enterprise2-registry-using"
 
 # Using Modules from the Terraform Enterprise Private Module Registry
 
--> **Note:** Currently, the private module registry works with all supported VCS providers except Bitbucket Cloud.
-
 By design, Terraform Enterprise (TFE)'s private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already familiar with the public registry, here are the main differences:
 
 - Use TFE's web UI to browse and search for modules.


### PR DESCRIPTION
TFE now supports importing private registry modules from Bitbucket
Cloud so this change updates the documentation to reflect current
functionality.