### PR TITLE
Add documentation about SAML cert rotation

### DIFF
--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -266,6 +266,8 @@ curl \
 
 ## Revoke previous SAML IdP Certificate
 
+`PUT /api/v2/admin/saml-settings/actions/revoke-old-certificate`
+
 When reconfiguring the IdP certificate, TFE will retain the old IdP certificate to allow for a rotation period. This PUT endpoint will revoke the older IdP certificate when the new IdP certificate is known to be functioning correctly.
 
 See [SAML Configuration](../../saml/configuration.html) for more details.

--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -156,6 +156,7 @@ curl \
     "attributes": {
       "enabled": true,
       "debug": false,
+      "old-idp-cert": null,
       "idp-cert": "SAMPLE-CERTIFICATE",
       "slo-endpoint-url": "https://example.com/slo",
       "sso-endpoint-url": "https://example.com/sso",
@@ -213,7 +214,7 @@ Key path                    | Type   | Default | Description
     "attributes": {
       "enabled": true,
       "debug": false,
-      "idp-cert": "SAMPLE-CERTIFICATE",
+      "idp-cert": "NEW-CERTIFICATE",
       "slo-endpoint-url": "https://example.com/slo",
       "sso-endpoint-url": "https://example.com/sso",
       "attr-username": "Username",
@@ -247,7 +248,50 @@ curl \
     "attributes": {
       "enabled": true,
       "debug": false,
-      "idp-cert": "SAMPLE-CERTIFICATE",
+      "old-idp-cert": "SAMPLE-CERTIFICATE",
+      "idp-cert": "NEW-CERTIFICATE",
+      "slo-endpoint-url": "https://example.com/slo",
+      "sso-endpoint-url": "https://example.com/sso",
+      "attr-username": "Username",
+      "attr-groups": "MemberOf",
+      "attr-site-admin": "SiteAdmin",
+      "site-admin-role": "site-admins",
+      "sso-api-token-session-timeout": 1209600,
+      "acs-consumer-url": "https://example.com/users/saml/auth",
+      "metadata-url": "https://example.com/users/saml/metadata"
+    }
+  }
+}
+```
+
+## Revoke previous SAML IdP Certificate
+
+When reconfiguring the IdP certificate, TFE will retain the old IdP certificate to allow for a rotation period. This PUT endpoint will revoke the older IdP certificate when the new IdP certificate is known to be functioning correctly.
+
+See [SAML Configuration](../../saml/configuration.html) for more details.
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PUT \
+  https://app.terraform.io/api/v2/admin/saml-settings/actions/revoke-old-certificate
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id":"saml",
+    "type":"saml-settings",
+    "attributes": {
+      "enabled": true,
+      "debug": false,
+      "old-idp-cert": null,
+      "idp-cert": "NEW-CERTIFICATE",
       "slo-endpoint-url": "https://example.com/slo",
       "sso-endpoint-url": "https://example.com/sso",
       "attr-username": "Username",

--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -43,6 +43,8 @@ The SAML settings are separated into sections:
 - **Single Log-Out URL**: The HTTP(s) endpoint on your IdP for single logout requests. This value is provided by your IdP configuration. Single Logout is not yet supported.
 - **IdP Certificate**: The PEM encoded X.509 Certificate as provided by the IdP configuration.
 
+-> **Note:** When reconfiguring the IdP certificate, TFE will retain the old IdP certificate to allow for a rotation period. When you are sure that the new certificate is functioning correctly, you must explicitly remove the old IdP certificate. You can do this via TFE's web UI or an [API endpoint](../api/admin/settings.html#revoke-previous-saml-idp-certificate).
+
 ### Attributes
 
 - **Username Attribute Name**: (default: `Username`) The name of the SAML attribute that determines the TFE username for a user logging in via SSO.

--- a/content/source/docs/enterprise/saml/configuration.html.md
+++ b/content/source/docs/enterprise/saml/configuration.html.md
@@ -43,7 +43,7 @@ The SAML settings are separated into sections:
 - **Single Log-Out URL**: The HTTP(s) endpoint on your IdP for single logout requests. This value is provided by your IdP configuration. Single Logout is not yet supported.
 - **IdP Certificate**: The PEM encoded X.509 Certificate as provided by the IdP configuration.
 
--> **Note:** When reconfiguring the IdP certificate, TFE will retain the old IdP certificate to allow for a rotation period. When you are sure that the new certificate is functioning correctly, you must explicitly remove the old IdP certificate. You can do this via TFE's web UI or an [API endpoint](../api/admin/settings.html#revoke-previous-saml-idp-certificate).
+-> **Note:** When reconfiguring the IdP certificate, TFE will retain the old IdP certificate to allow for a rotation period. When you are sure that the new certificate is functioning correctly, you must explicitly remove the old IdP certificate. A button labeled "Revoke old IDP certificate" will appear below the IdP Certificate field if you are in a rotation period. You can also remove the old certificate via an [API endpoint](../api/admin/settings.html#revoke-previous-saml-idp-certificate).
 
 ### Attributes
 


### PR DESCRIPTION
As of PTFE v201901-1, TFE will retain the previous IdP certificate when a new one is added. This allows for a rotation period where both certificates are used for authentication so that the new certificate can be explicitly verified without locking admins or users out of TFE. This adds documentation about the feature to our SAML docs, as well as documentation about the API endpoint for those who wish to automate their SAML configuration.