### PR TITLE
Redirect old interpolation.html to the new 0.11 docs version of it

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -156,3 +156,11 @@
 # /docs/providers/aws/guides/eks-getting-started.html     https://learn.hashicorp.com/terraform/aws/eks-intro
 # /docs/providers/aws/guides/iam-policy-documents.html    https://learn.hashicorp.com/terraform/aws/iam-policy
 # /docs/providers/aws/guides/serverless-with-aws-lambda-and-api-gateway.html    https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
+
+# Most Terraform v0.11 config language doc pages were updated in-place by
+# 0.12 versions, but there is no new equivalent to interpolation.html. We
+# redirect this one to the v0.11 copy of it rather than to the expressions
+# page because the expressions page has a very different structure and links
+# to the interpolation page tend to use section headers that no longer exist,
+# and so landing in the 0.11 interpolation docs gives a better result.
+/docs/configuration/interpolation.html /docs/configuration-0-11/interpolation.html


### PR DESCRIPTION
We're redirecting to the 0.11 interpolation page rather than the 0.12 expressions page here because most links to this page use section fragments and so landing in the 0.11 page gives a better navigation experience; the expressions page has a totally different structure and a lot of content formerly on the interpolation page has been split out into separate pages in the new doc structure.
