### PR TITLE
Terraform / TFE glossary

### DIFF
--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -793,7 +793,7 @@ Without state, Terraform has no way to identify the real resources it created du
 
 A snapshot of your infrastructure's [state][] at a point in time. Can be manually uploaded to TFE or created as the result of an [apply][].
 
-Unlike TFE, Terraform CLI doesn't track historical state versions, and only retains the most recent state.
+Terraform CLI doesn't have any concept of historical state data; it only interacts with the most recent state, and writes a snapshot of the new state to the configured [backend][] after making changes. Whatever system that backend writes to can choose to retain previous state; Terraform Enterprise does this, and some other backends (like S3) can also be configured to keep historical snapshots. The `local` backend does not.
 
 ## Team
 

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -308,15 +308,13 @@ HCL establishes the syntax Terraform uses for things like [arguments][], [blocks
 [id]: glossary.html#id
 [ids]: glossary.html#id
 
--> Terraform Enterprise
+An identifier; an opaque string permanently associated with a specific object, which doesn't contain any information about the object but which can be used to retrieve information about it or perform actions on it via an [API][].
 
-Also "external ID".
+In Terraform, many [resource][] types have an ID [attribute][] that helps link Terraform's [state][] to the real infrastructure resource being managed.
 
-An identifier; an opaque string permanently associated with a specific object, which doesn't contain any information about the object but which can be used to retrieve information about it or perform actions on it via the [API][].
+In Terraform Enterprise, most internal application objects (like [workspaces][], users, [policies][], etc.) can be identified by both a name (possibly including the parents, for disambiguation) and by an opaque, permanent ID. Most API endpoints use IDs instead of names, since names sometimes change. IDs for TFE's application objects are sometimes called "external IDs."
 
-Most application objects within Terraform Enterprise (like [workspaces][], users, [policies][policy], etc.) can be identified by both a name and an opaque, permanent ID. Most API endpoints use IDs instead of names, since names sometimes change.
-
-You can usually copy an ID from the URL bar when viewing an object in TFE's UI. Workspaces don't display an ID in the URL bar, but their general settings page includes a UI control for viewing and copying the ID.
+You can usually copy an external ID from the URL bar when viewing an object in TFE's UI. Workspaces don't display an ID in the URL bar, but their general settings page includes a UI control for viewing and copying the ID.
 
 ## Ingress
 

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -402,11 +402,13 @@ An OAuth client needs an [OAuth token][] in order to actually access data belong
 
 -> Terraform Enterprise
 
-The access token that a TFE organization needs in order to access data belonging to a user or organization in a specific [VCS provider][]. The token is granted by the VCS provider, and allows access with whatever permissions that VCS provider assigns to the token.
+**In general:** A secret string that allows an application to authenticate itself to another application. The token is generated ahead of time by the application being accessed (either during the OAuth authorization exchange or in response to a direct request by a user), and allows access with whatever permissions that application assigns to the token. The [VCS providers][] supported by Terraform Enterprise allow access via OAuth tokens; that access is generally restricted to data belonging to a given user or organization within that provider.
 
-An OAuth token has a one-to-one relationship with an [OAuth client][], but the client can outlive a specific token, to allow revoking and re-requesting VCS access.
+**Within Terraform Enterprise:** An entity in the TFE application that associates an OAuth token (in the "secret string" sense) with a permanent ID and with metadata about which VCS provider it applies to and which VCS user approved the token. When documentation refers specifically to this kind of entity, the name is often styled as `oauth-token` to indicate that it's an entity you can interact with via the [API][].
 
-[Workspaces][] that are linked to a VCS [repo][] have a relationship with one OAuth client.
+An `oauth-token` has a one-to-one relationship with an [OAuth client][], but the client can outlive a specific token, to allow revoking and re-requesting VCS access.
+
+[Workspaces][] that are linked to a VCS [repo][] have a relationship with one `oauth-token`.
 
 - [TFE docs: VCS Integration](/docs/enterprise/vcs/index.html)
 - [TFE API docs: OAuth Tokens](/docs/enterprise/api/oauth-tokens.html)

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -1,5 +1,92 @@
-Terraform Enterprise (TFE) Glossary
+---
+layout: intro
+page_title: "Terraform Glossary"
+sidebar_current: "terraform-glossary"
+description: |-
+  Brief definitions of technical terms and jargon used in Terraform and
+  Terraform Enterprise's documentation and throughout the Terraform community.
+---
 
+# Terraform Glossary
+
+This page collects brief definitions of some of the technical terms and jargon used in the documentation for Terraform and Terraform Enterprise, as well as some terms that come up frequently in conversations throughout the Terraform community.
+
+<div style="column-width: 14em;">
+
+- [API](#api)
+- [Apply (noun)](#apply-noun)
+- [Apply (verb)](#apply-verb)
+- [Argument](#argument)
+- [Attribute](#attribute)
+- [Backend](#backend)
+- [Blob Storage](#blob-storage)
+- [Block](#block)
+- [Branch](#branch)
+- [CLI](#cli)
+- [Commit](#commit)
+- [(Terraform) Configuration](#terraform-configuration)
+- [Configuration Version](#configuration-version)
+- [Data Source](#data-source)
+- [Expression](#expression)
+- [Fork](#fork)
+- [Git](#git)
+- [HCL](#hcl)
+- [ID](#id)
+- [Ingress](#ingress)
+- [JSON](#json)
+- [Locking](#locking)
+- [Log](#log)
+- [Module](#module)
+- [OAuth](#oauth)
+- [OAuth Client](#oauth-client)
+- [OAuth Token](#oauth-token)
+- [Organization](#organization)
+- [Output Values](#output-values)
+- [OSS](#oss)
+- [Permissions](#permissions)
+- [Plan (verb)](#plan-verb)
+- [Plan (noun, 1)](#plan-noun-1)
+- [Plan File](#plan-file)
+- [Policy Check](#policy-check)
+- [Policy](#policy)
+- [Policy Set](#policy-set)
+- [Private Module Registry](#private-module-registry)
+- [Private Terraform Enterprise (PTFE)](#private-terraform-enterprise-ptfe)
+- [(Terraform) Provider](#terraform-provider)
+- [TFE Provider](#tfe-provider)
+- [Pull Request (PR)](#pull-request-pr)
+- [Queue](#queue)
+- [(Terraform) Registry](#terraform-registry)
+- [Remote Operations](#remote-operations)
+- [Remote Backend](#remote-backend)
+- [Repository](#repository)
+- [Resource](#resource)
+- [Root Module](#root-module)
+- [Root Outputs](#root-outputs)
+- [Run](#run)
+- [S3](#s3)
+- [SAML](#saml)
+- [Service Account](#service-account)
+- [Sentinel](#sentinel)
+- [Site Admin](#site-admin)
+- [Speculative Plan](#speculative-plan)
+- [SSH Key](#ssh-key)
+- [State](#state)
+- [State Version](#state-version)
+- [Team](#team)
+- [Terraform](#terraform)
+- [TFE](#tfe)
+- [Trigger](#trigger)
+- [(API) Token](#api-token)
+- [Terraform Version](#terraform-version)
+- [Variables](#variables)
+- [VCS](#vcs)
+- [VCS Provider](#vcs-provider)
+- [Webhook](#webhook)
+- [Working Directory](#working-directory)
+- [Workspace](#workspace)
+
+</div>
 
 ## API
 

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -1,0 +1,324 @@
+Terraform Enterprise (TFE) Glossary
+
+## Apply (noun)
+
+Part of a run. TFE runs `terraform apply` using a plan (2) as its input. This makes changes to real infrastructure resources.
+
+https://www.terraform.io/docs/commands/apply.html
+
+## Apply (verb)
+
+To make changes to real infrastructure in order to make it match the desired state (as specified by a Terraform config and set of variables).
+
+To initiate an apply in Terraform Enterprise.
+
+https://www.terraform.io/docs/commands/apply.html
+
+## CLI
+
+Command-line Interface. The `terraform` tool uses a CLI to accept instructions and return text output.
+
+https://en.wikipedia.org/wiki/Command-line_interface
+
+## (Terraform) Configuration (or Config)
+
+Terraform HCL code that declaratively describes your infrastructure. A complete config consists of a root module, which can optionally call any number of child modules.
+
+https://www.terraform.io/docs/configuration/index.html
+
+## Configuration Version
+
+The contents of a Terraform config at a specific moment in time. Every stage of a given run uses one specific configuration version. Config versions can be automatically imported when new commits are merged to a workspace’s repo, uploaded via the API, or uploaded by running `terraform plan` or `terraform apply` as a remote operation. Adding a new config version is sometimes called “ingressing.”
+
+## Cost Estimation
+
+The second stage in a run. Shows the estimated total value and the difference in cost from before and after a plan.
+
+## Git
+
+A distributed version control system for tracking changes in source code during software development. It is designed for coordinating work among programmers, but it can be used to track changes in any set of files.
+
+https://en.wikipedia.org/wiki/Git
+
+## HCL
+
+HashiCorp Configuration Language. The declarative programming language used for Terraform configuration.
+
+https://github.com/hashicorp/hcl
+
+## Ingress
+
+See Configuration Version.
+
+## Locking
+
+The ability to prevent new runs from starting in a given workspace. Workspaces are automatically locked when a run is in progress, and can also be manually locked.
+
+## Log
+
+The text-based artifact of actions taken within a run. For example, the output of running `terraform plan`.
+
+## (Terraform) Modules
+
+A separate set of abstracted Terraform configurations with defined variables and outputs that can be used within other Terraform configurations.
+
+https://www.terraform.io/docs/modules/index.html
+
+## OAuth
+
+OAuth (Open Authorization) is an open standard for token-based authentication and authorization on the Internet. Terraform Enterprise uses OAuth to connect your organization to your VCS provider. Generally takes an `id` and `secret` from your VCS provider to give access to TFE and allow it to download configuration from the provider.
+
+https://www.terraform.io/docs/enterprise/vcs/index.html
+
+## OAuth Client
+
+The record of an association between an organization and a VCS provider. After creation, the client must be connected to get an OAuth token.
+
+https://www.terraform.io/docs/enterprise/vcs/index.html
+
+## OAuth Token
+
+The connection between an organization and a VCS provider. The token includes the permissions given by the VCS provider. Workspaces use an OAuth token to download configuration from the VCS provider.
+
+https://www.terraform.io/docs/enterprise/vcs/index.html
+
+## Organization
+
+TFE’s fundamental unit for controlling access and grouping things together; meant to represent a company or a business unit within a company. An organization contains a group of workspaces, a group of teams, a group of Sentinel policies, and a variety of settings. Adding users to an organization is done via teams.
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/organizations.html
+
+## Permissions
+
+Specific levels of access allowed within TFE. Can be managed at the workspace and/or organization level. For example, a “read” user role has “permission” to see a list of runs but cannot approve a run like a “write” user can.
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/permissions.html
+
+## Plan (verb), or Queue Plan
+
+To start a new run.
+
+## Plan (noun, 1)
+
+Part of a run. TFE runs `terraform plan` on the workspace’s config, resulting in a plan (2) object and a readable summary of the expected changes to real infrastructure.
+
+https://www.terraform.io/docs/commands/plan.html
+
+## Plan (noun, 2)
+
+A binary artifact produced by the `terraform plan` command, which `terraform apply` can use to carry out the exact changes that were decided at the time of the plan. TFE always uses a saved plan as the input to an apply, so that applies never make changes that weren’t shown to the user after the plan (in cases where the config or the variables changed in the meantime).
+
+## Policy Check
+
+Part of a run. After gathering the configuration, state, and plan (2) for a run, TFE runs Sentinel to check that data against the active policies. Policy checks end in success or failure. If a failure occurs in a required item, this can prevent the run from proceeding to the apply stage.
+
+## Policy
+
+Sentinel code that can be applied to a run. Combined into policy sets.
+
+https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html
+
+## Policy Set
+
+A list of policies to apply globally or to specific workspaces.
+
+https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html
+
+## Private Terraform Enterprise
+
+Private Terraform Enterprise is software provided to customers that allows full use of Terraform Enterprise in a private, isolated environment.
+
+https://www.terraform.io/docs/enterprise/private/index.html
+
+## Private Terraform Registry
+
+This is a version of the Terraform Registry that is built-in to TFE. It includes a Configuration Designer, which lets you combine and configure modules to generate Terraform configuration for them.
+
+https://www.terraform.io/docs/enterprise/registry/index.html
+
+## (Terraform) Provider
+
+A provider is responsible for understanding API interactions and
+
+exposing resources. Providers generally are IaaS providers (e.g. AWS, GCP, Microsoft Azure, OpenStack), PaaS (e.g. Heroku), or SaaS services (e.g. Terraform Enterprise, DNSimple, CloudFlare). There are many providers available but they can also be custom-built to work with any API.
+
+https://www.terraform.io/docs/providers/index.html
+
+## TFE Provider
+
+A Terraform provider that manages Terraform Enterprise. Allows you to manage TFE using Terraform configuration.
+
+https://www.terraform.io/docs/providers/tfe/index.html
+
+## Pull Request (PR)
+
+A mechanism created by GitHub to review and discuss changes made to a git repository branch that wish to be merged into another branch. Other collaborators can request changes, approve, or reject these changes. GitLab calls this a Merge Request.
+
+## Queue
+
+The list of runs waiting to be processed. TFE uses several queues of runs: a per-workspace queue (since only one run at a time is allowed in a given workspace, to avoid conflicts and state corruption), a global per-instance queue (since compute resources are finite and TFE only has access to so many VMs), and a per-organization queue (to prevent one organization from swamping the global queue and preventing other organizations from doing runs). The per-organization queue is part of a feature called “fair run queueing,” which is somewhat complex and is not yet globally enabled on the SaaS.
+
+## Terraform Registry
+
+The Terraform Registry is a repository of modules written by the Terraform community. The registry can help you get started with Terraform more quickly, see examples of how Terraform is written, and find pre-made modules for infrastructure components you require.
+
+https://www.terraform.io/docs/registry/index.html
+
+## Remote Operations
+
+The ability to start a run (or perform a few other tasks) from your local CLI and view output inline, while still allowing TFE to perform the actual operation. (TFE performs Terraform runs in its own disposable VMs, where it can capture information, control access to secrets, etc., but many users are accustomed to running Terraform on their local machines. Remote operations exist to help split the difference.)
+
+https://www.terraform.io/docs/backends/operations.html
+
+## Remote Backend
+
+A Terraform CLI feature that lets Terraform connect to TFE. Used for remote operations in TFE workspaces, or used for just state storage in the (still upcoming) free tiers.
+
+https://www.terraform.io/docs/backends/types/remote.html
+
+## Repository (repo)
+
+A collection of files and a history of the changes to them. In Terraform Enterprise, a “repo” is a git repository that contains a Terraform configuration.
+
+https://en.wikipedia.org/wiki/Repository_(version_control)
+
+## Run (or Terraform Run)
+
+The process of making real infrastructure match the desired state (as specified by the contents of the config and variables at a specific moment in time). Performed in a series of stages: plan, cost estimation, policy check, and apply. Not every stage occurs in every run. Information about historical runs is saved.
+
+https://www.terraform.io/docs/enterprise/run/index.html
+
+## SAML
+
+SAML is an XML-based standard for authentication and authorization. Terraform Enterprise can act as a service provider (SP) (or Relying Party, RP) with your internal SAML identity provider (IdP). The SAML Single Sign On feature is only available with the Premium tier on private installs.
+
+https://www.terraform.io/docs/enterprise/saml/index.html
+
+## Service Account
+
+An account (with API token) that doesn’t belong to a human user but to an entity in TFE. Terraform Enterprise provides two types of service accounts: team and organization. These accounts can access Terraform Enterprise APIs, but cannot be used interactively. The service accounts are designed to support server-to-server API calls using the service identity as opposed to individual user identities.
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/service-accounts.html
+
+## Sentinel
+
+A language (and runtime) for managing policy as code. Allows you to define rules around operations in TFE.
+
+https://www.terraform.io/docs/enterprise/sentinel/index.html
+
+## Speculative Plan
+
+A run that is only intended to show possible changes to infrastructure, when using a given config version and set of variables. Speculative plans can never be applied, and are usually started as a result of pull requests to a workspaces’ repo, or by running `terraform plan` on the command line  with remote operations configured.
+
+## SSH Key
+
+TFE allows you to upload private SSH keys to be used during a run. The key can be used for things like allowing a Terraform provider access to external servers. Separately, a key can also be used with a VCS Provider’s OAuth token to enable git clones using SSH.
+
+https://www.terraform.io/docs/enterprise/workspaces/ssh-keys.html
+
+## State
+
+Terraform must store state about your managed infrastructure and configuration. This state is used by Terraform to map real world resources to your configuration, keep track of metadata, and to improve performance for large infrastructures.
+
+https://www.terraform.io/docs/state/index.html
+
+## State Version
+
+A snapshot of your infrastructure’s state at a point in time. Can be manually uploaded or the result of an apply.
+
+## Team
+
+A group of TFE users, which can be given permission to access and/or edit various objects (workspaces, policies, etc.) within an organization. A team belongs to a single organization. Users can belong to any number of teams in any number of organizations.
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/teams.html
+
+## Terraform
+
+A tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.
+
+https://www.terraform.io/intro/index.html
+
+## TFE
+
+Terraform Enterprise.
+
+https://www.terraform.io/docs/enterprise/index.html
+
+## Trigger
+
+Something that causes a new run to queue. Can be UI/VCS-, API- or CLI-driven.
+
+https://www.terraform.io/docs/enterprise/run/ui.html
+
+## (API) Tokens
+
+Revocable alphanumeric strings that allow a user to authenticate itself in order to use the API. Different kinds of tokens grant different permissions. Can be granted by User, Team and/or Organization.
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/users.html#api-tokens
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/teams.html#api-tokens
+
+https://www.terraform.io/docs/enterprise/users-teams-organizations/organizations.html#api-tokens
+
+## Tool Version
+
+A particular version of the `terraform` binary, aka “Terraform Version”. Specifies a URL, a SHA256 checksum and enabled/beta flags.
+
+## Variables
+
+Key/values used in a run. Values can be “sensitive” and protected by Vault.
+
+https://www.terraform.io/docs/enterprise/workspaces/variables.html
+
+## VCS
+
+Version Control System, like Git.
+
+https://en.wikipedia.org/wiki/Version_control
+
+## VCS Provider
+
+Can be one of GitHub, GitHub Enterprise, GitLab.com, GitLab EE and CE, Bitbucket Cloud, or Bitbucket Server.
+
+https://www.terraform.io/docs/enterprise/vcs/index.html
+
+## Working Directory
+
+The directory where `terraform init` runs, creating a `.terraform` subdirectory. All subsequent commands for the same configuration should then be run from the same working directory.
+
+## Workspace
+
+A complex object that represents everything needed to manage a specific collection of infrastructure resources over time. In particular, this includes a Terraform configuration (which has multiple versions over time, and which can come from a repo or from manual uploads), a set of variables, state data that represents the current and historical condition of the infrastructure, and historical information about runs. All runs occur in the context of a workspace — they use that workspace’s config data, use that workspaces’ state to identify the real infrastructure being managed, and edit that workspaces’ state to match any infrastructure changes during the run. A workspace belongs to an organization.
+
+https://www.terraform.io/docs/enterprise/workspaces/index.html
+
+
+
+## Additional term definitions requested
+
+These terms are found in TFE and could use definitions added above:
+
+1. Branch
+
+2. Commit
+
+3. Broad User Adoption
+
+4. Forked repo
+
+5. Webhook
+
+6. API
+
+7. JSON
+
+8. Archivist
+
+9. OSS
+
+10. S3
+
+11. IDs: Run ID, Workspace ID, etc
+
+12. TFE V1 vs V2
+

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -162,7 +162,11 @@ In a general computer science sense, a backend is any lower-level implementation
 
 [blob storage]: glossary.html#blob-storage
 
-An API service for storing and retrieving arbitrary chunks of data using opaque addresses.
+-> Terraform Enterprise
+
+An API service for storing and retrieving arbitrary chunks of data using opaque addresses, which are indexed by a directory of some kind. The most notable example is AWS's [S3][].
+
+You do not need to be familiar with the properties and advantages of blob storage services in order to work with Terraform or TFE. However, you might need to administer or configure an S3-compatible blob storage service if you are responsible for administering a [Private Terraform Enterprise][] instance.
 
 ## Block
 

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -1,324 +1,851 @@
 Terraform Enterprise (TFE) Glossary
 
+
+## API
+
+[api]: glossary.html#api
+[apis]: glossary.html#api
+
+"Application Programming Interface". Any interface designed to allow programatic manipulation of some kind of software system. For most software developers today, the most common kinds of APIs are based on HTTP requests.
+
+Terraform relies on cloud service provider APIs to manage resources; each service's Terraform provider is responsible for mapping Terraform's resource model to the series of actual API calls necessary to create, check, modify, or delete a real infrastructure resource in that cloud service.
+
+Terraform Enterprise also offers its own API, for managing resources like team membership, policies, and workspaces. That API, in turn, is used by the `tfe` Terraform provider, so you can use Terraform to manage the system that runs Terraform for you.
+
+- [TFE docs: API](/docs/enterprise/api/index.html)
+- [Terraform providers: `tfe`](/docs/providers/tfe/index.html)
+
 ## Apply (noun)
 
-Part of a run. TFE runs `terraform apply` using a plan (2) as its input. This makes changes to real infrastructure resources.
+[apply]: glossary.html#apply-noun
+[applies]: glossary.html#apply-noun
 
-https://www.terraform.io/docs/commands/apply.html
+One of the stages of a [run][], in which changes are made to real infrastructure resources in order to make them match their desired state. The counterpart of a [plan][].
+
+In Terraform's CLI, applies are performed with the `terraform apply` command. TFE runs `terraform apply` using a [plan file][] as its input.
+
+- [Terraform docs: The `terraform apply` command](/docs/commands/apply.html)
+- [TFE docs: About Runs](/docs/enterprise/run/index.html)
 
 ## Apply (verb)
 
-To make changes to real infrastructure in order to make it match the desired state (as specified by a Terraform config and set of variables).
+[apply-v]: glossary.html#apply-verb
 
-To initiate an apply in Terraform Enterprise.
+To make changes to real infrastructure in order to make it match the desired state (as specified by a Terraform [config][] and set of [variables][]).
 
-https://www.terraform.io/docs/commands/apply.html
+In conversation, it's common to refer to "applying a [plan][]" (usually in the context of TFE's workflow) or "applying a [configuration][]" (usually in the context of the Terraform CLI workflow).
+
+- [Terraform docs: The `terraform apply` command](/docs/commands/apply.html)
+- [TFE docs: About Runs](/docs/enterprise/run/index.html)
+
+## Argument
+
+[argument]: glossary.html#argument
+[arguments]: glossary.html#argument
+
+In Terraform's [configuration][] language: a syntax construct that assigns a value to a name. Arguments have the form `<IDENTIFIER> = <EXPRESSION>`, and they appear within blocks.
+
+Most of a Terraform configuration consists of using arguments to configure Terraform [resources][]. Each resource type defines the arguments its resources can use, the allowed values for each argument, and which arguments are required or optional. Info about a given resource type can be found in the docs for that resource's [provider][].
+
+- [Terraform docs: Config Language — Arguments, Blocks and Expressions](/docs/configuration/index.html#arguments-blocks-and-expressions)
+
+## Attribute
+
+[attribute]: glossary.html#attribute
+[attributes]: glossary.html#attribute
+
+In Terraform's [configuration][] language: a named piece of data that belongs to some kind of object. The value of an attribute can be referenced in [expressions][] using a dot-separated notation, like `aws_instance.example.id`.
+
+Terraform [resources][] and [data sources][] make all of their [arguments][] available as readable attributes, and also typically export additional read-only attributes.
+
+- [Terraform docs: Expressions — Indices and Attributes](/docs/configuration/expressions.html#indices-and-attributes)
+
+## Backend
+
+[backend]: glossary.html#backend
+[backends]: glossary.html#backend
+
+The part of Terraform's core that determines how Terraform stores [state][] and performs [operations][remote operations] (like [plan][], [apply][], import, etc.). Backends are not plugins (and there are no third-party backends), but Terraform has multiple backends to choose from, which can be configured in a variety of ways.
+
+In a general computer science sense, a backend is any lower-level implementation that enables a higher-level feature. But in the context of Terraform, "backend" always means the built-in code that handles state and operations.
+
+- [Terraform docs: Backends](/docs/backends/index.html)
+
+## Blob Storage
+
+[blob storage]: glossary.html#blob-storage
+
+An API service for storing and retrieving arbitrary chunks of data using opaque addresses.
+
+## Block
+
+[block]: glossary.html#block
+[blocks]: glossary.html#block
+
+In Terraform's [configuration][] language: a container for other content which usually represents the configuration of some kind of object, like a [resource][]. Blocks have a _block type,_ can have zero or more _labels,_ and have a _body_ that contains any number of [arguments][] and nested blocks. Most of Terraform's features are controlled by top-level blocks in a configuration file.
+
+```hcl
+resource "aws_vpc" "main" {
+  cidr_block = var.base_cidr_block
+}
+
+<BLOCK TYPE> "<BLOCK LABEL>" "<BLOCK LABEL>" {
+  # Block body
+  <IDENTIFIER> = <EXPRESSION> # Argument
+}
+```
+
+- [Terraform docs: Config Language — Arguments, Blocks and Expressions](/docs/configuration/index.html#arguments-blocks-and-expressions)
+
+## Branch
+
+[branch]: glossary.html#branch
+[branches]: glossary.html#branch
+
+In some [version control systems][vcs]: a semi-independent history of changes to content in a repository. A branch generally shares some history with other branches in the same repository, but eventually diverges to include changes that aren't yet present elsewhere.
+
+A repository usually has a default branch (whose name, in [Git][], defaults to `master`), which successful changes are eventually merged into. Most modern development workflows also include topic branches (where a specific set of changes is explored, iterated on, and verified), and some workflows include long-lived branches other than the default branch (usually for maintaining older but still supported versions of software).
 
 ## CLI
 
-Command-line Interface. The `terraform` tool uses a CLI to accept instructions and return text output.
+[cli]: glossary.html#cli
 
-https://en.wikipedia.org/wiki/Command-line_interface
+Command-line interface. The `terraform` tool and its subcommands use a CLI to accept instructions and return text output.
 
-## (Terraform) Configuration (or Config)
+We often use "Terraform CLI" to refer to the core open source Terraform binary when we need to distinguish it from other parts of the Terraform ecosystem (like Terraform Enterprise or the Terraform GitHub Actions).
 
-Terraform HCL code that declaratively describes your infrastructure. A complete config consists of a root module, which can optionally call any number of child modules.
+- [Wikipedia: Command-line Interface](https://en.wikipedia.org/wiki/Command-line_interface)
+- [Terraform docs: Commands (CLI)](/docs/commands/index.html)
 
-https://www.terraform.io/docs/configuration/index.html
+## Commit
+
+[commit]: glossary.html#commit
+[commits]: glossary.html#commit
+
+In a [version control system][vcs]: A coherent set of changes saved to a repository's version history.
+
+In Git, commits act like a complete snapshot of the contents of a repo, on a specific [branch][] (or group of branches with shared history) and at a specific moment in time. Each commit also records the identity of its parent(s), which enables viewing the entire history of the repo up to any specific moment. Additionally, comparing a commit to its parent(s) can reveal the exact changes introduced by that commit; if those changes are applied as a diff, they can be added to a different branch in the repo without merging in the entire history of the commit in question.
+
+## (Terraform) Configuration
+
+[configuration]: glossary.html#terraform-configuration
+[configurations]: glossary.html#terraform-configuration
+[config]: glossary.html#terraform-configuration
+[configs]: glossary.html#terraform-configuration
+
+Also "config".
+
+Code written in Terraform's configuration language that declaratively describes the desired state of your infrastructure. A complete config consists of a [root module][], which can optionally call any number of child [modules][].
+
+- [Terraform docs: Configuration Language](/docs/configuration/index.html)
+- [Introduction to Terraform](/intro/index.html)
 
 ## Configuration Version
 
-The contents of a Terraform config at a specific moment in time. Every stage of a given run uses one specific configuration version. Config versions can be automatically imported when new commits are merged to a workspace’s repo, uploaded via the API, or uploaded by running `terraform plan` or `terraform apply` as a remote operation. Adding a new config version is sometimes called “ingressing.”
+[configuration version]: glossary.html#configuration-version
+[configuration versions]: glossary.html#configuration-version
+[config version]: glossary.html#configuration-version
+[config versions]: glossary.html#configuration-version
 
-## Cost Estimation
+-> Terraform Enterprise
 
-The second stage in a run. Shows the estimated total value and the difference in cost from before and after a plan.
+Also "config version".
+
+The contents of a Terraform [config][] at a specific moment in time. This concept only applies to Terraform Enterprise, since the Terraform CLI doesn't have any visibility into repeated runs over a period of time.
+
+Every stage of a given run uses one specific configuration version.
+
+Config versions can be automatically imported when new commits are merged to a workspace's repo, uploaded via the API, or uploaded by running `terraform plan` or `terraform apply` as a [remote operation][]. Adding a new config version is sometimes called "[ingressing][ingress]."
+
+## Data Source
+
+[data source]: glossary.html#data-source
+[data sources]: glossary.html#data-source
+
+A [resource][]-like object that can be configured in Terraform's [configuration][] language.
+
+Unlike resources, data sources do not create or manage infrastructure. Instead, they return information about some kind of external object in the form of readable [attributes][]. This allows a Terraform configuration to make use of information defined outside of Terraform, or defined by another separate Terraform configuration.
+
+Data sources are implemented by [providers][].
+
+- [Terraform docs: Data Sources](/docs/configuration/data-sources.html)
+
+## Expression
+
+[expression]: glossary.html#expression
+[expressions]: glossary.html#expression
+
+In Terraform's [configuration][] language: a piece of syntax that represents a value, either literally or by referencing and combining other values. Expressions appear as values for [arguments][], or within other expressions.
+
+- [Terraform docs: Expressions](/docs/configuration/expressions.html)
+
+## Fork
+
+[fork]: glossary.html#fork
+[forks]: glossary.html#fork
+[forked]: glossary.html#fork
+
+Also "forked repository" or "forked repo".
+
+A [VCS][] [repository][] that was created by copying content and history from another repository.
+
+Different VCS providers handle forks differently, but a fork is usually owned by a different person or organization than the original repo, and a fork usually does not inherit all of the original repo's access permissions.
+
+Terraform Enterprise makes extensive use of VCS repos, and assumes that forks of a trusted repo are not necessarily trusted. As such, TFE avoids evaluating any code from external forks, which prevents TFE from running [speculative plans][] for [pull requests][] from forks.
 
 ## Git
 
-A distributed version control system for tracking changes in source code during software development. It is designed for coordinating work among programmers, but it can be used to track changes in any set of files.
+[git]: glossary.html#git
 
-https://en.wikipedia.org/wiki/Git
+A distributed [version control system][vcs] for tracking changes in source code during software development. It is designed for coordinating work among programmers, but it can be used to track changes in any set of files.
+
+- [Wikipedia: Git](https://en.wikipedia.org/wiki/Git)
 
 ## HCL
 
-HashiCorp Configuration Language. The declarative programming language used for Terraform configuration.
+[hcl]: glossary.html#hcl
 
-https://github.com/hashicorp/hcl
+HashiCorp Configuration Language. The structured configuration syntax that serves as the basis for Terraform's [configuration][] language, as well as the configuration layer for several other HashiCorp products.
+
+HCL establishes the syntax Terraform uses for things like [arguments][], [blocks][], literal values, and [expressions][]. But what most people think of as the Terraform language extends beyond just the syntax; the built-in functions, Terraform-specific block types (like `resource` and `variable`), and Terraform-specific named values available in expressions are all implementation details of Terraform itself.
+
+- [GitHub: HCL](https://github.com/hashicorp/hcl)
+- [Terraform docs: Configuration Language](/docs/configuration/index.html)
+
+## ID
+
+[id]: glossary.html#id
+[ids]: glossary.html#id
+
+-> Terraform Enterprise
+
+Also "external ID".
+
+An identifier; an opaque string permanently associated with a specific object, which doesn't contain any information about the object but which can be used to retrieve information about it or perform actions on it via the [API][].
+
+Most application objects within Terraform Enterprise (like [workspaces][], users, [policies][policy], etc.) can be identified by both a name and an opaque, permanent ID. Most API endpoints use IDs instead of names, since names sometimes change.
+
+You can usually copy an ID from the URL bar when viewing an object in TFE's UI. Workspaces don't display an ID in the URL bar, but their general settings page includes a UI control for viewing and copying the ID.
 
 ## Ingress
 
-See Configuration Version.
+[ingress]: glossary.html#ingress
+[ingressing]: glossary.html#ingress
+
+-> Terraform Enterprise
+
+The process of bringing content into Terraform Enterprise. Usually that content is a [configuration version][], but it can also be a [private module][] version or some other kind of content.
+
+This term comes from TFE's internal subsystems. Most documentation and UI avoids using "ingress," but it can sometimes appear in API contexts or support conversations.
+
+## JSON
+
+[json]: glossary.html#json
+
+"JavaScript Object Notation". A popular text-based data interchange format, which can represent strings, numbers, booleans, null, arrays, and objects/maps.
+
+Terraform and Terraform Enterprise often interact with JSON data in order to consume or provide APIs. Terraform also supports JSON as an alternate format for [configurations][].
+
+- [Wikipedia: JSON](https://en.wikipedia.org/wiki/Json)
+- [Terraform docs: JSON Configuration Syntax](/docs/configuration/syntax-json.html)
 
 ## Locking
 
-The ability to prevent new runs from starting in a given workspace. Workspaces are automatically locked when a run is in progress, and can also be manually locked.
+[locking]: glossary.html#locking
+[lock]: glossary.html#locking
+
+-> Terraform Enterprise
+
+The ability to prevent new [runs][] from starting in a given [workspace][]. Workspaces are automatically locked while a run is in progress, and can also be manually locked.
+
+Some other Terraform [backends][] can also lock state during runs.
 
 ## Log
 
-The text-based artifact of actions taken within a run. For example, the output of running `terraform plan`.
+[log]: glossary.html#log
+[logs]: glossary.html#log
 
-## (Terraform) Modules
+The text-based output of actions taken within a [run][]. For example, the output of running `terraform plan`.
 
-A separate set of abstracted Terraform configurations with defined variables and outputs that can be used within other Terraform configurations.
+## Module
 
-https://www.terraform.io/docs/modules/index.html
+[module]: glossary.html#module
+[modules]: glossary.html#module
+
+Also "Terraform module".
+
+A self-contained collection of Terraform [configurations][] that manages a collection of related infrastructure resources.
+
+Other Terraform configurations can _call_ a module, which tells Terraform to manage any resources described by that module.
+
+Modules define [input variables][] (which the calling module can set values for) and [output values][] (which the calling module can reference in [expressions][]).
+
+- [Terraform docs: Modules](/docs/modules/index.html)
 
 ## OAuth
 
-OAuth (Open Authorization) is an open standard for token-based authentication and authorization on the Internet. Terraform Enterprise uses OAuth to connect your organization to your VCS provider. Generally takes an `id` and `secret` from your VCS provider to give access to TFE and allow it to download configuration from the provider.
+[oauth]: glossary.html#oauth
 
-https://www.terraform.io/docs/enterprise/vcs/index.html
+An open standard for token-based authorization between applications on the internet.
+
+Terraform Enterprise uses OAuth to connect your organization to your [VCS provider][]. Generally takes an `id` and `secret` from your VCS provider to give access to TFE and allow it to download configuration from the provider.
+
+- [TFE docs: VCS Integration](/docs/enterprise/vcs/index.html)
 
 ## OAuth Client
 
-The record of an association between an organization and a VCS provider. After creation, the client must be connected to get an OAuth token.
+[oauth client]: glossary.html#oauth-client
+[oauth clients]: glossary.html#oauth-client
 
-https://www.terraform.io/docs/enterprise/vcs/index.html
+-> Terraform Enterprise
+
+The set of configuration that a TFE organization needs in order to connect to a specific [VCS provider][].
+
+An OAuth client needs an [OAuth token][] in order to actually access data belonging to a user or organization in that VCS provider. The client can be created with an existing token for that VCS provider (when created via TFE's API), or it can be created with the details TFE needs in order to request a token. Requesting a token requires a user to click through and approve access with their VCS provider account.
+
+- [TFE docs: VCS Integration](/docs/enterprise/vcs/index.html)
+- [TFE API docs: OAuth Clients](/docs/enterprise/api/oauth-clients.html)
 
 ## OAuth Token
 
-The connection between an organization and a VCS provider. The token includes the permissions given by the VCS provider. Workspaces use an OAuth token to download configuration from the VCS provider.
+[oauth token]: glossary.html#oauth-token
+[oauth tokens]: glossary.html#oauth-token
 
-https://www.terraform.io/docs/enterprise/vcs/index.html
+-> Terraform Enterprise
+
+The access token that a TFE organization needs in order to access data belonging to a user or organization in a specific [VCS provider][]. The token is granted by the VCS provider, and allows access with whatever permissions that VCS provider assigns to the token.
+
+An OAuth token has a one-to-one relationship with an [OAuth client][], but the client can outlive a specific token, to allow revoking and re-requesting VCS access.
+
+[Workspaces][] that are linked to a VCS [repo][] have a relationship with one OAuth client.
+
+- [TFE docs: VCS Integration](/docs/enterprise/vcs/index.html)
+- [TFE API docs: OAuth Tokens](/docs/enterprise/api/oauth-tokens.html)
 
 ## Organization
 
-TFE’s fundamental unit for controlling access and grouping things together; meant to represent a company or a business unit within a company. An organization contains a group of workspaces, a group of teams, a group of Sentinel policies, and a variety of settings. Adding users to an organization is done via teams.
+[organization]: glossary.html#organization
+[organizations]: glossary.html#organization
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/organizations.html
+-> Terraform Enterprise
+
+TFE's fundamental unit for controlling access and grouping things together; meant to represent a company or a business unit within a company. An organization contains a group of [workspaces][], a group of [teams][], a group of [Sentinel policies][], and a variety of settings. Adding users to an organization is done via teams.
+
+- [TFE docs: Organizations](/docs/enterprise/users-teams-organizations/organizations.html)
+
+## Output Values
+
+[output value]: glossary.html#output-values
+[output values]: glossary.html#output-values
+[output]: glossary.html#output-values
+[outputs]: glossary.html#output-values
+
+Also "outputs".
+
+Data exported by a Terraform [module][], which can be displayed to a user and/or programmatically used by other Terraform code.
+
+## OSS
+
+[oss]: glossary.html#oss
+
+"Open-Source Software". Terraform and the publicly available Terraform providers are open-source. Terraform Enterprise is closed-source commercial software.
+
+- [Wikipedia: Open-Source Software](https://en.wikipedia.org/wiki/Open-source_software)
 
 ## Permissions
 
-Specific levels of access allowed within TFE. Can be managed at the workspace and/or organization level. For example, a “read” user role has “permission” to see a list of runs but cannot approve a run like a “write” user can.
+[permission]: glossary.html#permissions
+[permissions]: glossary.html#permissions
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/permissions.html
+-> Terraform Enterprise
 
-## Plan (verb), or Queue Plan
+Specific levels of access allowed within TFE. Can be managed at the [workspace][] and/or [organization][] level. For example, a user with "read" permissions for a workspace can see a list of runs but cannot approve a run like a user with "write" permissions can.
 
-To start a new run.
+- [TFE docs: Permissions](/docs/enterprise/users-teams-organizations/permissions.html)
+
+## Plan (verb)
+
+[plan-v]: glossary.html#plan-verb
+
+Also "queue plan".
+
+To start a new [run][], which begins by running a Terraform [plan (noun)][plan].
+
+- [TFE docs: About Runs](/docs/enterprise/run/index.html)
 
 ## Plan (noun, 1)
 
-Part of a run. TFE runs `terraform plan` on the workspace’s config, resulting in a plan (2) object and a readable summary of the expected changes to real infrastructure.
+[plan]: glossary.html#plan-noun-1
+[plans]: glossary.html#plan-noun-1
 
-https://www.terraform.io/docs/commands/plan.html
+One of the stages of a [run][], in which Terraform compares the managed infrastructure's real state to the [configuration][] and [variables][], determines which changes are necessary to make the real state match the desired state, and presents a human-readable summary to the user. The counterpart of an [apply][].
 
-## Plan (noun, 2)
+In Terraform's CLI, plans are performed by all of the following commands:
 
-A binary artifact produced by the `terraform plan` command, which `terraform apply` can use to carry out the exact changes that were decided at the time of the plan. TFE always uses a saved plan as the input to an apply, so that applies never make changes that weren’t shown to the user after the plan (in cases where the config or the variables changed in the meantime).
+- `terraform plan`, which only performs a plan. It can optionally output a [plan file][], which `terraform apply` can use to perform that exact set of planned changes.
+- `terraform apply`, which performs a plan and then, if a user approves, immediately applies it.
+- `terraform destroy`, which is similar to `terraform apply` but uses a desired state in which none of the managed resources exist; if the plan is approved, those resources are destroyed.
+
+In Terraform Enterprise, plans are performed by committing changes to a workspace's configuration, running `terraform plan` or `terraform apply` with the remote backend enabled, manually queueing a plan, or uploading a configuration via the API.
+
+TFE's workflow always creates a [plan file][], which can be auto-applied or can wait for a user's approval. TFE also supports [speculative plans][], which are for informational purposes only and cannot be applied.
+
+- [Terraform docs: The `terraform plan` command](/docs/commands/plan.html)
+- [TFE docs: About Runs](/docs/enterprise/run/index.html)
+
+## Plan File
+
+[plan file]: glossary.html#plan-file
+[plan files]: glossary.html#plan-file
+
+Also "`.tfplan`", "saved plan", or simply "plan" in contexts where it's clearly referring to an artifact.
+
+A binary artifact optionally produced by the `terraform plan` command, which `terraform apply` can use to carry out the exact changes that were decided at the time of the [plan][].
+
+TFE always uses a saved plan as the input to an [apply][], so that applies never make changes that weren't shown to the user after the plan (in cases where the config or the variables changed in the meantime).
 
 ## Policy Check
 
-Part of a run. After gathering the configuration, state, and plan (2) for a run, TFE runs Sentinel to check that data against the active policies. Policy checks end in success or failure. If a failure occurs in a required item, this can prevent the run from proceeding to the apply stage.
+[policy check]: glossary.html#policy-check
+[policy checks]: glossary.html#policy-check
+
+-> Terraform Enterprise
+
+Part of a [run][]. After gathering the [configuration][], [state][], and [plan file][] for a run, TFE runs [Sentinel][] to check that data against the active [policies][]. Policy checks end in success or failure. If a failure occurs in a required item, this can prevent the run from proceeding to the [apply][] stage.
+
+- [TFE docs: Run States and Stages](/docs/enterprise/run/states.html)
 
 ## Policy
 
-Sentinel code that can be applied to a run. Combined into policy sets.
+[policy]: glossary.html#policy
+[policies]: glossary.html#policy
+[sentinel policy]: glossary.html#policy
+[sentinel policies]: glossary.html#policy
 
-https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html
+-> Terraform Enterprise
+
+[Sentinel][] code that can be enforced on runs. Combined into [policy sets][].
+
+- [TFE docs: Managing Sentinel Policies](/docs/enterprise/sentinel/manage-policies.html)
 
 ## Policy Set
 
-A list of policies to apply globally or to specific workspaces.
+[policy set]: glossary.html#policy-set
+[policy sets]: glossary.html#policy-set
 
-https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html
+-> Terraform Enterprise
 
-## Private Terraform Enterprise
+A list of [Sentinel][] [policies][] to enforce globally or on specific workspaces.
+
+- [TFE docs: Managing Sentinel Policies](/docs/enterprise/sentinel/manage-policies.html)
+
+## Private Module Registry
+
+[private terraform registry]: glossary.html#private-terraform-registry
+[private module registry]: glossary.html#private-terraform-registry
+[private registry]: glossary.html#private-terraform-registry
+[private module]: glossary.html#private-terraform-registry
+[private modules]: glossary.html#private-terraform-registry
+
+-> Terraform Enterprise
+
+Also "private Terraform registry".
+
+A version of the [Terraform Registry][] that is built-in to TFE, to enable code sharing within an organization. It includes a configuration designer, which lets you combine and configure modules to generate a Terraform [configuration][] that uses them.
+
+- [TFE docs: Private Registry](/docs/enterprise/registry/index.html)
+
+## Private Terraform Enterprise (PTFE)
+
+[private terraform enterprise]: glossary.html#private-terraform-enterprise-ptfe
+[private installs]: glossary.html#private-terraform-enterprise-ptfe
+
+-> Terraform Enterprise
+
+Also "PTFE".
 
 Private Terraform Enterprise is software provided to customers that allows full use of Terraform Enterprise in a private, isolated environment.
 
-https://www.terraform.io/docs/enterprise/private/index.html
-
-## Private Terraform Registry
-
-This is a version of the Terraform Registry that is built-in to TFE. It includes a Configuration Designer, which lets you combine and configure modules to generate Terraform configuration for them.
-
-https://www.terraform.io/docs/enterprise/registry/index.html
+- [TFE docs: Private Terraform Enterprise](/docs/enterprise/private/index.html)
 
 ## (Terraform) Provider
 
-A provider is responsible for understanding API interactions and
+[provider]: glossary.html#terraform-provider
+[providers]: glossary.html#terraform-provider
 
-exposing resources. Providers generally are IaaS providers (e.g. AWS, GCP, Microsoft Azure, OpenStack), PaaS (e.g. Heroku), or SaaS services (e.g. Terraform Enterprise, DNSimple, CloudFlare). There are many providers available but they can also be custom-built to work with any API.
+A plugin for Terraform that makes a collection of related resources available. A provider plugin is responsible for understanding [API][] interactions with some kind of service and exposing [resources][] based on that API.
 
-https://www.terraform.io/docs/providers/index.html
+Terraform providers are generally tied to a specific _infrastructure provider,_ which might be an infrastructure as a service (IaaS) provider (like AWS, GCP, Microsoft Azure, OpenStack), a platform as a service (PaaS) provider (like Heroku), or a software as a service (SaaS) provider (like Terraform Enterprise, DNSimple, CloudFlare).
+
+There are many existing providers available, but providers can also be custom-built to work with any API.
+
+- [Terraform docs: Providers](/docs/providers/index.html)
 
 ## TFE Provider
 
-A Terraform provider that manages Terraform Enterprise. Allows you to manage TFE using Terraform configuration.
+[tfe provider]: glossary.html#tfe-provider
 
-https://www.terraform.io/docs/providers/tfe/index.html
+A Terraform provider that manages Terraform Enterprise. Allows you to manage TFE using a Terraform [configuration][].
+
+- [Provider docs: tfe](/docs/providers/tfe/index.html)
 
 ## Pull Request (PR)
 
-A mechanism created by GitHub to review and discuss changes made to a git repository branch that wish to be merged into another branch. Other collaborators can request changes, approve, or reject these changes. GitLab calls this a Merge Request.
+[pull request]: glossary.html#pull-request-pr
+[pull requests]: glossary.html#pull-request-pr
+[pr]: glossary.html#pull-request-pr
+[prs]: glossary.html#pull-request-pr
+
+A mechanism created by GitHub to review and discuss changes made to a [Git][] [repository][] [branch][] that a user wants to merge into another branch. Other collaborators can request changes, approve, or reject these changes.
+
+Conversationally, people often say "pull request" to refer to this review-before-merging workflow even when working with a VCS provider that calls it something else. (For example, GitLab calls this a Merge Request.)
 
 ## Queue
 
-The list of runs waiting to be processed. TFE uses several queues of runs: a per-workspace queue (since only one run at a time is allowed in a given workspace, to avoid conflicts and state corruption), a global per-instance queue (since compute resources are finite and TFE only has access to so many VMs), and a per-organization queue (to prevent one organization from swamping the global queue and preventing other organizations from doing runs). The per-organization queue is part of a feature called “fair run queueing,” which is somewhat complex and is not yet globally enabled on the SaaS.
+[queue]: glossary.html#queue
+[queues]: glossary.html#queue
 
-## Terraform Registry
+-> Terraform Enterprise
 
-The Terraform Registry is a repository of modules written by the Terraform community. The registry can help you get started with Terraform more quickly, see examples of how Terraform is written, and find pre-made modules for infrastructure components you require.
+The list of [runs][] waiting to be processed. TFE uses several queues of runs, including a per-workspace queue (since only one run at a time is allowed in a given [workspace][], to avoid conflicts and state corruption) and a global per-instance queue (since compute resources are finite and TFE only has access to so many VMs).
 
-https://www.terraform.io/docs/registry/index.html
+## (Terraform) Registry
+
+[terraform registry]: glossary.html#terraform-registry
+[registry]: glossary.html#terraform-registry
+
+A repository of [modules][] written by the Terraform community, which can be used as-is within a Terraform [configuration][] or [forked][] and modified. The registry can help you get started with Terraform more quickly, see examples of how Terraform is written, and find pre-made modules for infrastructure components you require.
+
+- [Terraform docs: The Terraform Registry](/docs/registry/index.html)
 
 ## Remote Operations
 
-The ability to start a run (or perform a few other tasks) from your local CLI and view output inline, while still allowing TFE to perform the actual operation. (TFE performs Terraform runs in its own disposable VMs, where it can capture information, control access to secrets, etc., but many users are accustomed to running Terraform on their local machines. Remote operations exist to help split the difference.)
+[remote operation]: glossary.html#remote-operations
+[remote operations]: glossary.html#remote-operations
 
-https://www.terraform.io/docs/backends/operations.html
+-> Terraform Enterprise
+
+The ability to start a [run][] (or perform a few other tasks) from your local [CLI][] and view output inline, while still allowing TFE to perform the actual operation.
+
+TFE performs Terraform runs in its own disposable VMs, where it can capture information, control access to secrets, etc., but many users are accustomed to running Terraform on their local machines. Remote operations exist to help split the difference.
+
+- [Terraform docs: Remote Operations](/docs/backends/operations.html)
 
 ## Remote Backend
 
-A Terraform CLI feature that lets Terraform connect to TFE. Used for remote operations in TFE workspaces, or used for just state storage in the (still upcoming) free tiers.
+[remote backend]: glossary.html#remote-backend
 
-https://www.terraform.io/docs/backends/types/remote.html
+A Terraform CLI feature that lets Terraform connect to TFE, by specifying in the Terraform [configuration][] which organization and workspace(s) to use. Used for [remote operations][] in TFE workspaces, and used for [state][] storage in TFE's free tier.
 
-## Repository (repo)
+See also [backend][]. Older documentation sometimes refers to backends like `s3` or `consul` as "remote backends," since they store Terraform's state in a remote service instead of the local filesystem, but today this term usually means the specific backend whose name is `remote`.
 
-A collection of files and a history of the changes to them. In Terraform Enterprise, a “repo” is a git repository that contains a Terraform configuration.
+- [Terraform docs: The `remote` Backend](/docs/backends/types/remote.html)
 
-https://en.wikipedia.org/wiki/Repository_(version_control)
+## Repository
 
-## Run (or Terraform Run)
+[repository]: glossary.html#repository
+[repositories]: glossary.html#repository
+[repo]: glossary.html#repository
+[repos]: glossary.html#repository
 
-The process of making real infrastructure match the desired state (as specified by the contents of the config and variables at a specific moment in time). Performed in a series of stages: plan, cost estimation, policy check, and apply. Not every stage occurs in every run. Information about historical runs is saved.
+Also "repo".
 
-https://www.terraform.io/docs/enterprise/run/index.html
+A collection of files and a history of the changes to them, managed by a [version control system][vcs]. In Terraform Enterprise, a "repo" is generally a Git repository that contains a Terraform configuration, although [private modules][] are also based on Git repos.
+
+- [Wikipedia: Repository (version control)](https://en.wikipedia.org/wiki/Repository_(version_control))
+
+## Resource
+
+[resource]: glossary.html#resource
+[resources]: glossary.html#resource
+
+Also "infrastructure resource".
+
+In Terraform's [configuration][] language: A [block][] that describes one or more infrastructure objects. Resources can be things like virtual networks, compute instances, or higher-level components such as DNS records.
+
+In other Terraform-related contexts: An infrastructure object of a type that _could_ be managed by Terraform.
+
+A resource block in a configuration instructs Terraform to _manage_ the described resource — during a run, Terraform will create a matching real infrastructure object if one doesn't already exist, and will modify the existing object if it doesn't match the desired configuration. Terraform uses [state][] to keep track of which real infrastructure objects correspond to resources in a configuration.
+
+Terraform uses cloud provider [APIs][] to create, edit, and destroy resources. Terraform [providers][] are responsible for defining resource types and mapping transitions in a resource's state to a specific series of API calls that will carry out the necessary changes.
+
+- [Terraform docs: Resources](/docs/configuration/resources.html)
+
+## Root Module
+
+[root module]: glossary.html#root-module
+[root modules]: glossary.html#root-module
+
+The place where Terraform begins evaluating a [configuration][]. The root module consists of all of the configuration files in Terraform's [working directory][].
+
+The root module's [variables][] and [outputs][] are handled directly by Terraform (unlike child [modules][], whose variables and outputs are handled by the calling module). Root variable values can be provided with Terraform Enterprise, `.tfvars` files, CLI options, or environment variables. Root outputs are printed after a run and stored in the state.
+
+## Root Outputs
+
+[root output]: glossary.html#root-outputs
+[root outputs]: glossary.html#root-outputs
+
+Also "root-level outputs".
+
+The [output values][] of a configuration's [root module][]. A [configuration][] can access the root outputs of another configuration with a `terraform_remote_state` data source.
+
+## Run
+
+[run]: glossary.html#run
+[runs]: glossary.html#run
+
+Also "Terraform Run".
+
+The process of using Terraform to make real infrastructure match the desired state (as specified by the contents of the config and variables at a specific moment in time).
+
+In Terraform Enterprise, runs are performed in a series of stages ([plan][], [policy check][], and [apply][]), though not every stage occurs in every run. TFE saves information about historical runs.
+
+- [Learn Terraform: Getting Started](https://learn.hashicorp.com/terraform/getting-started/install.html)
+- [TFE docs: About Runs](/docs/enterprise/run/index.html)
+
+## S3
+
+[s3]: glossary.html#s3
+
+Amazon Web Services' "Simple Storage Service", a service for storing and retrieving arbitrary blobs of data.
+
+Many other cloud or self-hosted services provide [APIs][] that are compatible with S3's API, which allows them to be used with software that was designed to work with S3.
+
+Terraform's `aws` [provider][] can manage S3 resources.
+
+Private Terraform Enterprise uses an S3-compatible [blob storage][] service when configured to use external services for storage.
+
+- [AWS: S3](https://aws.amazon.com/s3/)
 
 ## SAML
 
-SAML is an XML-based standard for authentication and authorization. Terraform Enterprise can act as a service provider (SP) (or Relying Party, RP) with your internal SAML identity provider (IdP). The SAML Single Sign On feature is only available with the Premium tier on private installs.
+[saml]: glossary.html#saml
 
-https://www.terraform.io/docs/enterprise/saml/index.html
+-> Terraform Enterprise
+
+SAML is an XML-based standard for authentication and authorization. Terraform Enterprise can act as a service provider (SP) (or Relying Party, RP) with your internal SAML identity provider (IdP). The SAML Single Sign On feature is only available with the Premium tier on [private installs][].
+
+- [PTFE docs: SAML Single Sign-On](/docs/enterprise/saml/index.html)
 
 ## Service Account
 
-An account (with API token) that doesn’t belong to a human user but to an entity in TFE. Terraform Enterprise provides two types of service accounts: team and organization. These accounts can access Terraform Enterprise APIs, but cannot be used interactively. The service accounts are designed to support server-to-server API calls using the service identity as opposed to individual user identities.
+[service account]: glossary.html#service-account
+[service accounts]: glossary.html#service-account
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/service-accounts.html
+-> Terraform Enterprise
+
+An account (with API [token][]) that doesn't belong to a human user but to an internal entity in TFE. Terraform Enterprise provides two types of service accounts: [team][] and [organization][]. These accounts can access Terraform Enterprise [APIs][], but cannot be used interactively. The service accounts are designed to support server-to-server API calls using the service identity as opposed to individual user identities.
+
+- [TFE docs: Service Accounts](/docs/enterprise/users-teams-organizations/service-accounts.html)
 
 ## Sentinel
 
-A language (and runtime) for managing policy as code. Allows you to define rules around operations in TFE.
+[sentinel]: glossary.html#sentinel
 
-https://www.terraform.io/docs/enterprise/sentinel/index.html
+-> Terraform Enterprise
+
+A language and runtime for managing policy as code. Allows you to define rules around operations in TFE.
+
+- [TFE docs: Sentinel](/docs/enterprise/sentinel/index.html)
+
+## Site Admin
+
+[site admin]: glossary.html#site-admin
+[site admins]: glossary.html#site-admin
+
+-> Terraform Enterprise
+
+An administrator of a [Private Terraform Enterprise][] instance, who has access to application settings that affect all [organizations][] using the instance.
+
+- [PTFE docs: Administration](/docs/enterprise/private/admin/index.html)
 
 ## Speculative Plan
 
-A run that is only intended to show possible changes to infrastructure, when using a given config version and set of variables. Speculative plans can never be applied, and are usually started as a result of pull requests to a workspaces’ repo, or by running `terraform plan` on the command line  with remote operations configured.
+[speculative plan]: glossary.html#speculative-plan
+[speculative plans]: glossary.html#speculative-plan
+
+-> Terraform Enterprise
+
+A [run][] that is only intended to show possible changes to infrastructure, when using a given [config version][] and set of [variables][]. Speculative plans can never be [applied][apply-v], and are usually started as a result of [pull requests][] to a [workspace][]'s repo, or by running `terraform plan` on the command line with [remote operations][] configured.
 
 ## SSH Key
 
-TFE allows you to upload private SSH keys to be used during a run. The key can be used for things like allowing a Terraform provider access to external servers. Separately, a key can also be used with a VCS Provider’s OAuth token to enable git clones using SSH.
+[ssh key]: glossary.html#ssh-key
+[ssh keys]: glossary.html#ssh-key
 
-https://www.terraform.io/docs/enterprise/workspaces/ssh-keys.html
+A type of access credential based on public key cryptography, used to log into servers.
+
+TFE uses SSH private keys for two kinds of operations:
+
+- Downloading private Terraform [modules][] with [Git][]-based sources during a Terraform run. Keys for downloading modules are assigned per-workspace.
+- Bringing content from a connected [VCS provider][] into TFE, usually when downloading a Terraform [configuration][] for a [workspace][] or importing a module into the [private module registry][]. Only some VCS providers require an SSH key, but others can optionally use SSH instead of the provider's normal API.
+
+- [Wikipedia: SSH](https://en.wikipedia.org/wiki/Secure_Shell)
+- [TFE docs: SSH Keys for Cloning Modules](/docs/enterprise/workspaces/ssh-keys.html)
 
 ## State
 
-Terraform must store state about your managed infrastructure and configuration. This state is used by Terraform to map real world resources to your configuration, keep track of metadata, and to improve performance for large infrastructures.
+[state]: glossary.html#state
 
-https://www.terraform.io/docs/state/index.html
+Terraform's cached information about your managed infrastructure and [configuration][]. This state is used to persistently map the same real world [resources][] to your configuration from run-to-run, keep track of metadata, and improve performance for large infrastructures.
+
+Without state, Terraform has no way to identify the real resources it created during previous runs. Thus, when multiple people are collaborating on shared infrastructure, it's important to store state in a shared location, like a free Terraform Enterprise organization.
+
+- [Terraform docs: State](/docs/state/index.html)
 
 ## State Version
 
-A snapshot of your infrastructure’s state at a point in time. Can be manually uploaded or the result of an apply.
+[state version]: glossary.html#state-version
+[state versions]: glossary.html#state-version
+
+-> Terraform Enterprise
+
+A snapshot of your infrastructure's [state][] at a point in time. Can be manually uploaded to TFE or created as the result of an [apply][].
+
+Unlike TFE, Terraform CLI doesn't track historical state versions, and only retains the most recent state.
 
 ## Team
 
-A group of TFE users, which can be given permission to access and/or edit various objects (workspaces, policies, etc.) within an organization. A team belongs to a single organization. Users can belong to any number of teams in any number of organizations.
+[team]: glossary.html#team
+[teams]: glossary.html#team
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/teams.html
+-> Terraform Enterprise
+
+A group of TFE users, which can be given permission to access and/or edit various objects ([workspaces][], [policies][], etc.) within an [organization][]. A team belongs to a single organization. Users can belong to any number of teams in any number of organizations.
+
+- [TFE docs: Teams](/docs/enterprise/users-teams-organizations/teams.html)
 
 ## Terraform
 
+[terraform]: glossary.html#terraform
+
 A tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.
 
-https://www.terraform.io/intro/index.html
+- [Intro to Terraform](/intro/index.html)
 
 ## TFE
 
+[tfe]: glossary.html#tfe
+[terraform enterprise]: glossary.html#tfe
+
 Terraform Enterprise.
 
-https://www.terraform.io/docs/enterprise/index.html
+- [TFE docs](/docs/enterprise/index.html)
 
 ## Trigger
 
-Something that causes a new run to queue. Can be UI/VCS-, API- or CLI-driven.
+[trigger]: glossary.html#trigger
+[triggers]: glossary.html#trigger
 
-https://www.terraform.io/docs/enterprise/run/ui.html
+-> Terraform Enterprise
 
-## (API) Tokens
+Something that causes a new [run][] to queue. Runs can be UI/VCS-driven (in which case the trigger is a new VCS commit or a UI action), API-driven (in which case the trigger is an API call) or CLI-driven (in which case the trigger is a CLI command).
 
-Revocable alphanumeric strings that allow a user to authenticate itself in order to use the API. Different kinds of tokens grant different permissions. Can be granted by User, Team and/or Organization.
+- [TFE docs: UI/VCS-based Run Workflow](/docs/enterprise/run/ui.html)
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/users.html#api-tokens
+## (API) Token
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/teams.html#api-tokens
+[token]: glossary.html#api-token
+[tokens]: glossary.html#api-token
 
-https://www.terraform.io/docs/enterprise/users-teams-organizations/organizations.html#api-tokens
+-> Terraform Enterprise
 
-## Tool Version
+A revocable secret string that authenticates a user, to allow use of TFE's [API][] or the [remote backend][].
 
-A particular version of the `terraform` binary, aka “Terraform Version”. Specifies a URL, a SHA256 checksum and enabled/beta flags.
+Different kinds of tokens grant different permissions. Tokens can be granted by user, [team][], or [organization][].
+
+Many applications other than TFE use token-based authentication, but within TFE's documentation and UI, "token" without any other qualification generally means a TFE API token.
+
+- [TFE docs: User Tokens](/docs/enterprise/users-teams-organizations/users.html#api-tokens)
+- [TFE docs: Team Tokens](/docs/enterprise/users-teams-organizations/teams.html#api-tokens)
+- [TFE docs: Organization Tokens](/docs/enterprise/users-teams-organizations/organizations.html#api-tokens)
+
+## Terraform Version
+
+[terraform version]: glossary.html#tool-version
+[terraform versions]: glossary.html#tool-version
+
+-> Terraform Enterprise
+
+A particular version of the `terraform` binary available for use in TFE workspaces. Specifies a URL, a SHA256 checksum and enabled/beta flags.
+
+Available Terraform versions are configured at a per-instance level in [Private Terraform Enterprise][], and can be managed by [site admins][].
+
+- [PTFE docs: Managing Terraform Versions](/docs/enterprise/private/admin/resources.html#managing-terraform-versions)
 
 ## Variables
 
-Key/values used in a run. Values can be “sensitive” and protected by Vault.
+[variables]: glossary.html#variables
+[input variables]: glossary.html#variables
 
-https://www.terraform.io/docs/enterprise/workspaces/variables.html
+Also "input variables".
+
+Key/value pairs used in a [run][]. Terraform [modules][] can declare variables to allow customization. For child modules, the parent module provides a value when calling the module; for the [root module][], values are provided at run time.
+
+TFE lets you set root input variables in a [workspace][], so all collaborators can use the same values. Variable values marked as "sensitive" become unreadable in the UI and API, and all variable values are protected by Vault.
+
+- [Terraform docs: Input Variables](/docs/configuration/variables.html)
+- [TFE docs: Variables](/docs/enterprise/workspaces/variables.html)
 
 ## VCS
 
-Version Control System, like Git.
+[vcs]: glossary.html#vcs
 
-https://en.wikipedia.org/wiki/Version_control
+Version Control System, like [Git][]. Software that tracks changes over time to a collection of files, making it possible to keep track of changes, undo changes, and combine changes made in parallel by different users. Usually used for any non-trivial code effort, including infrastructure as code.
+
+Different VCSes use different models for history; Git models changes as a directed acyclic graph of [commits][], and parallel changes that begin from the same parent commit become diverging [branches][] (which might later be merged together).
+
+- [Wikipedia: Version Control](https://en.wikipedia.org/wiki/Version_control)
 
 ## VCS Provider
 
-Can be one of GitHub, GitHub Enterprise, GitLab.com, GitLab EE and CE, Bitbucket Cloud, or Bitbucket Server.
+[vcs provider]: glossary.html#vcs-provider
+[vcs providers]: glossary.html#vcs-provider
 
-https://www.terraform.io/docs/enterprise/vcs/index.html
+-> Terraform Enterprise
+
+A specific service that provides [VCS][] features, with the goal of enabling teams to collaborate on code. TFE can integrate with VCS providers to access your Terraform [configurations][] and [modules][], and currently supports GitHub, GitHub Enterprise, GitLab.com, GitLab EE and CE, Bitbucket Cloud, and Bitbucket Server.
+
+- [TFE docs: Connecting VCS Providers](/docs/enterprise/vcs/index.html)
+
+## Webhook
+
+[webhook]: glossary.html#webhook
+[webhooks]: glossary.html#webhook
+
+A server-to-server HTTP request, in which one system responds to a change in its internal state by asking another system to perform some kind of action.
+
+The recipient of a webhook might return information to the requesting system, call other webhooks in response, perform its action silently, or ignore the request entirely.
+
+Terraform Enterprise uses webhooks in multiple ways. Most notably:
+
+- TFE creates webhook configurations on [VCS providers][], so that they send webhook requests to TFE whenever linked [repositories][] receive [pull requests][] or new [commits][]. ([TFE docs: UI/VCS-driven Runs](/docs/enterprise/run/ui.html))
+- Users can create webhook configurations on TFE [workspaces][], so that TFE will send run notification webhooks to Slack or other external services. ([TFE docs: Run Notifications](/docs/enterprise/workspaces/notifications.html))
 
 ## Working Directory
 
-The directory where `terraform init` runs, creating a `.terraform` subdirectory. All subsequent commands for the same configuration should then be run from the same working directory.
+[working directory]: glossary.html#working-directory
+[working directories]: glossary.html#working-directory
+
+The directory where `terraform init` runs, creating a `.terraform` subdirectory. All subsequent commands for the same [configuration][] should then be run from the same working directory.
+
+The [root module][] consists of all of the configuration files in the top level of Terraform's working directory. Subdirectories of the working directory can contain child [modules][].
 
 ## Workspace
 
-A complex object that represents everything needed to manage a specific collection of infrastructure resources over time. In particular, this includes a Terraform configuration (which has multiple versions over time, and which can come from a repo or from manual uploads), a set of variables, state data that represents the current and historical condition of the infrastructure, and historical information about runs. All runs occur in the context of a workspace — they use that workspace’s config data, use that workspaces’ state to identify the real infrastructure being managed, and edit that workspaces’ state to match any infrastructure changes during the run. A workspace belongs to an organization.
+[workspace]: glossary.html#workspace
+[workspaces]: glossary.html#workspace
 
-https://www.terraform.io/docs/enterprise/workspaces/index.html
+In Terraform CLI, a workspace is an isolated instance of [state][] data. Using multiple workspaces lets you manage multiple non-overlapping sets of infrastructure from a single [configuration][] in a single [working directory][].
 
+In Terraform Enterprise, a workspace is a complex object that represents everything needed to manage a specific collection of infrastructure resources over time. In particular, this includes:
 
+- A Terraform [configuration][] (which has multiple versions over time, and which can come from a repo or from manual uploads)
+- A set of [variables][]
+- [State][] data that represents the current and historical condition of the infrastructure
+- Historical information about [runs][].
 
-## Additional term definitions requested
+All TFE runs occur in the context of a workspace — they use that workspace's config data, use that workspaces' state to identify the real infrastructure being managed, and edit that workspaces' state to match any infrastructure changes during the run. A workspace belongs to an [organization][].
 
-These terms are found in TFE and could use definitions added above:
-
-1. Branch
-
-2. Commit
-
-3. Broad User Adoption
-
-4. Forked repo
-
-5. Webhook
-
-6. API
-
-7. JSON
-
-8. Archivist
-
-9. OSS
-
-10. S3
-
-11. IDs: Run ID, Workspace ID, etc
-
-12. TFE V1 vs V2
-
+- [TFE docs: Workspaces](/docs/enterprise/workspaces/index.html)
+- [Terraform docs: Workspaces](/docs/state/workspaces.html)

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # Terraform Glossary
 
-This page collects brief definitions of some of the technical terms and jargon used in the documentation for Terraform and Terraform Enterprise, as well as some terms that come up frequently in conversations throughout the Terraform community.
+This page collects brief definitions of some of the technical terms used in the documentation for Terraform and Terraform Enterprise, as well as some terms that come up frequently in conversations throughout the Terraform community.
 
 <div style="column-width: 14em;">
 
@@ -132,7 +132,7 @@ In conversation, it's common to refer to "applying a [plan][]" (usually in the c
 
 In Terraform's [configuration][] language: a syntax construct that assigns a value to a name. Arguments have the form `<IDENTIFIER> = <EXPRESSION>`, and they appear within blocks.
 
-Most of a Terraform configuration consists of using arguments to configure Terraform [resources][]. Each resource type defines the arguments its resources can use, the allowed values for each argument, and which arguments are required or optional. Info about a given resource type can be found in the docs for that resource's [provider][].
+Most of a Terraform configuration consists of using arguments to configure Terraform [resources][]. Each resource type defines the arguments its resources can use, the allowed values for each argument, and which arguments are required or optional. Information about a given resource type can be found in the docs for that resource's [provider][].
 
 - [Terraform docs: Config Language — Arguments, Blocks and Expressions](/docs/configuration/index.html#arguments-blocks-and-expressions)
 
@@ -152,7 +152,7 @@ Terraform [resources][] and [data sources][] make all of their [arguments][] ava
 [backend]: glossary.html#backend
 [backends]: glossary.html#backend
 
-The part of Terraform's core that determines how Terraform stores [state][] and performs [operations][remote operations] (like [plan][], [apply][], import, etc.). Backends are not plugins (and there are no third-party backends), but Terraform has multiple backends to choose from, which can be configured in a variety of ways.
+The part of Terraform's core that determines how Terraform stores [state][] and performs [operations][remote operations] (like [plan][], [apply][], import, etc.). Terraform has multiple backends to choose from, which can be configured in a variety of ways. Backends are not plugins, so it is not possible to install additional backends.
 
 In a general computer science sense, a backend is any lower-level implementation that enables a higher-level feature. But in the context of Terraform, "backend" always means the built-in code that handles state and operations.
 
@@ -166,7 +166,7 @@ In a general computer science sense, a backend is any lower-level implementation
 
 An API service for storing and retrieving arbitrary chunks of data using opaque addresses, which are indexed by a directory of some kind. The most notable example is AWS's [S3][].
 
-You do not need to be familiar with the properties and advantages of blob storage services in order to work with Terraform or TFE. However, you might need to administer or configure an S3-compatible blob storage service if you are responsible for administering a [Private Terraform Enterprise][] instance.
+You do not need to be familiar with the properties and advantages of blob storage services in order to work with Terraform or TFE. However, you might need to administer or configure a blob storage service if you are responsible for administering a [Private Terraform Enterprise][] instance.
 
 ## Block
 
@@ -195,13 +195,13 @@ resource "aws_vpc" "main" {
 
 In some [version control systems][vcs]: a semi-independent history of changes to content in a repository. A branch generally shares some history with other branches in the same repository, but eventually diverges to include changes that aren't yet present elsewhere.
 
-A repository usually has a default branch (whose name, in [Git][], defaults to `master`), which successful changes are eventually merged into. Most modern development workflows also include topic branches (where a specific set of changes is explored, iterated on, and verified), and some workflows include long-lived branches other than the default branch (usually for maintaining older but still supported versions of software).
+A repository usually has a default branch (whose name, in [Git][], defaults to `master`), which successful changes are eventually merged into. Most modern development workflows also include topic branches (where a specific set of changes is explored, iterated on, and verified), and some workflows include long-lived branches other than the default branch.
 
 ## CLI
 
 [cli]: glossary.html#cli
 
-Command-line interface. The `terraform` tool and its subcommands use a CLI to accept instructions and return text output.
+Command-line interface. The `terraform` command expects to be run in a CLI (a Unix shell or the Windows command prompt), which it uses to accept instructions and return text output.
 
 We often use "Terraform CLI" to refer to the core open source Terraform binary when we need to distinguish it from other parts of the Terraform ecosystem (like Terraform Enterprise or the Terraform GitHub Actions).
 
@@ -226,7 +226,7 @@ In Git, commits act like a complete snapshot of the contents of a repo, on a spe
 
 Also "config".
 
-Code written in Terraform's configuration language that declaratively describes the desired state of your infrastructure. A complete config consists of a [root module][], which can optionally call any number of child [modules][].
+Code written in [Terraform's configuration language][hcl] that declaratively describes the desired state of your infrastructure. A complete config consists of a [root module][], which can optionally call any number of child [modules][].
 
 - [Terraform docs: Configuration Language](/docs/configuration/index.html)
 - [Introduction to Terraform](/intro/index.html)
@@ -242,7 +242,7 @@ Code written in Terraform's configuration language that declaratively describes 
 
 Also "config version".
 
-The contents of a Terraform [config][] at a specific moment in time. This concept only applies to Terraform Enterprise, since the Terraform CLI doesn't have any visibility into repeated runs over a period of time.
+The contents of a Terraform [config][] at a specific moment in time. This concept only applies to Terraform Enterprise, since the Terraform CLI doesn't have visibility into repeated runs for a specific configuration over a period of time.
 
 Every stage of a given run uses one specific configuration version.
 
@@ -312,7 +312,7 @@ An identifier; an opaque string permanently associated with a specific object, w
 
 In Terraform, many [resource][] types have an ID [attribute][] that helps link Terraform's [state][] to the real infrastructure resource being managed.
 
-In Terraform Enterprise, most internal application objects (like [workspaces][], users, [policies][], etc.) can be identified by both a name (possibly including the parents, for disambiguation) and by an opaque, permanent ID. Most API endpoints use IDs instead of names, since names sometimes change. IDs for TFE's application objects are sometimes called "external IDs."
+In Terraform Enterprise, most internal application objects (like [workspaces][], users, [policies][], etc.) can be identified by both a name and by an opaque, permanent ID. Most API endpoints use IDs instead of names, since names sometimes change. IDs for TFE's application objects are sometimes called "external IDs."
 
 You can usually copy an external ID from the URL bar when viewing an object in TFE's UI. Workspaces don't display an ID in the URL bar, but their general settings page includes a UI control for viewing and copying the ID.
 
@@ -347,7 +347,7 @@ Terraform and Terraform Enterprise often interact with JSON data in order to con
 
 The ability to prevent new [runs][] from starting in a given [workspace][]. Workspaces are automatically locked while a run is in progress, and can also be manually locked.
 
-Some other Terraform [backends][] can also lock state during runs.
+The [`remote` backend][remote backend] respects the lock status in Terraform Enterprise workspaces. Some other Terraform [backends][] can also lock state during runs.
 
 ## Log
 
@@ -377,7 +377,7 @@ Modules define [input variables][] (which the calling module can set values for)
 
 An open standard for token-based authorization between applications on the internet.
 
-Terraform Enterprise uses OAuth to connect your organization to your [VCS provider][]. Generally takes an `id` and `secret` from your VCS provider to give access to TFE and allow it to download configuration from the provider.
+Terraform Enterprise uses OAuth to connect your organization to your [VCS provider][]. Generally takes an `id` and `secret` from your VCS provider to give access to TFE and allow it to pull in configuration from the provider.
 
 - [TFE docs: VCS Integration](/docs/enterprise/vcs/index.html)
 
@@ -388,9 +388,9 @@ Terraform Enterprise uses OAuth to connect your organization to your [VCS provid
 
 -> Terraform Enterprise
 
-The set of configuration that a TFE organization needs in order to connect to a specific [VCS provider][].
+An entity collecting the configuration information that a TFE organization needs in order to connect to a specific [VCS provider][].
 
-An OAuth client needs an [OAuth token][] in order to actually access data belonging to a user or organization in that VCS provider. The client can be created with an existing token for that VCS provider (when created via TFE's API), or it can be created with the details TFE needs in order to request a token. Requesting a token requires a user to click through and approve access with their VCS provider account.
+An OAuth client needs an [OAuth token][] in order to actually access data belonging to a user or organization in that VCS provider. The client can be created with an existing token for that VCS provider (API-only, and not supported for some VCS providers), or it can be created with the details TFE needs in order to request a token. Requesting a token requires a user to click through and approve access with their VCS provider account.
 
 - [TFE docs: VCS Integration](/docs/enterprise/vcs/index.html)
 - [TFE API docs: OAuth Clients](/docs/enterprise/api/oauth-clients.html)
@@ -437,7 +437,7 @@ Data exported by a Terraform [module][], which can be displayed to a user and/or
 
 [oss]: glossary.html#oss
 
-"Open-Source Software". Terraform and the publicly available Terraform providers are open-source. Terraform Enterprise is closed-source commercial software.
+"Open-Source Software". Terraform and the publicly available Terraform providers are open-source. Terraform Enterprise is closed-source commercial software, but makes use of Terraform and the available Terraform providers.
 
 - [Wikipedia: Open-Source Software](https://en.wikipedia.org/wiki/Open-source_software)
 
@@ -500,7 +500,7 @@ TFE always uses a saved plan as the input to an [apply][], so that applies never
 
 -> Terraform Enterprise
 
-Part of a [run][]. After gathering the [configuration][], [state][], and [plan file][] for a run, TFE runs [Sentinel][] to check that data against the active [policies][]. Policy checks end in success or failure. If a failure occurs in a required item, this can prevent the run from proceeding to the [apply][] stage.
+Part of a [run][]. After gathering the [configuration][], [state][], and [plan file][] for a run, TFE runs [Sentinel][] to check that data against the active [policies][]. Policy checks end in success or failure. If a failure occurs in a required policy, this can prevent the run from proceeding to the [apply][] stage.
 
 - [TFE docs: Run States and Stages](/docs/enterprise/run/states.html)
 
@@ -702,7 +702,7 @@ Many other cloud or self-hosted services provide [APIs][] that are compatible wi
 
 Terraform's `aws` [provider][] can manage S3 resources.
 
-Private Terraform Enterprise uses an S3-compatible [blob storage][] service when configured to use external services for storage.
+Private Terraform Enterprise can use an S3-compatible [blob storage][] service when configured to use external services for storage.
 
 - [AWS: S3](https://aws.amazon.com/s3/)
 
@@ -767,7 +767,7 @@ A type of access credential based on public key cryptography, used to log into s
 TFE uses SSH private keys for two kinds of operations:
 
 - Downloading private Terraform [modules][] with [Git][]-based sources during a Terraform run. Keys for downloading modules are assigned per-workspace.
-- Bringing content from a connected [VCS provider][] into TFE, usually when downloading a Terraform [configuration][] for a [workspace][] or importing a module into the [private module registry][]. Only some VCS providers require an SSH key, but others can optionally use SSH instead of the provider's normal API.
+- Bringing content from a connected [VCS provider][] into TFE, usually when pulling in a Terraform [configuration][] for a [workspace][] or importing a module into the [private module registry][]. Only some VCS providers require an SSH key, but others can optionally use SSH if an SSH key is provided.
 
 - [Wikipedia: SSH](https://en.wikipedia.org/wiki/Secure_Shell)
 - [TFE docs: SSH Keys for Cloning Modules](/docs/enterprise/workspaces/ssh-keys.html)
@@ -902,7 +902,7 @@ A specific service that provides [VCS][] features, with the goal of enabling tea
 [webhook]: glossary.html#webhook
 [webhooks]: glossary.html#webhook
 
-A server-to-server HTTP request, in which one system responds to a change in its internal state by asking another system to perform some kind of action.
+A server-to-server HTTP request, in which one system responds to a change in its internal state by sending information to another system.
 
 The recipient of a webhook might return information to the requesting system, call other webhooks in response, perform its action silently, or ignore the request entirely.
 
@@ -934,7 +934,7 @@ In Terraform Enterprise, a workspace is a complex object that represents everyth
 - [State][] data that represents the current and historical condition of the infrastructure
 - Historical information about [runs][].
 
-All TFE runs occur in the context of a workspace — they use that workspace's config data, use that workspaces' state to identify the real infrastructure being managed, and edit that workspaces' state to match any infrastructure changes during the run. A workspace belongs to an [organization][].
+All TFE runs occur in the context of a workspace — they use that workspace's config data, use that workspace's state to identify the real infrastructure being managed, and edit that workspace's state to match any infrastructure changes during the run. A workspace belongs to an [organization][].
 
 - [TFE docs: Workspaces](/docs/enterprise/workspaces/index.html)
 - [Terraform docs: Workspaces](/docs/state/workspaces.html)

--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -1,9 +1,9 @@
 <%# Call with partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) -%>
 <% other_docs = {
-    "Download Terraform" => "/downloads.html",
-    "Introduction to Terraform" => "/intro/index.html",
     "Terraform CLI" => "/docs/index.html",
     "Terraform Enterprise" => "/docs/enterprise/index.html",
+    "Download Terraform" => "/downloads.html",
+    "Introduction to Terraform" => "/intro/index.html",
     "Guides and Whitepapers" => "/guides/index.html",
     "Terraform Registry" => "/docs/registry/index.html",
     "Terraform GitHub Actions" => "/docs/github-actions/index.html",
@@ -12,6 +12,9 @@
     <h4>Other Docs</h4>
 
     <ul class="nav docs-sidenav">
+      <li<%= sidebar_current("terraform-glossary") %>>
+        <a class="back" href="/docs/glossary.html">Terraform Glossary</a>
+      </li>
 <% other_docs.each do |name, path| -%>
 <% unless name.downcase == skip.downcase -%>
       <li>

--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -1,0 +1,22 @@
+<%# Call with partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) -%>
+<% other_docs = {
+    "Download Terraform" => "/downloads.html",
+    "Introduction to Terraform" => "/intro/index.html",
+    "Terraform CLI" => "/docs/index.html",
+    "Terraform Enterprise" => "/docs/enterprise/index.html",
+    "Guides and Whitepapers" => "/guides/index.html",
+    "Terraform Registry" => "/docs/registry/index.html",
+    "Terraform GitHub Actions" => "/docs/github-actions/index.html",
+    "Extending Terraform" => "/docs/extend/index.html"
+} -%>
+    <h4>Other Docs</h4>
+
+    <ul class="nav docs-sidenav">
+<% other_docs.each do |name, path| -%>
+<% unless name.downcase == skip.downcase -%>
+      <li>
+        <a class="back" href="<%= path %>"><%= name %></a>
+      </li>
+<% end %>
+<% end -%>
+    </ul>

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -454,37 +454,8 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform Enterprise" }) %>
 
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
   <% end %>
 
   <%= yield %>

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -125,33 +125,7 @@
       </li>
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/github-actions/index.html">Terraform GitHub Actions</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Extending Terraform" }) %>
   <% end %>
 
   <%= yield %>

--- a/content/source/layouts/github-actions.erb
+++ b/content/source/layouts/github-actions.erb
@@ -35,37 +35,7 @@
 
     </ul>
 
-    <h4>Other Docs</h4>
-
-    <ul class="nav docs-sidenav">
-      <li>
-        <a class="back" href="/downloads.html">Download Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/intro/index.html">Introduction to Terraform</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/index.html">Terraform CLI</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/enterprise/index.html">Terraform Enterprise</a>
-      </li>
-
-      <li>
-        <a class="back" href="/guides/index.html">Guides and Whitepapers</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/registry/index.html">Terraform Registry</a>
-      </li>
-
-      <li>
-        <a class="back" href="/docs/extend/index.html">Extending Terraform</a>
-      </li>
-    </ul>
+    <%= partial("layouts/otherdocs", :locals => { :skip => "Terraform GitHub Actions" }) %>
   <% end %>
 
   <%= yield %>


### PR DESCRIPTION
This is a new glossary for both Terraform and Terraform Enterprise! Much of the content you might have seen in a google doc before, but some of it is new; see the commit history for details. 

This PR also changes the way the "Other Docs" section gets added to nav sidebars (accompanying PR for hashicorp/terraform incoming soon), and includes the glossary as a top-level item in "other docs" for easy access across different regions of the docs. 

Screenshot funtimes so you can see the big ol multi-column TOC: 

![image](https://user-images.githubusercontent.com/484309/54046719-16e94c00-41cd-11e9-86b8-2a91aa434eff.png)
