### PR TITLE
Remove bitbucket cloud from OAuth creation docs

### DIFF
--- a/content/source/docs/enterprise/api/oauth-clients.html.md
+++ b/content/source/docs/enterprise/api/oauth-clients.html.md
@@ -148,13 +148,12 @@ Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization that will be connected to the VCS provider. The organization must already exist in the system, and the user must have permissions to initiate the connection.
 
-This endpoint allows you to create a VCS connection between an organization and a VCS provider (GitHub, Bitbucket, or GitLab) for use when creating or setting up workspaces. By using this API endpoint, you can provide a pre-generated OAuth token string instead of going through the process of creating a GitHub/GitLab OAuth Application or Bitbucket App Link. To learn how to generate one of these token strings for your VCS provider, you can read the following documentation:
+This endpoint allows you to create a VCS connection between an organization and a VCS provider (GitHub or GitLab) for use when creating or setting up workspaces. By using this API endpoint, you can provide a pre-generated OAuth token string instead of going through the process of creating a GitHub or GitLab OAuth Application. To learn how to generate one of these token strings for your VCS provider, you can read the following documentation:
 
 * [GitHub and GitHub Enterprise](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
-* [Bitbucket Cloud](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html)
 * [GitLab, GitLab Community Edition, and GitLab Enterprise Edition](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#creating-a-personal-access-token)
 
-~> **Note:** This endpoint does not currently support creation of a Bitbucket Server OAuth Client.
+~> **Note:** This endpoint does not currently support creation of a Bitbucket Cloud or Bitbucket Server OAuth Client.
 
 Status  | Response                                        | Reason
 --------|-------------------------------------------------|----------


### PR DESCRIPTION
Bitbucket does not support using personal access tokens as oauth tokens, so our API to create a client was incorrect. This was confusing users. Bitbucket also does not issue oauth tokens via their API (just the normal OAuth flow), so we cannot easily code a workaround that fetches a token.