### PR TITLE
Document extensions required by PTFE

### DIFF
--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -155,14 +155,15 @@ When Terraform Enterprise uses an external PostgreSQL database, the
 following must be present on it:
 
 * PostgreSQL version 9.4 or greater
-* User with all privileges granted on the schemas created and the ability to run "CREATE EXTENSION" on the database
+* User with the ability to create/modify/read tables and indices on all schemas created
+  * If the user can not create extensions (ie is not a superuser), then the extensions listed below must be created first
 * The following PostgreSQL schemas must be installed into the database: `rails`, `vault`, `registry`
 
 To create schemas in PostgreSQL, the `CREATE SCHEMA` command is used. So to
 create the above required schemas, the following snippet must be run on the
 database:
 
-```
+```sql
 CREATE SCHEMA rails;
 CREATE SCHEMA vault;
 CREATE SCHEMA registry;
@@ -171,6 +172,18 @@ CREATE SCHEMA registry;
 When providing optional extra keyword parameters for the database connection,
 note an additional restriction on the `sslmode` parameter is that only the
 `require`, `verify-full`, `verify-ca`, and `disable` values are allowed.
+
+
+#### Extensions
+
+If the configured PostgreSQL user does not have permission to create PostgreSQL extensions
+(ie is not a superuser), then run the following SQL commands to create the proper extensions:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS "hstore";
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "citext";
+```
 
 ### External Vault Option
 

--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -156,7 +156,7 @@ following must be present on it:
 
 * PostgreSQL version 9.4 or greater
 * User with the ability to create/modify/read tables and indices on all schemas created
-  * If the user can not create extensions (ie is not a superuser), then the extensions listed below must be created first
+  * If it's not feasible to have a user with "CREATE EXTENSION", then create the [extensions](#extensions) below before installation
 * The following PostgreSQL schemas must be installed into the database: `rails`, `vault`, `registry`
 
 To create schemas in PostgreSQL, the `CREATE SCHEMA` command is used. So to


### PR DESCRIPTION
Customer that want to use a more restrictive user will need to create the postgresql extensions before hand. This documents what those extensions are.