### PR TITLE
Update the required TF version for the Free Tier

### DIFF
--- a/content/source/docs/enterprise/free/index.html.md
+++ b/content/source/docs/enterprise/free/index.html.md
@@ -17,7 +17,7 @@ Your free account allows you to share unlimited workspaces with an unlimited num
 
 To begin using Terraform Enterprise for state storage, do the following steps:
 
-1. Upgrade Terraform to 0.11.12 or later.
+1. Upgrade Terraform to 0.11.13 or later.
 1. Create (or join) an organization, and optionally add other users to it.
 1. Configure credentials for Terraform to use.
 1. Update your Terraform configurations to use remote workspaces.
@@ -29,9 +29,9 @@ Currently, only users who have been added to the beta can create free organizati
 
 If you aren't participating in the beta, you were probably sent here by a beta participant who added you to their organization. You can ignore the instructions about creating an organization.
 
-## Upgrade to Terraform 0.11.12 or later
+## Upgrade to Terraform 0.11.13 or later
 
-The Terraform Enterprise Free Tier requires Terraform 0.11.12 or later. [Upgrade Terraform](https://releases.hashicorp.com/terraform/) on any systems where you or your collaborators plan to run Terraform.
+The Terraform Enterprise Free Tier requires Terraform 0.11.13 or later. [Upgrade Terraform](https://releases.hashicorp.com/terraform/) on any systems where you or your collaborators plan to run Terraform.
 
 The newest 0.12 preview releases (as of alpha 4) also support the Terraform Enterprise Free Tier.
 

--- a/content/source/docs/enterprise/free/overview.html.md
+++ b/content/source/docs/enterprise/free/overview.html.md
@@ -29,13 +29,13 @@ The application manages access in two ways:
 
 ## The Backend
 
-The `remote` backend, built into Terraform 0.11.12 and later, allows the Terraform CLI to seamlessly work with state in the Terraform Free State Storage application.
+The `remote` backend, built into Terraform 0.11.13 and later, allows the Terraform CLI to seamlessly work with state in the Terraform Free State Storage application.
 
 The backend requires an API token, which is created by an application user and then stored in Terraform's [CLI config file](/docs/commands/cli-config.html). Once a token is configured, Terraform can work with any workspace accessible to the user who created the token.
 
 Terraform still defaults to storing state locally, but any Terraform configuration can enable remote state with [a backend configuration](/docs/backends/config.html) that specifies which remote workspace to use.
 
--> **Note:** Several earlier versions of Terraform included preview versions of the `remote` backend. The Terraform Enterprise Free Tier relies on enhancements added in 0.11.12, and does not work with these earlier versions.
+-> **Note:** Several earlier versions of Terraform included preview versions of the `remote` backend. The Terraform Enterprise Free Tier relies on enhancements added in 0.11.13, and does not work with these earlier versions.
 
 ## The Workflow
 


### PR DESCRIPTION
There was a bug in TF v0.11.12, so TF v0.11.13 is the version people
should use when they are using the Free Tier.