### PR TITLE
Fix remaining broken links (in this repo)

### DIFF
--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -33,7 +33,7 @@ Status  | Response                                     | Reason
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 <!-- ^ Include status codes even if they're plain 200/404. If a JSON API document is returned, specify the `type`. If the table includes links, use reference-style links to keep the table size small. -->

--- a/content/source/docs/enterprise/api/account.md
+++ b/content/source/docs/enterprise/api/account.md
@@ -234,5 +234,5 @@ curl \
 [401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/admin/organizations.html.md
+++ b/content/source/docs/enterprise/api/admin/organizations.html.md
@@ -25,7 +25,7 @@ Status  | Response                                        | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
@@ -126,7 +126,7 @@ Status  | Response                                        | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Available Related Resources

--- a/content/source/docs/enterprise/api/admin/runs.html.md
+++ b/content/source/docs/enterprise/api/admin/runs.html.md
@@ -25,7 +25,7 @@ Status  | Response                               | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
@@ -140,7 +140,7 @@ Status  | Response                               | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request body

--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -22,7 +22,7 @@ Status  | Response                                         | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -64,7 +64,7 @@ Status  | Response                                     | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -133,7 +133,7 @@ Status  | Response                                         | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -183,7 +183,7 @@ Status  | Response                                         | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -272,7 +272,7 @@ Status  | Response                                         | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -324,7 +324,7 @@ Status  | Response                                     | Reason
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -403,7 +403,7 @@ Status  | Response                                         | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -444,7 +444,7 @@ Status  | Response                                         | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -514,7 +514,7 @@ Status  | Response                                         | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body

--- a/content/source/docs/enterprise/api/admin/terraform-versions.html.md
+++ b/content/source/docs/enterprise/api/admin/terraform-versions.html.md
@@ -25,7 +25,7 @@ Status  | Response                                             | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
@@ -112,7 +112,7 @@ Status  | Response                                             | Reason
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -196,7 +196,7 @@ Status  | Response                                             | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -246,7 +246,7 @@ Status  | Response                                             | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -330,7 +330,7 @@ Status  | Response                  | Reason
 [204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/admin/users.html.md
+++ b/content/source/docs/enterprise/api/admin/users.html.md
@@ -25,7 +25,7 @@ Status  | Response                                | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
@@ -162,7 +162,7 @@ Status  | Response                                | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -226,7 +226,7 @@ Status  | Response                                | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -290,7 +290,7 @@ Status  | Response                                | Reason
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -352,7 +352,7 @@ Status  | Response                                | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -416,7 +416,7 @@ Status  | Response                                | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/admin/workspaces.html.md
+++ b/content/source/docs/enterprise/api/admin/workspaces.html.md
@@ -25,7 +25,7 @@ Status  | Response                                     | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
@@ -141,7 +141,7 @@ Status  | Response                                     | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters

--- a/content/source/docs/enterprise/api/applies.md
+++ b/content/source/docs/enterprise/api/applies.md
@@ -77,5 +77,5 @@ curl \
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/modules.html.md
+++ b/content/source/docs/enterprise/api/modules.html.md
@@ -58,7 +58,7 @@ Status  | Response                                           | Reason
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -158,7 +158,7 @@ Status  | Response                                           | Reason
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 
@@ -257,7 +257,7 @@ Status  | Response                                                   | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 

--- a/content/source/docs/enterprise/api/notification-configurations.html.md
+++ b/content/source/docs/enterprise/api/notification-configurations.html.md
@@ -127,7 +127,7 @@ Status  | Response                                                      | Reason
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body

--- a/content/source/docs/enterprise/api/oauth-clients.html.md
+++ b/content/source/docs/enterprise/api/oauth-clients.html.md
@@ -375,5 +375,5 @@ curl \
 [400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise/api/oauth-tokens.html.md
@@ -227,5 +227,5 @@ curl \
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -27,7 +27,7 @@ Status  | Response                                                | Reason
 
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -21,7 +21,7 @@ Status  | Response                                        | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 
 ### Sample Request
 
@@ -84,7 +84,7 @@ Status  | Response                                        | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 
 ### Sample Request
 
@@ -143,7 +143,7 @@ Status  | Response                                        | Reason
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -238,7 +238,7 @@ Status  | Response                                        | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body

--- a/content/source/docs/enterprise/api/plans.html.md
+++ b/content/source/docs/enterprise/api/plans.html.md
@@ -28,7 +28,7 @@ Status  | Response                                | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -33,7 +33,7 @@ Status  | Response                                     | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -139,7 +139,7 @@ Status  | Response                                        | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/policy-sets.html.md
+++ b/content/source/docs/enterprise/api/policy-sets.html.md
@@ -31,7 +31,7 @@ Status  | Response                                      | Reason
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -140,7 +140,7 @@ Status  | Response                                      | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
@@ -216,7 +216,7 @@ Status  | Response                                      | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -283,7 +283,7 @@ Status  | Response                                      | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -46,7 +46,7 @@ Status  | Response                               | Reason
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]              | Malformed request body (missing attributes, wrong types, etc.)
 
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -34,7 +34,7 @@ Status  | Response                                             | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -35,7 +35,7 @@ Status  | Response                                     | Reason
 [409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
 [412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -102,7 +102,7 @@ curl \
             "vcs-commit-sha": null,
             "vcs-commit-url": null,
             "created-at": "2018-07-12T20:32:01.490Z",
-            "hosted-state-download-url": "https://terraform.io/v1/object/f55b739b-ff03-4716-b436-726466b96dc4",
+            "hosted-state-download-url": "https://archivist.terraform.io/v1/object/f55b739b-ff03-4716-b436-726466b96dc4",
             "serial": 1
         },
         "links": {
@@ -241,7 +241,7 @@ Status  | Response                                     | Reason
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -86,7 +86,7 @@ Status  | Response                                | Reason
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body

--- a/content/source/docs/enterprise/api/user-tokens.md
+++ b/content/source/docs/enterprise/api/user-tokens.md
@@ -245,5 +245,5 @@ curl \
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/users.md
+++ b/content/source/docs/enterprise/api/users.md
@@ -73,5 +73,5 @@ curl \
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -607,7 +607,7 @@ Status  | Response                                     | Reason(s)
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
@@ -706,7 +706,7 @@ Status  | Response                                     | Reason(s)
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
@@ -775,7 +775,7 @@ Status  | Response                                     | Reason(s)
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API document]: https://www.terraform.io/docs/enterprise/api/index.html#json-api-documents
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request

--- a/content/source/docs/enterprise/guides/recommended-practices/part1.html.md
+++ b/content/source/docs/enterprise/guides/recommended-practices/part1.html.md
@@ -15,7 +15,7 @@ There are two major challenges everyone faces when trying to improve their provi
 
 1. Technical complexity — Different infrastructure providers use different interfaces to provision new resources, and the inconsistency between these interfaces imposes extra costs on daily operations. These costs get worse as you add more infrastructure providers and more collaborators.
 
-    Terraform addresses this complexity by separating the provisioning workload. It uses a single core engine to read infrastructure as code configurations and determine the relationships between resources, then uses many [provider plugins](https://www.terraform.io/docs/providers/index.html) to create, modify, and destroy resources on the infrastructure providers. These provider plugins can talk to IaaS (e.g. AWS, GCP, Microsoft Azure, OpenStack), PaaS (e.g. Heroku), or SaaS services (e.g. GitHub, DNSimple, Cloudflare).
+    Terraform addresses this complexity by separating the provisioning workload. It uses a single core engine to read infrastructure as code configurations and determine the relationships between resources, then uses many [provider plugins](/docs/providers/index.html) to create, modify, and destroy resources on the infrastructure providers. These provider plugins can talk to IaaS (e.g. AWS, GCP, Microsoft Azure, OpenStack), PaaS (e.g. Heroku), or SaaS services (e.g. GitHub, DNSimple, Cloudflare).
 
     In other words, Terraform uses a model of workflow-level abstraction, rather than resource-level abstraction. It lets you use a single workflow for managing  infrastructure, but acknowledges the uniqueness of each provider instead of imposing generic concepts on non-equivalent resources.
 
@@ -23,7 +23,7 @@ There are two major challenges everyone faces when trying to improve their provi
 
     To delegate a large application, companies often split it into small, focused microservice components that are owned by specific teams. Each microservice provides an API, and as long as those APIs don't change, microservice teams can make changes in parallel despite relying on each others' functionality.
 
-    Similarly, infrastructure code can be split into smaller Terraform configurations, which have limited scope and are owned by specific teams. These independent configurations use [output variables](https://www.terraform.io/docs/configuration/outputs.html) to publish information and [remote state resources](https://www.terraform.io/docs/providers/terraform/d/remote_state.html) to access output data from other workspaces. Just like microservices communicate and connect via APIs, Terraform workspaces connect via remote state.
+    Similarly, infrastructure code can be split into smaller Terraform configurations, which have limited scope and are owned by specific teams. These independent configurations use [output variables](/docs/configuration/outputs.html) to publish information and [remote state resources](/docs/providers/terraform/d/remote_state.html) to access output data from other workspaces. Just like microservices communicate and connect via APIs, Terraform workspaces connect via remote state.
 
     Once you have loosely-coupled Terraform configurations, you can delegate their development and maintenance to different teams. To do this effectively, you need to control access to that code. Version control systems can regulate who can commit code, but since Terraform affects real infrastructure, you also need to regulate who can run the code.
 

--- a/content/source/docs/enterprise/guides/recommended-practices/part3.2.html.md
+++ b/content/source/docs/enterprise/guides/recommended-practices/part3.2.html.md
@@ -33,11 +33,11 @@ Make sure you've picked a VCS system that Terraform Enterprise will be able to a
 
 Start moving infrastructure code into version control. New Terraform code should all be going into version control; if you have existing Terraform code that’s outside version control, start moving it in so that everyone in your organization knows where to look for things and can track the history and purpose of changes.
 
--> **Note:** There are several ways to structure Terraform repositories. If you want to learn more about how your repo structure can affect your Terraform Enterprise workflows, see [VCS Repository Structure](https://www.terraform.io/docs/enterprise/workspaces/repo-structure.html) in the Terraform Enterprise documentation.
+-> **Note:** There are several ways to structure Terraform repositories. If you want to learn more about how your repo structure can affect your Terraform Enterprise workflows, see [VCS Repository Structure](/docs/enterprise/workspaces/repo-structure.html) in the Terraform Enterprise documentation.
 
 ## 3. Create Your First Module
 
-[Terraform modules](https://www.terraform.io/docs/modules/index.html) are reusable configuration units. They let you manage pieces of infrastructure as a single package you can call and define multiple times in the main configuration for a workspace. Examples of a good Terraform module candidate would be an auto-scaling group on AWS that wraps a launch configuration, auto-scaling group, and EC2 Elastic Load Balancer (ELB). If you are already using Terraform modules, make sure you’re following the best practices and keep an eye on places where your modules could improve.
+[Terraform modules](/docs/modules/index.html) are reusable configuration units. They let you manage pieces of infrastructure as a single package you can call and define multiple times in the main configuration for a workspace. Examples of a good Terraform module candidate would be an auto-scaling group on AWS that wraps a launch configuration, auto-scaling group, and EC2 Elastic Load Balancer (ELB). If you are already using Terraform modules, make sure you’re following the best practices and keep an eye on places where your modules could improve.
 
 The diagram below can help you decide when to write a module:
 
@@ -63,7 +63,7 @@ Here are a few examples of good build patterns from several cloud providers:
 
 ## 6. Integrate Terraform With Configuration Management
 
-If your organization already has a configuration management tool, then it’s time to integrate it with Terraform — you can use [Terraform’s provisioners](https://www.terraform.io/docs/provisioners/index.html) to pass control to configuration management after a resource is created. Terraform should handle the infrastructure, and other tools should handle user data and applications.
+If your organization already has a configuration management tool, then it’s time to integrate it with Terraform — you can use [Terraform’s provisioners](/docs/provisioners/index.html) to pass control to configuration management after a resource is created. Terraform should handle the infrastructure, and other tools should handle user data and applications.
 
 If your organization doesn't use a configuration management tool yet, and the configuration of the infrastructure being managed is mutable, you should consider adopting a configuration management tool. This might be a large task, but it supports the same goals that drove you to infrastructure as code, by making application configuration more controllable, understandable, and repeatable across teams.
 
@@ -71,7 +71,7 @@ If you’re just getting started, try this tutorial on how to [create a Chef coo
 
 ## 7. Manage Secrets
 
-Integrate Terraform with [Vault](https://www.terraform.io/docs/providers/vault/index.html) or another secret management tool. Secrets like service provider credentials must stay secret, but they also must be easy to use when needed. The best way to address those needs is to use a dedicated secret management tool. We believe HashiCorp’s Vault is the best choice for most people, but Terraform can integrate with other secret management tools as well.
+Integrate Terraform with [Vault](/docs/providers/vault/index.html) or another secret management tool. Secrets like service provider credentials must stay secret, but they also must be easy to use when needed. The best way to address those needs is to use a dedicated secret management tool. We believe HashiCorp’s Vault is the best choice for most people, but Terraform can integrate with other secret management tools as well.
 
 ## Next
 

--- a/content/source/docs/enterprise/guides/recommended-practices/part3.2.html.md
+++ b/content/source/docs/enterprise/guides/recommended-practices/part3.2.html.md
@@ -37,7 +37,7 @@ Start moving infrastructure code into version control. New Terraform code should
 
 ## 3. Create Your First Module
 
-[Terraform modules](https://www.terraform.io/docs/modules/usage.html) are reusable configuration units. They let you manage pieces of infrastructure as a single package you can call and define multiple times in the main configuration for a workspace. Examples of a good Terraform module candidate would be an auto-scaling group on AWS that wraps a launch configuration, auto-scaling group, and EC2 Elastic Load Balancer (ELB). If you are already using Terraform modules, make sure you’re following the best practices and keep an eye on places where your modules could improve.
+[Terraform modules](https://www.terraform.io/docs/modules/index.html) are reusable configuration units. They let you manage pieces of infrastructure as a single package you can call and define multiple times in the main configuration for a workspace. Examples of a good Terraform module candidate would be an auto-scaling group on AWS that wraps a launch configuration, auto-scaling group, and EC2 Elastic Load Balancer (ELB). If you are already using Terraform modules, make sure you’re following the best practices and keep an eye on places where your modules could improve.
 
 The diagram below can help you decide when to write a module:
 

--- a/content/source/docs/enterprise/private/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/private/automating-the-installer.html.md
@@ -139,7 +139,7 @@ The following apply to every installation:
 
 - `hostname` — (Required) this is the hostname you will use to access your installation
 - `installation_type` — (Required) one of `poc` or `production`
-- `enc_password` — Set the [encryption password](https://www.terraform.io/docs/enterprise/private/encryption-password.html) for the install
+- `enc_password` — Set the [encryption password](/docs/enterprise/private/encryption-password.html) for the install
 - `capacity_concurrency` — number of concurrent plans and applies; defaults to `10`
 - `capacity_memory` — The maximum amount of memory (in megabytes) that a Terraform plan or apply can use on the system; defaults to `256`
 - `enable_metrics_collection` — whether PTFE's [internal metrics collection](./monitoring.html#internal-monitoring) should be enabled; defaults to true

--- a/content/source/docs/enterprise/private/aws-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/aws-setup-guide.html.md
@@ -16,10 +16,10 @@ HashiCorp Private Terraform Enterprise (PTFE) implementations on AWS.
 
 Prior to making hardware sizing and architectural decisions, read through the
 [installation information available for
-PTFE](https://www.terraform.io/docs/enterprise/private/install-installer.html)
+PTFE](/docs/enterprise/private/install-installer.html)
 to familiarise yourself with the application components and architecture.
 Further, read the [reliability and availability
-guidance](https://www.terraform.io/docs/enterprise/private/reliability-availability.html)
+guidance](/docs/enterprise/private/reliability-availability.html)
 as a primer to understanding the recommendations in this reference
 architecture.
 
@@ -29,7 +29,7 @@ architecture.
 Services_ operational mode.
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
+mode](/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single AWS EC2 instance
 for demo installations to multiple instances connected to RDS and S3 for a
 stateless production installation.
@@ -322,7 +322,7 @@ With external services (PostgreSQL Database, Object Storage) in
 use, there is still some application configuration data present on the
 PTFE server such as installation type, database connection settings,
 hostname. This data rarely changes. We recommend [configuring automated
-snapshots](https://www.terraform.io/docs/enterprise/private/automated-recovery.html#1-configure-snapshots)
+snapshots](/docs/enterprise/private/automated-recovery.html#1-configure-snapshots)
 for this installation data so it can be recovered in the event of data
 corruption.
 

--- a/content/source/docs/enterprise/private/azure-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/azure-setup-guide.html.md
@@ -20,10 +20,10 @@ implementations on Azure.
 
 Prior to making hardware sizing and architectural decisions, read through the
 [installation information available for
-PTFE](https://www.terraform.io/docs/enterprise/private/install-installer.html)
+PTFE](/docs/enterprise/private/install-installer.html)
 to familiarize yourself with the application components and architecture.
 Further, read the [reliability and availability
-guidance](https://www.terraform.io/docs/enterprise/private/reliability-availability.html)
+guidance](/docs/enterprise/private/reliability-availability.html)
 as a primer to understanding the recommendations in this reference
 architecture.
 
@@ -32,7 +32,7 @@ architecture.
 -> **Note:** This reference architecture focuses on the _Production - External Services_ operational mode.
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
+mode](/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single [Azure VM
 instance](https://azure.microsoft.com/en-us/services/virtual-machines/) for
 demo or proof of concept installations to multiple instances connected to
@@ -194,16 +194,16 @@ are routed to the highly available infrastructure supporting Azure Storage.
 ### Monitoring
 
 While there is not currently a monitoring guide for PTFE, information around
-[logging](https://www.terraform.io/docs/enterprise/private/logging.html),
-[diagnostics](https://www.terraform.io/docs/enterprise/private/diagnostics.html)
+[logging](/docs/enterprise/private/logging.html),
+[diagnostics](/docs/enterprise/private/diagnostics.html)
 as well as [reliability and
-availability](https://www.terraform.io/docs/enterprise/private/reliability-availability.html)
+availability](/docs/enterprise/private/reliability-availability.html)
 can be found on our website.
 
 ### Upgrades
 
 See [the Upgrades
-section](https://www.terraform.io/docs/enterprise/private/upgrades.html)
+section](/docs/enterprise/private/upgrades.html)
 of the documentation.
 
 ## High Availability
@@ -231,7 +231,7 @@ not changed since installation, both PTFE1 and PTFE2 will
 use the same configuration and no action is required.
 
 If the
-configuration on the active instance changes, you should [create a snapshot](https://www.terraform.io/docs/enterprise/private/automated-recovery.html#1-configure-snapshots) via the
+configuration on the active instance changes, you should [create a snapshot](/docs/enterprise/private/automated-recovery.html#1-configure-snapshots) via the
 UI or CLI and recover this to the standby instance so that both instances use the
 same configuration.
 
@@ -303,7 +303,7 @@ When using the _Production - External Services_ deployment model (PostgreSQL Dat
 PTFE server such as installation type, database connection settings, and
 hostname; however, this data rarely changes. We recommend
 [configuring automated
-snapshots](https://www.terraform.io/docs/enterprise/private/automated-recovery.html#1-configure-snapshots)
+snapshots](/docs/enterprise/private/automated-recovery.html#1-configure-snapshots)
 for this installation data so it can be recovered in the event of data
 corruption.
 

--- a/content/source/docs/enterprise/private/capacity.html.md
+++ b/content/source/docs/enterprise/private/capacity.html.md
@@ -23,7 +23,7 @@ After factoring in the memory needed to run the base services that make up the a
 ### Settings
 
 The settings for per-run memory and concurrency are available in the dashboard on port 8800, on the Settings page, under the Capacity section. They can also be set via
-the [application settings JSON file when using the automated install procedure](https://www.terraform.io/docs/enterprise/private/automating-the-installer.html#available-settings).
+the [application settings JSON file when using the automated install procedure](/docs/enterprise/private/automating-the-installer.html#available-settings).
 
 ## Increasing Capacity
 

--- a/content/source/docs/enterprise/private/data-security.html.md
+++ b/content/source/docs/enterprise/private/data-security.html.md
@@ -29,4 +29,4 @@ seriously. This table lists which parts of the PTFE app can contain sensitive da
 | Vault Unseal Key                     | PostgreSQL    | ChaCha20+Poly1305                     |
 
 ## Vault Transit Encryption
-The [Vault Transit Secret Engine](https://www.vaultproject.io/docs/secrets/transit/index.html) handles encryption for data in-transit and is used when encrypting data from the application to the applicable [storage layer](https://www.terraform.io/docs/enterprise/private/reliability-availability.html#components).
+The [Vault Transit Secret Engine](https://www.vaultproject.io/docs/secrets/transit/index.html) handles encryption for data in-transit and is used when encrypting data from the application to the applicable [storage layer](/docs/enterprise/private/reliability-availability.html#components).

--- a/content/source/docs/enterprise/private/encryption-password.md
+++ b/content/source/docs/enterprise/private/encryption-password.md
@@ -26,7 +26,7 @@ encryption password itself and details in PostgreSQL.
 The password can be specified during an unattended
 installation with the installer option `enc_password`
 within the [application settings JSON file when
-using the automated install procedure](https://www.terraform.io/docs/enterprise/private/automating-the-installer.html#available-settings):
+using the automated install procedure](/docs/enterprise/private/automating-the-installer.html#available-settings):
 
 ```json
 {

--- a/content/source/docs/enterprise/private/faq.html.md
+++ b/content/source/docs/enterprise/private/faq.html.md
@@ -244,7 +244,7 @@ Terraform Enterprise makes several categories of outbound requests, detailed in 
 
 #### Version Control System Integrations
 
-Private Terraform Enterprise can be configured to connect to a number of [Version Control Systems (VCSs)](https://www.terraform.io/docs/enterprise/vcs/index.html), some supporting both SaaS and private-network installations.
+Private Terraform Enterprise can be configured to connect to a number of [Version Control Systems (VCSs)](/docs/enterprise/vcs/index.html), some supporting both SaaS and private-network installations.
 
 In order to perform ingress of Terraform configuration from a configured VCS, Private Terraform Enterprise will need to be able to communicate with that provider's API, and webhooks from that provider will need to be able to reach Private Terraform Enterprise.
 
@@ -281,7 +281,7 @@ HashiCorp recommends storing the Terraform state for the install in an encrypted
 
 ### Recommended State Storage Setup
 
-Terraform supports various [remote state](https://www.terraform.io/docs/state/remote.html) backends that can be used to securely store the Terraform state produced by the install.
+Terraform supports various [remote state](/docs/state/remote.html) backends that can be used to securely store the Terraform state produced by the install.
 
 HashiCorp recommends a versioned, encrypted-at-rest S3 bucket as a good default choice.
 

--- a/content/source/docs/enterprise/private/gcp-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/gcp-setup-guide.html.md
@@ -16,10 +16,10 @@ HashiCorp Private Terraform Enterprise (PTFE) implementations on GCP.
 
 Prior to making hardware sizing and architectural decisions, read through the
 [installation information available for
-PTFE](https://www.terraform.io/docs/enterprise/private/install-installer.html)
+PTFE](/docs/enterprise/private/install-installer.html)
 to familiarise yourself with the application components and architecture.
 Further, read the [reliability and availability
-guidance](https://www.terraform.io/docs/enterprise/private/reliability-availability.html)
+guidance](/docs/enterprise/private/reliability-availability.html)
 as a primer to understanding the recommendations in this reference
 architecture.
 
@@ -29,7 +29,7 @@ architecture.
 Services_ operational mode.
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
+mode](/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single Cloud Compute VM instance
 for demo installations to multiple instances connected to Cloud SQL and Cloud Storage for a
 stateless production installation.
@@ -285,7 +285,7 @@ With external services (PostgreSQL Database, Object Storage) in
 use, there is still some application configuration data present on the
 PTFE server such as installation type, database connection settings,
 hostname. This data rarely changes. We recommend [configuring automated
-snapshots](https://www.terraform.io/docs/enterprise/private/automated-recovery.html#1-configure-snapshots)
+snapshots](/docs/enterprise/private/automated-recovery.html#1-configure-snapshots)
 for this installation data so it can be recovered in the event of data
 corruption.
 

--- a/content/source/docs/enterprise/private/install-installer.html.md
+++ b/content/source/docs/enterprise/private/install-installer.html.md
@@ -213,7 +213,7 @@ From a shell on your instance, in the directory where you placed the `replicated
    and re-run the checks, or ignore the warnings and proceed. If the system is running behind a proxy and is unable to connect to `releases.hashicorp.com:443`, it is likely safe to proceed; this check does not currently use the proxy. For any other issues, if you proceed despite the warnings, you are assuming the support responsibility.
 1. Set an encryption password used to encrypt the sensitive information at rest. The default value is auto-generated,
    but we strongly suggest you create your own password. Be sure to retain the value, because you will need to use this
-   password to restore access to the data in the event of a reinstall. See [Encryption Password](https://www.terraform.io/docs/enterprise/private/encryption-password.html) for more information.
+   password to restore access to the data in the event of a reinstall. See [Encryption Password](/docs/enterprise/private/encryption-password.html) for more information.
 1. Configure the operational mode for this installation. See
    [Preflight: Operational Modes](./preflight-installer.html#operational-mode-decision) for information on what the different values are. Ensure that you've met the relevant preflight requirements for the mode you chose.
 1. _Optional:_ Adjust the concurrent capacity of the instance. This should

--- a/content/source/docs/enterprise/private/vmware-setup-guide.html.md
+++ b/content/source/docs/enterprise/private/vmware-setup-guide.html.md
@@ -16,17 +16,17 @@ HashiCorp Private Terraform Enterprise (PTFE) implementations on VMware.
 
 Prior to making hardware sizing and architectural decisions, read through the
 [installation information available for
-PTFE](https://www.terraform.io/docs/enterprise/private/install-installer.html)
+PTFE](/docs/enterprise/private/install-installer.html)
 to familiarise yourself with the application components and architecture.
 Further, read the [reliability and availability
-guidance](https://www.terraform.io/docs/enterprise/private/reliability-availability.html)
+guidance](/docs/enterprise/private/reliability-availability.html)
 as a primer to understanding the recommendations in this reference
 architecture.
 
 ## Infrastructure Requirements
 
 Depending on the chosen [operational
-mode](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
+mode](/docs/enterprise/private/preflight-installer.html#operational-mode-decision),
 the infrastructure requirements for PTFE range from a single virtual machine
 for demo or proof of concept installations, to multiple virtual machines
 hosting the Terraform Enterprise application, PostgreSQL, and external Vault servers for
@@ -175,16 +175,16 @@ endpoint URL.
 ### Monitoring
 
 While there is not currently a monitoring guide for PTFE, information around
-[logging](https://www.terraform.io/docs/enterprise/private/logging.html),
-[diagnostics](https://www.terraform.io/docs/enterprise/private/diagnostics.html)
+[logging](/docs/enterprise/private/logging.html),
+[diagnostics](/docs/enterprise/private/diagnostics.html)
 as well as [reliability and
-availability](https://www.terraform.io/docs/enterprise/private/reliability-availability.html)
+availability](/docs/enterprise/private/reliability-availability.html)
 can be found on our website.
 
 ### Upgrades
 
 Please reference the [upgrade
-instructions](https://www.terraform.io/docs/enterprise/private/upgrades.html)
+instructions](/docs/enterprise/private/upgrades.html)
 in the documentation.
 
 ## High Availability

--- a/content/source/docs/enterprise/registry/publish.html.md
+++ b/content/source/docs/enterprise/registry/publish.html.md
@@ -46,7 +46,7 @@ infrastructure. The `<NAME>` segment can contain additional hyphens. Examples:
 `terraform-google-vault` or `terraform-aws-ec2-instance`.
 
 - **Standard module structure.** The module must adhere to the
-[standard module structure](/docs/modules/create.html#standard-module-structure).
+[standard module structure](/docs/modules/index.html#standard-module-structure).
 This allows the registry to inspect your module and generate documentation,
 track resource usage, and more.
 

--- a/content/source/docs/enterprise/registry/using.html.md
+++ b/content/source/docs/enterprise/registry/using.html.md
@@ -55,7 +55,7 @@ module "vpc" {
 
 If you're using the SaaS version of TFE, the hostname is `app.terraform.io`; private installs have their own hostnames. The second part of the source string (the namespace) is the name of your TFE organization.
 
-For more details on using modules in Terraform configurations, see ["Using Modules" in the Terraform docs.](/docs/modules/usage.html)
+For more details on using modules in Terraform configurations, see ["Configuration Language: Modules"](/docs/configuration/modules.html) in the Terraform docs.
 
 ### Usage Examples and the Configuration Designer
 

--- a/content/source/docs/enterprise/run/index.html.md
+++ b/content/source/docs/enterprise/run/index.html.md
@@ -160,7 +160,7 @@ Terraform only automatically installs plugins from [the main list of providers](
 
 Currently, there are two ways to use custom provider plugins with TFE.
 
-- Add the provider binary to the VCS repo (or manually-uploaded configuration version) for any workspace that uses it. Place the compiled `linux_amd64` version of the plugin at `terraform.d/plugins/linux_amd64/<PLUGIN NAME>` (as a relative path from the root of the working directory). The plugin name should follow the [naming scheme](https://www.terraform.io/docs/configuration/providers.html#plugin-names-and-versions). (Third-party plugins are often distributed with an appropriate filename already set in the distribution archive.)
+- Add the provider binary to the VCS repo (or manually-uploaded configuration version) for any workspace that uses it. Place the compiled `linux_amd64` version of the plugin at `terraform.d/plugins/linux_amd64/<PLUGIN NAME>` (as a relative path from the root of the working directory). The plugin name should follow the [naming scheme](/docs/configuration/providers.html#plugin-names-and-versions). (Third-party plugins are often distributed with an appropriate filename already set in the distribution archive.)
 
     You can add plugins directly to a configuration repo, or you can add them as Git submodules and symlink the files into `terraform.d/plugins/linux_amd64/`. Submodules are a good choice when many workspaces use the same custom provider, since they keep your repos smaller. If using submodules, enable the ["Include submodules on clone" setting](../workspaces/settings.html#include-submodules-on-clone) on any affected workspace.
 

--- a/content/source/docs/enterprise/run/install-software.html.md
+++ b/content/source/docs/enterprise/run/install-software.html.md
@@ -9,7 +9,7 @@ sidebar_current: "docs-enterprise2-run-install"
 In some cases, it may be useful to install certain software on the Terraform worker,
 such as a configuration management tool or cloud CLI.
 
-Terraform's `local-exec` [provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, the provisioner configuration block containing the local-exec provisioner should be added to the resource(s) the software being installed will interact with.
+Terraform's `local-exec` [provisioner](/docs/provisioners/local-exec.html) can be used in Terraform Enterprise (TFE). This will execute commands on the host machine running Terraform. In general, the provisioner configuration block containing the local-exec provisioner should be added to the resource(s) the software being installed will interact with.
 
 ```hcl
 resource "aws_instance" "example" {
@@ -28,6 +28,6 @@ Using software installed via local-exec to create unmanaged infrastructure is no
 
 Please note that the machines that run Terraform (containers, in Private Terraform Enterprise) exist in an isolated environment and are destroyed after each use. Very little is pre-installed and nothing is persisted between Terraform runs, so you will need to install any custom software on each run.
 
-Because the run environments are disposable, using a null resource with a `local-exec` provisioner to install software, rather than a related resource, is only appropriate if the null resource can be properly configured with [triggers](https://www.terraform.io/docs/provisioners/null_resource.html#example-usage). Otherwise, a null resource with the `local-exec` provisioner will only install software on the initial run where the `null_resource` is created. The `null_resource` will not be automatically recreated in subsequent runs and the related software won't be installed, which may cause runs to encounter errors.
+Because the run environments are disposable, using a null resource with a `local-exec` provisioner to install software, rather than a related resource, is only appropriate if the null resource can be properly configured with [triggers](/docs/provisioners/null_resource.html#example-usage). Otherwise, a null resource with the `local-exec` provisioner will only install software on the initial run where the `null_resource` is created. The `null_resource` will not be automatically recreated in subsequent runs and the related software won't be installed, which may cause runs to encounter errors.
 
 Currently, the Terraform workers run the latest version of Ubuntu LTS, but this may change in the future.

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -447,7 +447,7 @@ constraint][module-version-constraint] for modules that support it, such as
 modules within the [Terraform Module Registry][terraform-module-registry] or the
 [Terraform Enterprise private module registry][tfe-private-registry].
 
-[module-version-constraint]: /docs/modules/usage.html#module-versions
+[module-version-constraint]: /docs/configuration/modules.html#module-versions
 [terraform-module-registry]: https://registry.terraform.io/
 [tfe-private-registry]: /docs/enterprise/registry/index.html
 

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -516,7 +516,7 @@ represents any _explicit_ dependencies for this output. For more information,
 see the [depends_on output setting][ref-depends_on] within the general Terraform
 documentation.
 
-[ref-depends_on]: https://www.terraform.io/docs/configuration/outputs.html#depends_on
+[ref-depends_on]: /docs/configuration/outputs.html#depends_on
 
 As an example, given the following output declaration block:
 

--- a/content/source/docs/enterprise/workspaces/variables.html.md
+++ b/content/source/docs/enterprise/workspaces/variables.html.md
@@ -11,7 +11,7 @@ sidebar_current: "docs-enterprise2-workspaces-variables"
 Terraform Enterprise (TFE) workspaces can set values for two kinds of variables:
 
 - [Terraform input variables][variables], which define the parameters of a Terraform configuration.
-- Shell environment variables, which many providers can use for credentials and other data. You can also set [environment variables that affect Terraform's behavior](/docs/configuration/environment-variables.html), like `TF_LOG`.
+- Shell environment variables, which many providers can use for credentials and other data. You can also set [environment variables that affect Terraform's behavior](/docs/commands/environment-variables.html), like `TF_LOG`.
 
 You can edit a workspace's variables via the UI or the API. All runs in a workspace use its variables.
 

--- a/content/source/docs/extend/schemas/schema-types.html.md
+++ b/content/source/docs/extend/schemas/schema-types.html.md
@@ -49,8 +49,8 @@ for more information on configuring element behaviors.
 ## Types
 
 The schema attribute `Type` determines what data is valid in configuring the
-element, as well as the type of data returned when used in
-[interpolation](/docs/configuration/interpolation.html). Schemas attributes must
+element, as well as the type of data returned when used in an
+[expression](/docs/configuration/expressions.html). Schemas attributes must
 be one of the types defined below, and can be loosely categorized as either
 **Primitive** or **Aggregate** types:  
 


### PR DESCRIPTION
This is part of an effort that includes, uh....

- https://github.com/terraform-providers/terraform-provider-ucloud/pull/20
- https://github.com/terraform-providers/terraform-provider-oci/pull/731
- https://github.com/terraform-providers/terraform-provider-azurestack/pull/73
- https://github.com/terraform-providers/terraform-provider-aws/pull/7927
- https://github.com/terraform-providers/terraform-provider-panos/pull/150
- https://github.com/terraform-providers/terraform-provider-azurerm/pull/3045
- https://github.com/terraform-providers/terraform-provider-cloudstack/pull/60
- https://github.com/hashicorp/terraform/pull/20676

...eight additional PRs in other repos. 

ONCE ALL THESE ARE MERGED (and cherry-picked to stable-website everywhere) then TRAVIS BUILDS SHOULD GO GREEN. 

**Update:** Wow, all the other PRs are merged! The following still need cherry-picks (which @paultyng and I will follow up on later today):

- ucloud
- azurestack
- aws
- panos
- azurerm
- cloudstack