### PR TITLE
Replace /docs/index.html with a map to all of the docs!

### DIFF
--- a/content/source/docs/cli-index.html.md
+++ b/content/source/docs/cli-index.html.md
@@ -1,0 +1,1 @@
+../../../ext/terraform/website/docs/cli-index.html.md

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -15,6 +15,10 @@ There are a lot of things a user of Terraform might need to know about. To help 
 
 You can navigate the docs via this index page, or you can jump from section to section using the "Other Docs" area of the navigation sidebar, available in most areas of this site.
 
+<div class="container-fluid"><div class="row">
+
+<div class="col-md-6 col-sm-12">
+
 ### [Terraform Glossary](/docs/glossary.html)
 
 Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
@@ -49,6 +53,15 @@ A broad overview of what Terraform is and why people use it.
 
 Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install.html), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
 
+</div>
+
+
+
+
+
+
+<div class="col-md-6 col-sm-12">
+
 ### [Guides and Whitepapers](/guides/index.html)
 
 -> Intermediate users can go here for a deeper understanding of what's possible with Terraform.
@@ -77,3 +90,6 @@ Documentation about developing Terraform providers, with extensive information a
 
 Terraform relies on provider plugins to manage infrastructure resources across a wide variety of infrastructure services. Anyone can make and distribute a Terraform provider for their own service.
 
+</div>
+
+</div></div>

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Documentation"
-sidebar_current: "docs-home"
+sidebar_current: "docs-frontpage"
 description: |-
   Welcome to the Terraform documentation! This documentation is more of a reference guide for all available features and options of Terraform. If you're just getting started with Terraform, please start with the introduction and getting started guide instead.
 ---

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -1,14 +1,79 @@
 ---
-layout: "docs"
+layout: "docs-frontpage"
 page_title: "Documentation"
 sidebar_current: "docs-frontpage"
 description: |-
-  Welcome to the Terraform documentation! This documentation is more of a reference guide for all available features and options of Terraform. If you're just getting started with Terraform, please start with the introduction and getting started guide instead.
+  A brief map of the documentation for Terraform CLI, Terraform Enterprise, the
+  Terraform GitHub Actions, and the rest of the Terraform ecosystem.
 ---
 
 # Terraform Documentation
 
-Welcome to the Terraform documentation! This documentation is more of a reference
-guide for all available features and options of Terraform. If you're just getting
-started with Terraform, please start with the
-[introduction and getting started guide](/intro/index.html) instead.
+Welcome to the Terraform documentation!
+
+There are a lot of things a user of Terraform might need to know about. To help you manage this information, we've divided the Terraform docs into several sections.
+
+You can navigate the docs via this index page, or you can jump from section to section using the "Other Docs" area of the navigation sidebar, available in most areas of this site.
+
+### [Terraform Glossary](/docs/glossary.html)
+
+Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
+
+### [Terraform CLI](/docs/cli-index.html)
+
+-> Intermediate and advanced users spend most of their time here.
+
+Documentation for Terraform's core functionality, including:
+
+- [Terraform's configuration language](/docs/configuration/index.html)
+- [The `terraform` binary and its subcommands](/docs/commands/index.html)
+- [The main Terraform providers](/docs/providers/index.html)
+
+...and much more.
+
+### [Terraform Enterprise](/docs/enterprise/index.html)
+
+Documentation for Terraform Enterprise.
+
+Terraform Enterprise is a supplementary paid product that makes it easier for teams to manage infrastructure together. It provides a way to share access to sensitive data, a consistent and reliable environment for Terraform runs, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more.
+
+### [Introduction to Terraform](/intro/index.html)
+
+-> Visitors who are curious about Terraform can start here.
+
+A broad overview of what Terraform is and why people use it.
+
+### [Learn Terraform](https://learn.hashicorp.com/terraform/) (➡︎ external site)
+
+-> New users can start here.
+
+Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install.html), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
+
+### [Guides and Whitepapers](/guides/index.html)
+
+-> Intermediate users can go here for a deeper understanding of what's possible with Terraform.
+
+Detailed descriptions of various Terraform workflows, both general and specific. This includes things like:
+
+- [The end-to-end loop of making infrastructure changes with Terraform](/guides/core-workflow.html)
+- [The long-term process of evolving provisioning practices in a large organization](/docs/enterprise/guides/recommended-practices/index.html)
+- [Tasks for upgrading to major new Terraform versions](/upgrade-guides/index.html)
+
+This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the guides at [Learn Terraform](https://learn.hashicorp.com/terraform/)), but to explain best practices and show how the different pieces of a workflow fit together.
+
+### [Terraform Registry](/docs/registry/index.html)
+
+Documentation about the [Terraform Registry](https://registry.terraform.io/), a web service for distributing Terraform modules. Includes information about publishing, finding, and using modules.
+
+### [Terraform GitHub Actions](/docs/github-actions/index.html)
+
+Documentation about the Terraform GitHub Actions. [GitHub Actions](https://developer.github.com/actions) is GitHub's service for running commands in reaction to events in a Git repository, and HashiCorp publishes several actions for validating repositories that contain Terraform configurations.
+
+### [Extending Terraform](/docs/extend/index.html)
+
+-> If you need to create a new Terraform provider (for a public cloud service or a purely internal service), go here.
+
+Documentation about developing Terraform providers, with extensive information about Terraform's internals.
+
+Terraform relies on provider plugins to manage infrastructure resources across a wide variety of infrastructure services. Anyone can make and distribute a Terraform provider for their own service.
+

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -19,9 +19,11 @@ You can navigate the docs via this index page, or you can jump from section to s
 
 <div class="col-md-6 col-sm-12">
 
-### [Terraform Glossary](/docs/glossary.html)
+### [Introduction to Terraform](/intro/index.html)
 
-Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
+-> Visitors who are curious about Terraform can start here.
+
+A broad overview of what Terraform is and why people use it.
 
 ### [Terraform CLI](/docs/cli-index.html)
 
@@ -35,32 +37,11 @@ Documentation for Terraform's core functionality, including:
 
 ...and much more.
 
-### [Terraform Enterprise](/docs/enterprise/index.html)
-
-Documentation for Terraform Enterprise.
-
-Terraform Enterprise is a supplementary paid product that makes it easier for teams to manage infrastructure together. It provides a way to share access to sensitive data, a consistent and reliable environment for Terraform runs, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more.
-
-### [Introduction to Terraform](/intro/index.html)
-
--> Visitors who are curious about Terraform can start here.
-
-A broad overview of what Terraform is and why people use it.
-
 ### [Learn Terraform](https://learn.hashicorp.com/terraform/) (➡︎ external site)
 
 -> New users can start here.
 
 Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install.html), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
-
-</div>
-
-
-
-
-
-
-<div class="col-md-6 col-sm-12">
 
 ### [Guides and Whitepapers](/guides/index.html)
 
@@ -73,6 +54,25 @@ Detailed descriptions of various Terraform workflows, both general and specific.
 - [Tasks for upgrading to major new Terraform versions](/upgrade-guides/index.html)
 
 This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the guides at [Learn Terraform](https://learn.hashicorp.com/terraform/)), but to explain best practices and show how the different pieces of a workflow fit together.
+
+</div>
+
+
+
+
+
+
+<div class="col-md-6 col-sm-12">
+
+### [Terraform Glossary](/docs/glossary.html)
+
+Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
+
+### [Terraform Enterprise](/docs/enterprise/index.html)
+
+Documentation for Terraform Enterprise.
+
+Terraform Enterprise is a supplementary paid product that makes it easier for teams to manage infrastructure together. It provides a way to share access to sensitive data, a consistent and reliable environment for Terraform runs, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more.
 
 ### [Terraform Registry](/docs/registry/index.html)
 

--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -1,6 +1,6 @@
 <%# Call with partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) -%>
 <% other_docs = {
-    "Terraform CLI" => "/docs/index.html",
+    "Terraform CLI" => "/docs/cli-index.html",
     "Terraform Enterprise" => "/docs/enterprise/index.html",
     "Download Terraform" => "/downloads.html",
     "Introduction to Terraform" => "/intro/index.html",

--- a/content/source/layouts/docs-frontpage.erb
+++ b/content/source/layouts/docs-frontpage.erb
@@ -1,0 +1,12 @@
+<% wrap_layout :inner do %>
+  <% content_for :sidebar do %>
+    <h4><a href="/docs/index.html">Terraform Docs</a></h4>
+
+    <%= partial(
+                "layouts/otherdocs", :locals => { :skip => "none" }
+        ).sub(%r{^ *<h4>Other Docs</h4> *$}, '').gsub(/class="back" /, '') %>
+
+  <% end %>
+
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
> **Related PRs:** This can't be merged until after https://github.com/hashicorp/terraform/pull/20693 is merged and cherry-picked to stable-master. 

During a conversation in the Terraform docs slack channel, it occurred to several of us that the current /docs/index.html page isn't very helpful at all! I think this should improve it. 

Notably, changing this page means we need a dedicated landing page for the Terraform CLI docs now, which is what https://github.com/hashicorp/terraform/pull/20693 is about. That's going to be /docs/cli-index.html. 

![image](https://user-images.githubusercontent.com/484309/54377719-a6837480-467d-11e9-83cf-9bbeaf76baa2.png)
