### PR TITLE
Link to provider docs in sidebar quick links

### DIFF
--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -2,7 +2,8 @@
 <% other_docs = {
     "Terraform CLI" => "/docs/cli-index.html",
     "Terraform Enterprise" => "/docs/enterprise/index.html",
-    "Download Terraform" => "/downloads.html",
+    "Provider References" => "/docs/providers/index.html",
+    "Terraform Glossary" => "/docs/glossary.html",
     "Introduction to Terraform" => "/intro/index.html",
     "Guides and Whitepapers" => "/guides/index.html",
     "Terraform Registry" => "/docs/registry/index.html",
@@ -12,9 +13,6 @@
     <h4>Other Docs</h4>
 
     <ul class="nav docs-sidenav">
-      <li<%= sidebar_current("terraform-glossary") %>>
-        <a class="back" href="/docs/glossary.html">Terraform Glossary</a>
-      </li>
 <% other_docs.each do |name, path| -%>
 <% unless name.downcase == skip.downcase -%>
       <li>


### PR DESCRIPTION
Evan reminded me that the people who use the site _every day_ are probably going
straight to the provider docs, and they deserve a shortcut. We might do more
later to surface the provider docs (and/or separate them from the rest of the
CLI docs), but this will at least make sure they have a one-touch path from any
docs page.

This commit also moves the glossary a little lower in the list, and removes the
downloads page from the list (it's already in the top nav, and it's not properly
"docs," so it eventually felt weird to have there.)

### Open questions for the PR:

- Should we also have a content block on the [new front page](https://terraform.io/docs/index.html) for providers? Or is just a shortcut good enough. 
- Should we separate out the provider docs into their own nav sidebar, so they feel like a more separate section of the site (vs. a sub-part of "Terraform CLI")? Or nah.

<img src="https://user-images.githubusercontent.com/484309/54454358-30504200-4751-11e9-85c2-e6eaf261e380.png" width="292" height="421">
