### PR TITLE
sentinel: tfstate, remove outdated reference to outputs

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -16,10 +16,6 @@ general information about how Terraform uses state [here][ref-tf-state].
 
 [ref-tf-state]: /docs/state/index.html
 
-`tfstate` is also the only import that can provide introspection into the
-outputs in a Terraform workspace. For more information, see the [output
-namespace](#namespace-outputs) documentation.
-
 -> **NOTE:** Terraform Enterprise currently only supports policy checks at plan
 time, limiting the usefulness of this import. This will be resolved in future
 releases. Until that time, the [`tfconfig`][import-tfconfig] and


### PR DESCRIPTION
Outputs can be referenced in tfconfig now. Although tfstate is the
only place you can see values, I'd rather just let the docs
themselves explain that and just remove the reference as explaining
it in the intro might seem a little bit too wordy.