### PR TITLE
ProviderFunc should return the terraform.ResourceProvider interface

### DIFF
--- a/content/source/docs/extend/writing-custom-providers.html.md
+++ b/content/source/docs/extend/writing-custom-providers.html.md
@@ -56,7 +56,7 @@ import (
         "github.com/hashicorp/terraform/helper/schema"
 )
 
-func Provider() *schema.Provider {
+func Provider() terraform.ResourceProvider {
         return &schema.Provider{
                 ResourcesMap: map[string]*schema.Resource{},
         }


### PR DESCRIPTION
The docs say it should return *schema.Provider. Real-world providers
return type is the ResourceProvider interface.

https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/provider.go#L16
https://github.com/terraform-providers/terraform-provider-openstack/blob/master/openstack/provider.go#L13

I ran into [issues](https://github.com/openshift-metalkube/terraform-provider-ironic/pull/7) integrating my custom provider with another piece of software than can pull in terraform plugins.
