### PR TITLE
WIP: Corrected 200 response links

### DIFF
--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -213,6 +213,8 @@ Status  | Response                                         | Reason
 --------|--------------------------------------------------|-------
 [200][] | Array of [JSON API document][]s (`type: "runs"`) | Successfully listed runs
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200 
+
 ### Query Parameters
 
 This endpoint supports pagination [with standard URL query parameters](./index.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.


### PR DESCRIPTION
Corrected broken links for the `200` response for "List Runs in a Workspace" and "Get run details"

**Note:** I noticed when doing this that defining the link once allows it to be reused throughout the document, yet there are other links that are defined several times. Should we consider defining all API status/response links once at the top of the document so as to not unnecessarily repeat ourselves?