### PR TITLE
Make API status code links easier

### DIFF
--- a/content/source/docs/enterprise/api/_template.md
+++ b/content/source/docs/enterprise/api/_template.md
@@ -1,5 +1,25 @@
 Follow this template to format each API method. There are usually multiple sections like this on a given API endpoint page.
 
+<!-- Boilerplate link references: This entire list should be included at the top of every API page, so that the tables can use short links freely. This SHOULD be all of the status codes we use in TFE's API; if we need to add more, update the list on every page. -->
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
+
 ## Create a Something
 
 <!-- Header: "Verb a Noun" or "Verb Nouns." -->
@@ -28,15 +48,10 @@ Status  | Response                                     | Reason
 [422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 [500][] | [JSON API error object][]                    | Failure during team creation
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
-
-<!-- ^ Include status codes even if they're plain 200/404. If a JSON API document is returned, specify the `type`. If the table includes links, use reference-style links to keep the table size small. -->
+<!-- ^ Include status codes even if they're plain 200/404.
+If a JSON API document is returned, specify the `type`.
+If the table includes links, use reference-style links to keep the table size small. The references should be included once per API page, at the very top.
+ -->
 
 ### Query Parameters
 

--- a/content/source/docs/enterprise/api/account.md
+++ b/content/source/docs/enterprise/api/account.md
@@ -230,9 +230,3 @@ curl \
 }
 ```
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/account.md
+++ b/content/source/docs/enterprise/api/account.md
@@ -4,6 +4,23 @@ page_title: "Account - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-account"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Account API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/organizations.html.md
+++ b/content/source/docs/enterprise/api/admin/organizations.html.md
@@ -4,6 +4,23 @@ page_title: "Organizations - Admin - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-admin-organizations"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Admin Organizations API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/organizations.html.md
+++ b/content/source/docs/enterprise/api/admin/organizations.html.md
@@ -23,10 +23,6 @@ Status  | Response                                        | Reason
 [200][] | [JSON API document][] (`type: "organizations"`) | Successfully listed organizations
 [404][] | [JSON API error object][]                       | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -124,10 +120,6 @@ Status  | Response                                        | Reason
 [200][] | [JSON API document][] (`type: "organizations"`) | The request was successful
 [404][] | [JSON API error object][]                       | Organization not found, or client is not an administrator
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Available Related Resources
 
@@ -187,9 +179,6 @@ Status  | Response                  | Reason
 [204][] | Empty response            | The organization was successfully deleted
 [404][] | [JSON API error object][] | Organization not found, or client is not an administrator
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/admin/runs.html.md
+++ b/content/source/docs/enterprise/api/admin/runs.html.md
@@ -23,10 +23,6 @@ Status  | Response                               | Reason
 [200][] | [JSON API document][] (`type: "runs"`) | Successfully listed runs
 [404][] | [JSON API error object][]              | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -138,10 +134,6 @@ Status  | Response                               | Reason
 [200][] | [JSON API document][] (`type: "runs"`) | Successfully canceled the run.
 [404][] | [JSON API error object][]              | Run not found, or client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request body
 

--- a/content/source/docs/enterprise/api/admin/runs.html.md
+++ b/content/source/docs/enterprise/api/admin/runs.html.md
@@ -4,6 +4,23 @@ page_title: "Runs - Admin - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-admin-runs"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Admin Runs API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -4,6 +4,23 @@ page_title: "Private Terraform Enterprise Settings - API Docs - Terraform Enterp
 sidebar_current: "docs-enterprise2-api-admin-settings"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Private Terraform Enterprise Settings API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -20,10 +20,6 @@ Status  | Response                                         | Reason
 [200][] | [JSON API document][] (`type: "general-settings"`) | Successfully listed General settings
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -61,11 +57,6 @@ Status  | Response                                     | Reason
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 [422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -131,10 +122,6 @@ Status  | Response                                         | Reason
 [200][] | [JSON API document][] (`type: "saml-settings"`) | Successfully listed SAML settings
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -181,11 +168,6 @@ Status  | Response                                         | Reason
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 [422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -316,10 +298,6 @@ Status  | Response                                         | Reason
 [200][] | [JSON API document][] (`type: "smtp-settings"`) | Successfully listed SMTP settings
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -364,14 +342,6 @@ Status  | Response                                     | Reason
 [500][] | [JSON API error object][]                    | SMTP server returned a server error
 [504][] | [JSON API error object][]                    | SMTP server timed out
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
-[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -447,10 +417,6 @@ Status  | Response                                         | Reason
 [200][] | [JSON API document][] (`type: "twilio-settings"`) | Successfully listed Twilio settings
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -487,11 +453,6 @@ Status  | Response                                         | Reason
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 [422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -557,11 +518,6 @@ Status  | Response                                         | Reason
 [400][] | [JSON API error object][]                    | Verification settings invalid (missing test number, Twilio disabled, etc.)
 [404][] | [JSON API error object][]                    | User unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 

--- a/content/source/docs/enterprise/api/admin/terraform-versions.html.md
+++ b/content/source/docs/enterprise/api/admin/terraform-versions.html.md
@@ -4,6 +4,23 @@ page_title: "Terraform Versions - Admin - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-admin-terraform-versions"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Admin Terraform Versions API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/terraform-versions.html.md
+++ b/content/source/docs/enterprise/api/admin/terraform-versions.html.md
@@ -23,10 +23,6 @@ Status  | Response                                             | Reason
 [200][] | [JSON API document][] (`type: "terraform-versions"`) | Successfully listed Terraform versions
 [404][] | [JSON API error object][]                            | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -109,11 +105,6 @@ Status  | Response                                             | Reason
 [404][] | [JSON API error object][]                            | Client is not an administrator
 [422][] | [JSON API error object][]                            | Validation errors
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -194,10 +185,6 @@ Status  | Response                                             | Reason
 [200][] | [JSON API document][] (`type: "terraform-versions"`) | The request was successful
 [404][] | [JSON API error object][]                            | Terraform version not found, or client is not an administrator
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -243,11 +230,6 @@ Status  | Response                                             | Reason
 [404][] | [JSON API error object][]                            | Terraform version not found, or client is not an administrator
 [422][] | [JSON API error object][]                            | Validation errors
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -327,11 +309,6 @@ Status  | Response                  | Reason
 [404][] | [JSON API error object][] | Terraform version not found, or client is not an administrator
 [422][] | [JSON API error object][] | The Terraform version cannot be removed (it is official or is in use)
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/admin/users.html.md
+++ b/content/source/docs/enterprise/api/admin/users.html.md
@@ -4,6 +4,23 @@ page_title: "Users - Admin - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-admin-users"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Admin Users API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/users.html.md
+++ b/content/source/docs/enterprise/api/admin/users.html.md
@@ -23,10 +23,6 @@ Status  | Response                                | Reason
 [200][] | [JSON API document][] (`type: "users"`) | Successfully listed users
 [404][] | [JSON API error object][]               | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -128,10 +124,6 @@ Status  | Response                  | Reason
 [404][] | [JSON API error object][] | Client is not an administrator.
 [422][] | [JSON API error object][] | The user cannot be deleted because they are the sole owner of one or more organizations.
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -159,11 +151,6 @@ Status  | Response                                | Reason
 [400][] | [JSON API error object][]               | User is already suspended.
 [404][] | [JSON API error object][]               | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -223,11 +210,6 @@ Status  | Response                                | Reason
 [400][] | [JSON API error object][]               | User is not suspended.
 [404][] | [JSON API error object][]               | User not found, or client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -286,12 +268,6 @@ Status  | Response                                | Reason
 [404][] | [JSON API error object][]               | User not found, or client is not an administrator.
 [422][] | [JSON API error object][]               | Validation errors
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -349,11 +325,6 @@ Status  | Response                                | Reason
 [400][] | [JSON API error object][]               | User is not an administrator.
 [404][] | [JSON API error object][]               | User not found, or client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -413,11 +384,6 @@ Status  | Response                                | Reason
 [400][] | [JSON API error object][]               | User does not have two-factor authentication enabled.
 [404][] | [JSON API error object][]               | User not found, or client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -487,11 +453,6 @@ Status  | Response                  | Reason
 [403][] | [JSON API error object][] | User cannot be impersonated.
 [404][] | [JSON API error object][] | User not found, or client is not an administrator.
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -534,10 +495,6 @@ Status  | Response                  | Reason
 [400][] | [JSON API error object][] | Client is not in an impersonation session.
 [404][] | [JSON API error object][] | Client is not an administrator.
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/admin/workspaces.html.md
+++ b/content/source/docs/enterprise/api/admin/workspaces.html.md
@@ -4,6 +4,23 @@ page_title: "Workspaces - Admin - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-admin-workspaces"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Admin Workspaces API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/admin/workspaces.html.md
+++ b/content/source/docs/enterprise/api/admin/workspaces.html.md
@@ -23,10 +23,6 @@ Status  | Response                                     | Reason
 [200][] | [JSON API document][] (`type: "workspaces"`) | Successfully listed workspaces
 [404][] | [JSON API error object][]                    | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -139,10 +135,6 @@ Status  | Response                                     | Reason
 [200][] | [JSON API document][] (`type: "workspaces"`) | Successfully listed workspaces
 [404][] | [JSON API error object][]                    | Client is not an administrator.
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -217,9 +209,6 @@ Status  | Response                                        | Reason
 [204][] |                                                 | The workspace was successfully destroyed
 [404][] | [JSON API error object][]                       | Workspace not found or user unauthorized to perform action
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/applies.md
+++ b/content/source/docs/enterprise/api/applies.md
@@ -75,7 +75,3 @@ curl \
 }
 ```
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/applies.md
+++ b/content/source/docs/enterprise/api/applies.md
@@ -4,6 +4,23 @@ page_title: "Applies - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-applies"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Applies API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/configuration-versions.html.md
+++ b/content/source/docs/enterprise/api/configuration-versions.html.md
@@ -4,6 +4,23 @@ page_title: "Configuration Versions - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-configuration-versions"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Configuration Versions API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -19,8 +19,6 @@ See the navigation sidebar for the list of available endpoints.
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, TFE responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.
 
-[JSON API error object]: http://jsonapi.org/format/#error-objects
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
 
 There are three kinds of token available:
 
@@ -251,8 +249,6 @@ Status  | Response                                     | Reason
 --------|----------------------------------------------|----------
 [429][] | [JSON API error object][]                    | Rate limit has been reached.
 
-[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ```json
 {

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -4,6 +4,22 @@ layout: "enterprise2"
 sidebar_current: "docs-enterprise2-api"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 # Terraform Enterprise API Documentation
 

--- a/content/source/docs/enterprise/api/modules.html.md
+++ b/content/source/docs/enterprise/api/modules.html.md
@@ -4,6 +4,23 @@ page_title: "Modules - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-modules"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Registry Modules API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/modules.html.md
+++ b/content/source/docs/enterprise/api/modules.html.md
@@ -55,11 +55,6 @@ Status  | Response                                           | Reason
 [422][] | [JSON API error object][]                          | Malformed request body (missing attributes, wrong types, etc.)
 [404][] | [JSON API error object][]                          | User not authorized
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -155,11 +150,6 @@ Status  | Response                                           | Reason
 [422][] | [JSON API error object][]                          | Malformed request body (missing attributes, wrong types, etc.)
 [404][] | [JSON API error object][]                          | User not authorized
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 
 ### Request Body
@@ -254,11 +244,6 @@ Status  | Response                                                   | Reason
 [422][] | [JSON API error object][]                                  | Malformed request body (missing attributes, wrong types, etc.)
 [404][] | [JSON API error object][]                                  | User not authorized
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 
 ### Request Body
@@ -400,9 +385,6 @@ Status  | Response                                             | Reason
 [204][] | Nothing                                              | Success
 [404][] | [JSON API error object][]                            | Module, provider, or version not found or user not authorized
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/notification-configurations.html.md
+++ b/content/source/docs/enterprise/api/notification-configurations.html.md
@@ -4,6 +4,23 @@ page_title: "Notification Configurations - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-notification-configurations"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Notification Configurations API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/notification-configurations.html.md
+++ b/content/source/docs/enterprise/api/notification-configurations.html.md
@@ -122,13 +122,6 @@ Status  | Response                                                      | Reason
 [404][] | [JSON API error object][]                                     | Workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]                                     | Malformed request body (missing attributes, wrong types, etc.)
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -531,7 +524,6 @@ Status  | Response                                                      | Reason
 [404][] | [JSON API error object][]                                     | Notification configuration not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]                                     | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 
 ### Request Body
 
@@ -748,7 +740,6 @@ Status  | Response                  | Reason
 [204][] | None                      | Successfully deleted the notification configuration
 [404][] | [JSON API error object][] | Notification configuration not found, or user unauthorized to perform action
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/oauth-clients.html.md
+++ b/content/source/docs/enterprise/api/oauth-clients.html.md
@@ -4,6 +4,23 @@ page_title: "OAuth Clients - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-oauth-clients"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # OAuth Clients API
 
 -> **Note:** These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/oauth-clients.html.md
+++ b/content/source/docs/enterprise/api/oauth-clients.html.md
@@ -369,11 +369,3 @@ curl \
   https://app.terraform.io/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K
 ```
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise/api/oauth-tokens.html.md
@@ -221,11 +221,3 @@ curl \
   https://app.terraform.io/api/v2/oauth-tokens/ot-29t7xkUKiNC2XasL
 ```
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise/api/oauth-tokens.html.md
@@ -4,6 +4,23 @@ page_title: "OAuth Tokens - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-oauth-tokens"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # OAuth Tokens
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -25,10 +25,6 @@ Status  | Response                                                | Reason
 [201][] | [JSON API document][] (`type: "authentication-tokens"`) | Success
 [404][] | [JSON API error object][]                               | User not authorized
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -80,7 +76,6 @@ Status  | Response                                             | Reason
 [204][] | Nothing                                              | Success
 [404][] | [JSON API error object][]                            | User not authorized
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -4,6 +4,23 @@ page_title: "Organization Tokens - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-organization-tokens"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Organization Token API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -4,6 +4,23 @@ page_title: "Organizations - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-organizations"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Organizations API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -19,9 +19,6 @@ Status  | Response                                        | Reason
 [200][] | [JSON API document][] (`type: "organizations"`) | The request was successful
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 
 ### Sample Request
 
@@ -82,9 +79,6 @@ Status  | Response                                        | Reason
 [200][] | [JSON API document][] (`type: "organizations"`) | The request was successful
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 
 ### Sample Request
 
@@ -140,11 +134,6 @@ Status  | Response                                        | Reason
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
 [422][] | [JSON API error object][]                       | Malformed request body (missing attributes, wrong types, etc.)
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -235,11 +224,6 @@ Status  | Response                                        | Reason
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
 [422][] | [JSON API error object][]                       | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -326,9 +310,6 @@ Status  | Response                                        | Reason
 [204][] |                                                 | The organization was successfully destroyed
 [404][] | [JSON API error object][]                       | Organization not found or user unauthorized to perform action
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -359,9 +340,6 @@ Status  | Response                                           | Reason
 [200][] | [JSON API document][] (`type: "entitlement-sets"`) | The request was successful
 [404][] | [JSON API error object][]                          | Organization not found or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/plans.html.md
+++ b/content/source/docs/enterprise/api/plans.html.md
@@ -4,6 +4,23 @@ page_title: "Plans - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-plans"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Plans API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/plans.html.md
+++ b/content/source/docs/enterprise/api/plans.html.md
@@ -26,10 +26,6 @@ Status  | Response                                | Reason
 [200][] | [JSON API document][] (`type: "plans"`) | The request was successful
 [404][] | [JSON API error object][]               | Plan not found, or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -4,6 +4,23 @@ page_title: "Policies - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-policies"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Policies API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -30,11 +30,6 @@ Status  | Response                                     | Reason
 [404][] | [JSON API error object][]                    | Organization not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -137,9 +132,6 @@ Status  | Response                                        | Reason
 [200][] | [JSON API document][] (`type: "policies"`)      | The request was successful
 [404][] | [JSON API error object][]                       | Policy not found or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
 
 ### Sample Request
 
@@ -393,7 +385,6 @@ Status  | Response                  | Reason
 [204][] | Nothing                   | Successfully deleted the policy
 [404][] | [JSON API error object][] | Policy not found, or user unauthorized to perform action
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/policy-checks.html.md
+++ b/content/source/docs/enterprise/api/policy-checks.html.md
@@ -4,6 +4,23 @@ page_title: "Policy Checks - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-policy-checks"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Policy Checks API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/policy-sets.html.md
+++ b/content/source/docs/enterprise/api/policy-sets.html.md
@@ -4,6 +4,23 @@ page_title: "Policy Sets - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-policy-sets"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Policy Sets API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/policy-sets.html.md
+++ b/content/source/docs/enterprise/api/policy-sets.html.md
@@ -28,11 +28,6 @@ Status  | Response                                      | Reason
 [404][] | [JSON API error object][]                     | Organization not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]                     | Malformed request body (missing attributes, wrong types, etc.)
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -138,10 +133,6 @@ Status  | Response                                      | Reason
 [200][] | [JSON API document][] (`type: "policy-sets"`) | Request was successful
 [404][] | [JSON API error object][]                     | Organization not found, or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Query Parameters
 
@@ -214,10 +205,6 @@ Status  | Response                                      | Reason
 [200][] | [JSON API document][] (`type: "policy-sets"`) | The request was successful
 [404][] | [JSON API error object][]                     | Policy set not found or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -280,11 +267,6 @@ Status  | Response                                      | Reason
 [404][] | [JSON API error object][]                     | Policy set not found or user unauthorized to perform action
 [422][] | [JSON API error object][]                     | Malformed request body (missing attributes, wrong types, etc.)
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -380,10 +362,6 @@ Status  | Response                  | Reason
 [404][] | [JSON API error object][] | Policy set not found or user unauthorized to perform action
 [422][] | [JSON API error object][] | Malformed request body (one or more policies not found, wrong types, etc.)
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -431,10 +409,6 @@ Status  | Response                  | Reason
 [404][] | [JSON API error object][] | Policy set not found or user unauthorized to perform action
 [422][] | [JSON API error object][] | Malformed request body (one or more workspaces not found, wrong types, etc.)
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -482,10 +456,6 @@ Status  | Response                  | Reason
 [404][] | [JSON API error object][] | Policy set not found or user unauthorized to perform action
 [422][] | [JSON API error object][] | Malformed request body (wrong types, etc.)
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -533,10 +503,6 @@ Status  | Response                  | Reason
 [404][] | [JSON API error object][] | Policy set not found or user unauthorized to perform action
 [422][] | [JSON API error object][] | Malformed request body (wrong types, etc.)
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -583,9 +549,6 @@ Status  | Response                  | Reason
 [204][] | Nothing                   | Successfully deleted the policy set
 [404][] | [JSON API error object][] | Policy set not found, or user unauthorized to perform action
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -46,10 +46,6 @@ Status  | Response                               | Reason
 [404][] | [JSON API error object][]              | Organization or workspace not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]              | Malformed request body (missing attributes, wrong types, etc.)
 
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 
 
 ### Sample Payload
@@ -166,9 +162,6 @@ Status  | Response                  | Reason(s)
 [202][] | none                      | Successfully queued an apply request.
 [409][] | [JSON API error object][] | Run was not paused for confirmation; apply not allowed.
 
-[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 
 ### Request Body
@@ -213,7 +206,6 @@ Status  | Response                                         | Reason
 --------|--------------------------------------------------|-------
 [200][] | Array of [JSON API document][]s (`type: "runs"`) | Successfully listed runs
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200 
 
 ### Query Parameters
 

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -4,6 +4,23 @@ page_title: "Runs - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-run"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Runs API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -32,10 +32,6 @@ Status  | Response                                             | Reason
 [200][] | Array of [JSON API document][]s (`type: "ssh-keys"`) | Success
 [404][] | [JSON API error object][]                            | Organization not found or user not authorized
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -123,8 +119,6 @@ Status  | Response                                   | Reason
 [422][] | [JSON API error object][]                  | Malformed request body (missing attributes, wrong types, etc.)
 [404][] | [JSON API error object][]                  | User not authorized
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 
 
 ### Request Body
@@ -269,7 +263,6 @@ Status  | Response                                             | Reason
 [204][] | Nothing                                              | Success
 [404][] | [JSON API error object][]                            | SSH key not found or user not authorized
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 
 
 ### Sample Request

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -4,6 +4,23 @@ page_title: "SSH Keys - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-ssh-keys"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # SSH Keys
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -30,13 +30,6 @@ Status  | Response                                     | Reason
 [412][] | [JSON API error object][]                    | Precondition failed; check the error object for more information
 [422][] | [JSON API error object][]                    | Malformed request body (missing attributes, wrong types, etc.)
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -239,10 +232,6 @@ Status  | Response                                     | Reason
 [200][] | [JSON API document][]                        | Successfully returned current state version for the given workspace
 [404][] | [JSON API error object][]                    | Workspace not found, workspace does not have a current state version, or user unauthorized to perform action
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -4,6 +4,23 @@ page_title: "State Versions - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-state-versions"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # State Versions API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/team-access.html.md
+++ b/content/source/docs/enterprise/api/team-access.html.md
@@ -4,6 +4,23 @@ page_title: "Team Acccess - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-team-access"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Team access API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/team-members.html.md
+++ b/content/source/docs/enterprise/api/team-members.html.md
@@ -4,6 +4,23 @@ page_title: "Team Membership - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-team-members"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Team Membership API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/team-tokens.html.md
+++ b/content/source/docs/enterprise/api/team-tokens.html.md
@@ -4,6 +4,23 @@ page_title: "Team Tokens - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-team-tokens"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Team Token API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -4,6 +4,23 @@ page_title: "Teams - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-teams"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Teams API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -81,13 +81,6 @@ Status  | Response                                | Reason
 [422][] | [JSON API error object][]               | Malformed request body (missing attributes, wrong types, etc.)
 [500][] | [JSON API error object][]               | Failure during team creation
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 

--- a/content/source/docs/enterprise/api/user-tokens.md
+++ b/content/source/docs/enterprise/api/user-tokens.md
@@ -4,6 +4,23 @@ page_title: "User Tokens - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-user-tokens"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # User Tokens API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/user-tokens.md
+++ b/content/source/docs/enterprise/api/user-tokens.md
@@ -238,12 +238,3 @@ curl \
   https://app.terraform.io/api/v2/authentication-tokens/at-6yEmxNAhaoQLH1Da
 ```
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/users.md
+++ b/content/source/docs/enterprise/api/users.md
@@ -4,6 +4,23 @@ page_title: "Users - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-users"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Users API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/users.md
+++ b/content/source/docs/enterprise/api/users.md
@@ -70,8 +70,3 @@ curl \
 }
 ```
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects

--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -4,6 +4,23 @@ page_title: "Variables - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-variables"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Variables API
 
 -> **Note**: These API endpoints are in beta and are subject to change.

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -604,11 +604,6 @@ Status  | Response                                     | Reason(s)
 [404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
 [409][] | [JSON API error object][]                    | Workspace already locked
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -703,11 +698,6 @@ Status  | Response                                     | Reason(s)
 [404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
 [409][] | [JSON API error object][]                    | Workspace already unlocked, or locked by a different user
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -772,11 +762,6 @@ Status  | Response                                     | Reason(s)
 [404][] | [JSON API error object][]                    | Workspace not found, or user unauthorized to perform action
 [409][] | [JSON API error object][]                    | Workspace already unlocked
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -4,6 +4,23 @@ page_title: "Workspaces - API Docs - Terraform Enterprise"
 sidebar_current: "docs-enterprise2-api-workspaces"
 ---
 
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/enterprise/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+
 # Workspaces API
 
 -> **Note**: These API endpoints are in beta and are subject to change.


### PR DESCRIPTION
Previously, when people add or update an API method, we've been having them add their own link anchors for any HTTP status codes they need to reference. 

**Advantages:**

- Well, at first we didn't really even know which status codes we were going to need. So that was a good lightweight way to find out. 

**Disadvantages:**

- Too easy to forget one. 
- Too easy to link to the [wrong](https://github.com/hashicorp/terraform-website/pull/728/files#diff-cb7de1a2065460d6b09fc222f25af2b4L561) status code! 
- Pain in the butt! Lots of duplicated effort.

**Point:**

So, let's just put all the anchors we've ever used so far at the top of every API page, and then we can just reference them by number. 

**Counterpoint:**

Or! should we put an anchor for _every_ status code and never have to update it again? Seems heavyweight; the API is mature enough that if we haven't used a status by now, are we _really_ going to start using it anytime soon?