### PR TITLE
Sentinel doc updates for Terraform 0.12

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -22,7 +22,7 @@ Terraform state at the time the plan was run. See the section on [accessing a
 plan's state and configuration
 data](#accessing-a-plan-39-s-state-and-configuration-data) for more information.
 
-## The Namespace
+## Namespace Overview
 
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
@@ -385,17 +385,9 @@ The `applied` value within the [resource
 namespace](#namespace-resources-data-sources) contains a "predicted"
 representation of the resource's state post-apply. It's created by merging the
 pending resource's diff on top of the existing data from the resource's state
-(if any).
-
-The map is a complex representation of these values with data going as far down
-as needed to represent any state values such as maps, lists, and sets.
-
-Note that some values will not be available in the `applied` state because they
-cannot be known until the plan is actually applied. These values are represented
-by a placeholder (the UUID value `74D93920-ED26-11E3-AC10-0800200C9A66`). This
-is not a stable API and should not be relied on. Instead, use the
-[`computed`](#value-computed) key within the [diff
-namespace](#namespace-resource-diff) to determine if a value is known or not.
+(if any). The map is a complex representation of these values with data going
+as far down as needed to represent any state values such as maps, lists, and
+sets.
 
 As an example, given the following resource:
 
@@ -414,6 +406,15 @@ import "tfplan"
 
 main = rule { tfplan.resources.null_resource.foo[0].applied.triggers.foo is "bar" }
 ```
+
+-> Note that some values will not be available in the `applied` state because
+they cannot be known until the plan is actually applied. In Terraform 0.11 or
+earlier, these values are represented by a placeholder (the UUID value
+`74D93920-ED26-11E3-AC10-0800200C9A66`) and in Terraform 0.12 or later they
+are `undefined`. **In either case**, you should instead use the
+[`computed`](#value-computed) key within the [diff
+namespace](#namespace-resource-diff) to determine that a computed value will
+exist.
 
 ### Value: `diff`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -24,7 +24,7 @@ releases. Until that time, the [`tfconfig`][import-tfconfig] and
 [import-tfconfig]: /docs/enterprise/sentinel/import/tfconfig.html
 [import-tfplan]: /docs/enterprise/sentinel/import/tfplan.html
 
-## The Namespace
+## Namespace Overview
 
 The following is a tree view of the import namespace. For more detail on a
 particular part of the namespace, see below.
@@ -51,7 +51,7 @@ tfstate
 │       │       ├── depends_on ([]string)
 │       │       ├── id (string)
 │       │       └── tainted (boolean)
-│       ├── outputs
+│       ├── outputs (root module only in TF 0.12 or later)
 │       │   └── NAME
 │       │       ├── sensitive (bool)
 │       │       ├── type (string)
@@ -239,7 +239,8 @@ documented below:
 * `data` - Loads the [resource namespace](#namespace-resources-data-sources),
   filtered against data sources.
 * `outputs` - Loads the [output namespace](#namespace-outputs), which supply the
-  outputs present in this module's state.
+  outputs present in this module's state. Note that with Terraform 0.12 or
+  later, this value is only available for the root namespace.
 * `resources` - Loads the [resource
   namespace](#namespace-resources-data-sources), filtered against resources.
 
@@ -447,9 +448,13 @@ The **output namespace** represents all of the outputs present within a
 during a previous apply, or if they were updated with known values during the
 pre-plan refresh.
 
-Note that this can be used to fetch both the outputs of the root module, and the
-outputs of any module in the state below the root. This makes it possible to see
-outputs that have not been threaded to the root module.
+**With Terraform 0.11 or earlier** this can be used to fetch both the outputs
+of the root module, and the outputs of any module in the state below the root.
+This makes it possible to see outputs that have not been threaded to the root
+module.
+
+**With Terraform 0.12 or later** outputs are available in the top-level (root
+module) namespace only and not accessible within submodules.
 
 This namespace is indexed by output name.
 


### PR DESCRIPTION
Contains doc updates for the following changes in 0.12:

* Module-level outputs no longer available in `tfstate`
* Unknown values no longer show up as magic UUIDs in `tfplan`'s `applied`
* Raw interpolation strings are no longer available within `tfconfig`
* Consequently, new `references` config key docs in `tfconfig`
* `tfconfig` no longer expresses config blocks of the same type as arrays