### PR TITLE
End constant, error-prone fussing with `sidebar_current`

### DIFF
--- a/content/middleman_helpers.rb
+++ b/content/middleman_helpers.rb
@@ -48,12 +48,7 @@ module Helpers
   # This helps by setting the "active" class for sidebar nav elements
   # if the YAML frontmatter matches the expected value.
   def sidebar_current(expected)
-    current = current_page.data.sidebar_current || ""
-    if current.start_with?(expected)
-      return " class=\"active\""
-    else
-      return ""
-    end
+    return ""
   end
 
   # Returns the id for this page.

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -10,6 +10,6 @@
 document.addEventListener("turbolinks:load", function() {
     "use strict";
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
-    var activeListItems = docsSidebar.find("li").has("a.current-page");
-    activeListItems.addClass("active");
+    docsSidebar.find("ul.nav").addClass("nav-hidden");
+    docsSidebar.find("li").has("a.current-page").addClass("active");
 });

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -6,3 +6,10 @@
 //= require hashicorp/analytics
 
 //= require analytics
+
+document.addEventListener("turbolinks:load", function() {
+    "use strict";
+    var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
+    var activeListItems = docsSidebar.find("li").has("a.current-page");
+    activeListItems.addClass("active");
+});

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -76,8 +76,10 @@
     }
 
     // subnav
-    ul.nav {
+    ul.nav-hidden {
       display: none;
+    }
+    ul.nav {
       margin: 10px;
 
       li {

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -3,306 +3,306 @@
     <h4><a href="/docs/enterprise/index.html">Terraform Enterprise</a></h4>
 
     <ul class="nav docs-sidenav">
-      <li<%= sidebar_current("docs-enterprise2-started") %>>
+      <li>
         <a href="/docs/enterprise/getting-started/index.html">Getting Started</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-started-access") %>>
+          <li>
             <a href="/docs/enterprise/getting-started/access.html">Accessing TFE</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-started-vcs") %>>
+          <li>
             <a href="/docs/enterprise/getting-started/vcs.html">Configuring VCS Access</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-started-workspaces") %>>
+          <li>
             <a href="/docs/enterprise/getting-started/workspaces.html">Creating Workspaces</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-started-runs") %>>
+          <li>
             <a href="/docs/enterprise/getting-started/runs.html">Running Terraform</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-started-policies") %>>
+          <li>
             <a href="/docs/enterprise/getting-started/policies.html">Creating Policies</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-migrating") %>>
+      <li>
         <a href="/docs/enterprise/migrate/index.html">Migrating from Open Source</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-migrating-workspaces") %>>
+          <li>
             <a href="/docs/enterprise/migrate/workspaces.html">Migrating Multiple Workspaces</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-upgrading") %>>
+      <li>
         <a href="/docs/enterprise/upgrade/index.html">Upgrading</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-upgrading-batch") %>>
+          <li>
             <a href="/docs/enterprise/upgrade/batch.html">Batch migration</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-upgrading-differences") %>>
+          <li>
             <a href="/docs/enterprise/upgrade/differences.html">Current vs. Legacy</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-vcs") %>>
+      <li>
         <a href="/docs/enterprise/vcs/index.html">VCS Integration</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-vcs-github") %>>
+          <li>
             <a href="/docs/enterprise/vcs/github.html">Github</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-vcs-ghenterprise") %>>
+          <li>
             <a href="/docs/enterprise/vcs/github-enterprise.html">Github Enterprise</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-vcs-gitlab-com") %>>
+          <li>
             <a href="/docs/enterprise/vcs/gitlab-com.html">GitLab.com</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-vcs-gitlab-eece") %>>
+          <li>
             <a href="/docs/enterprise/vcs/gitlab-eece.html">GitLab EE and CE</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-vcs-bitbucket-cloud") %>>
+          <li>
             <a href="/docs/enterprise/vcs/bitbucket-cloud.html">Bitbucket Cloud</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-vcs-bitbucket-server") %>>
+          <li>
             <a href="/docs/enterprise/vcs/bitbucket-server.html">Bitbucket Server</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-vcs-troubleshooting") %>>
+          <li>
             <a href="/docs/enterprise/vcs/troubleshooting.html">Troubleshooting</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-workspaces") %>>
+      <li>
         <a href="/docs/enterprise/workspaces/index.html">Workspaces</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-workspaces-naming") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/naming.html">Naming</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-creating") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/creating.html">Creating Workspaces</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-access") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/access.html">Managing Access</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-repo-structure") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/repo-structure.html">Repo Structure</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-settings") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/settings.html">Settings</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-notifications") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/notifications.html">Notifications</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-variables") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/variables.html">Variables</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-workspaces-ssh-keys") %>>
+          <li>
             <a href="/docs/enterprise/workspaces/ssh-keys.html">SSH Keys for Modules</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-run") %>>
+      <li>
         <a href="/docs/enterprise/run/index.html">Terraform Runs</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-run-states") %>>
+          <li>
             <a href="/docs/enterprise/run/states.html">Run States and Stages</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-run-ui") %>>
+          <li>
             <a href="/docs/enterprise/run/ui.html">UI/VCS-driven Runs</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-run-api") %>>
+          <li>
             <a href="/docs/enterprise/run/api.html">API-driven Runs</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-run-cli") %>>
+          <li>
             <a href="/docs/enterprise/run/cli.html">CLI-driven Runs</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-run-install") %>>
+          <li>
             <a href="/docs/enterprise/run/install-software.html">Installing Software</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-registry") %>>
+      <li>
         <a href="/docs/enterprise/registry/index.html">Private Module Registry</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-registry-using") %>>
+          <li>
             <a href="/docs/enterprise/registry/using.html">Using Private Modules</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-registry-publish") %>>
+          <li>
             <a href="/docs/enterprise/registry/publish.html">Publishing Private Modules</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-registry-design") %>>
+          <li>
             <a href="/docs/enterprise/registry/design.html">Configuration Designer</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-users-teams-organizations") %>>
+      <li>
         <a href="/docs/enterprise/users-teams-organizations/index.html">Users, Teams, Organizations</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-users-teams-organizations-users") %>>
+          <li>
             <a href="/docs/enterprise/users-teams-organizations/users.html">Users</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-users-teams-organizations-teams") %>>
+          <li>
             <a href="/docs/enterprise/users-teams-organizations/teams.html">Teams</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-users-teams-organizations-organizations") %>>
+          <li>
             <a href="/docs/enterprise/users-teams-organizations/organizations.html">Organizations</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-users-teams-organizations-permissions") %>>
+          <li>
             <a href="/docs/enterprise/users-teams-organizations/permissions.html">Permissions</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-users-teams-organizations-2fa") %>>
+          <li>
           <a href="/docs/enterprise/users-teams-organizations/2fa.html">Two-factor Authentication</a>
         </li>
-          <li<%= sidebar_current("docs-enterprise2-users-teams-organizations-service-accounts") %>>
+          <li>
             <a href="/docs/enterprise/users-teams-organizations/service-accounts.html">Service Accounts</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-sentinel") %>>
+      <li>
         <a href="/docs/enterprise/sentinel/index.html">Sentinel</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-sentinel-manage-policies") %>>
+          <li>
             <a href="/docs/enterprise/sentinel/manage-policies.html">Manage Policies</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-sentinel-integrate-vcs") %>>
+          <li>
             <a href="/docs/enterprise/sentinel/integrate-vcs.html">Manage Policies with VCS</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-sentinel-enforce") %>>
+          <li>
             <a href="/docs/enterprise/sentinel/enforce.html">Enforce and Override Policies</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-sentinel-import") %>>
+          <li>
             <a href="/docs/enterprise/sentinel/import/index.html">Defining Policies</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfplan") %>>
+              <li>
                 <a href="/docs/enterprise/sentinel/import/tfplan.html">import: tfplan</a>
                 <ul class="nav">
-                  <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfplan-mock") %>>
+                  <li>
                     <a href="/docs/enterprise/sentinel/import/mock-tfplan.html">Mocking tfplan Data</a>
                   </li>
                 </ul>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfconfig") %>>
+              <li>
                 <a href="/docs/enterprise/sentinel/import/tfconfig.html">import: tfconfig</a>
                 <ul class="nav">
-                  <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfconfig-mock") %>>
+                  <li>
                     <a href="/docs/enterprise/sentinel/import/mock-tfconfig.html">Mocking tfconfig Data</a>
                   </li>
                 </ul>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfstate") %>>
+              <li>
                 <a href="/docs/enterprise/sentinel/import/tfstate.html">import: tfstate</a>
                 <ul class="nav">
-                  <li<%= sidebar_current("docs-enterprise2-sentinel-imports-tfstate-mock") %>>
+                  <li>
                     <a href="/docs/enterprise/sentinel/import/mock-tfstate.html">Mocking tfstate Data</a>
                   </li>
                 </ul>
               </li>
             </ul>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-sentinel-examples") %>>
+          <li>
             <a href="/docs/enterprise/sentinel/examples.html">Example Policies</a>
           </li>
         </ul>
       </li>
 
-      <li<%= sidebar_current("docs-enterprise2-api") %>>
+      <li>
         <a href="/docs/enterprise/api/index.html">API</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-api-account") %>>
+          <li>
             <a href="/docs/enterprise/api/account.html">Account</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-applies") %>>
+          <li>
             <a href="/docs/enterprise/api/applies.html">Applies</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-configuration-versions") %>>
+          <li>
             <a href="/docs/enterprise/api/configuration-versions.html">Configuration Versions</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-notification-configurations") %>>
+          <li>
             <a href="/docs/enterprise/api/notification-configurations.html">Notification Configurations</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-oauth-clients") %>>
+          <li>
             <a href="/docs/enterprise/api/oauth-clients.html">OAuth Clients</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-oauth-tokens") %>>
+          <li>
             <a href="/docs/enterprise/api/oauth-tokens.html">OAuth Tokens</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-organizations") %>>
+          <li>
             <a href="/docs/enterprise/api/organizations.html">Organizations</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-organization-tokens") %>>
+          <li>
             <a href="/docs/enterprise/api/organization-tokens.html">Organization Tokens</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-plans") %>>
+          <li>
             <a href="/docs/enterprise/api/plans.html">Plans</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-policies") %>>
+          <li>
             <a href="/docs/enterprise/api/policies.html">Policies</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-policy-checks") %>>
+          <li>
             <a href="/docs/enterprise/api/policy-checks.html">Policy Checks</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-policy-sets") %>>
+          <li>
             <a href="/docs/enterprise/api/policy-sets.html">Policy Sets</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-modules") %>>
+          <li>
             <a href="/docs/enterprise/api/modules.html">Registry Modules</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-run") %>>
+          <li>
             <a href="/docs/enterprise/api/run.html">Runs</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-ssh-keys") %>>
+          <li>
             <a href="/docs/enterprise/api/ssh-keys.html">SSH Keys</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-state-versions") %>>
+          <li>
             <a href="/docs/enterprise/api/state-versions.html">State Versions</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-team-access") %>>
+          <li>
             <a href="/docs/enterprise/api/team-access.html">Team Access</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-team-members") %>>
+          <li>
             <a href="/docs/enterprise/api/team-members.html">Team Membership</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-team-tokens") %>>
+          <li>
             <a href="/docs/enterprise/api/team-tokens.html">Team Tokens</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-teams") %>>
+          <li>
             <a href="/docs/enterprise/api/teams.html">Teams</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-user-tokens") %>>
+          <li>
             <a href="/docs/enterprise/api/user-tokens.html">User Tokens</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-users") %>>
+          <li>
             <a href="/docs/enterprise/api/users.html">Users</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-variables") %>>
+          <li>
             <a href="/docs/enterprise/api/variables.html">Variables</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-workspaces") %>>
+          <li>
             <a href="/docs/enterprise/api/workspaces.html">Workspaces</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-api-admin") %>>
+          <li>
             <a href="/docs/enterprise/api/admin/index.html">Admin</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-api-admin-organizations") %>>
+              <li>
                 <a href="/docs/enterprise/api/admin/organizations.html">Organizations</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-api-admin-runs") %>>
+              <li>
                 <a href="/docs/enterprise/api/admin/runs.html">Runs</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-api-admin-settings") %>>
+              <li>
                 <a href="/docs/enterprise/api/admin/settings.html">Settings</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-api-admin-terraform-versions") %>>
+              <li>
                 <a href="/docs/enterprise/api/admin/terraform-versions.html">Terraform Versions</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-api-admin-users") %>>
+              <li>
                 <a href="/docs/enterprise/api/admin/users.html">Users</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-api-admin-workspaces") %>>
+              <li>
                 <a href="/docs/enterprise/api/admin/workspaces.html">Workspaces</a>
               </li>
             </ul>
@@ -312,139 +312,139 @@
 
       <hr>
 
-      <li<%= sidebar_current("docs-enterprise2-private") %>>
+      <li>
         <a href="/docs/enterprise/private/index.html">Private Terraform Enterprise</a>
         <ul class="nav">
-          <li<%= sidebar_current("docs-enterprise2-private-reference-architecture") %>>
+          <li>
             <a href="/docs/enterprise/private/reference-architecture-installer.html">Reference Architecture (Installer)</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-private-reference-architecture-aws") %>>
+              <li>
                 <a href="/docs/enterprise/private/aws-setup-guide.html">AWS Reference Architecture</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-reference-architecture-azure") %>>
+              <li>
                 <a href="/docs/enterprise/private/azure-setup-guide.html">Azure Reference Architecture</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-reference-architecture-gcp") %>>
+              <li>
                 <a href="/docs/enterprise/private/gcp-setup-guide.html">GCP Reference Architecture</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-reference-architecture-vmware") %>>
+              <li>
                 <a href="/docs/enterprise/private/vmware-setup-guide.html">VMware Reference Architecture</a>
               </li>
             </ul>
-          <li<%= sidebar_current("docs-enterprise2-private-installer") %>>
+          <li>
             <a href="/docs/enterprise/private/install-installer.html">Installation (Installer)</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-private-installer-preflight") %>>
+              <li>
                 <a href="/docs/enterprise/private/preflight-installer.html">Installer Preflight</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-install") %>>
+              <li>
                 <a href="/docs/enterprise/private/install-installer.html">Installation</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-migration") %>>
+              <li>
                 <a href="/docs/enterprise/private/migrate.html">Migrate from AMI</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-rhel") %>>
+              <li>
                 <a href="/docs/enterprise/private/rhel-install-guide.html">RedHat Enterprise Linux Install Guide</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-centos") %>>
+              <li>
                 <a href="/docs/enterprise/private/centos-install-guide.html">CentOS Linux Install Guide</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-minio") %>>
+              <li>
                 <a href="/docs/enterprise/private/minio-setup-guide.html">Minio Setup Guide</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-automating") %>>
+              <li>
                 <a href="/docs/enterprise/private/automating-the-installer.html">Automated Installation</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-automating-initial-user") %>>
+              <li>
                 <a href="/docs/enterprise/private/automating-initial-user.html">Initial Admin Automation </a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-upgrades") %>>
+              <li>
                 <a href="/docs/enterprise/private/upgrades.html">Upgrades</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-vault") %>>
+              <li>
                 <a href="/docs/enterprise/private/vault.html">External Vault</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-automated-recovery") %>>
+              <li>
                 <a href="/docs/enterprise/private/automated-recovery.html">Automated Recovery</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-installer-capacity") %>>
+              <li>
                 <a href="/docs/enterprise/private/capacity.html">Capacity &amp; Performance</a>
               </li>
             </ul>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-install-ami") %>>
+          <li>
             <a href="/docs/enterprise/private/install-ami.html">Installation (AMI)</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-config") %>>
+          <li>
             <a href="/docs/enterprise/private/config.html">Configuration</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-admin") %>>
+          <li>
             <a href="/docs/enterprise/private/admin/index.html">Administration</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-private-admin-general") %>>
+              <li>
                 <a href="/docs/enterprise/private/admin/general.html">General Settings</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-admin-integration") %>>
+              <li>
                 <a href="/docs/enterprise/private/admin/integration.html">Integration Settings</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-admin-resources") %>>
+              <li>
                 <a href="/docs/enterprise/private/admin/resources.html">Managing Accounts &amp; Resources</a>
               </li>
             </ul>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-saml") %>>
+          <li>
             <a href="/docs/enterprise/saml/index.html">SAML SSO</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-enterprise2-private-saml-configuration") %>>
+              <li>
                 <a href="/docs/enterprise/saml/configuration.html">Configuration</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-team-membership") %>>
+              <li>
                 <a href="/docs/enterprise/saml/team-membership.html">Team Membership</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-attributes") %>>
+              <li>
                 <a href="/docs/enterprise/saml/attributes.html">Attributes</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-login") %>>
+              <li>
                 <a href="/docs/enterprise/saml/login.html">Login</a>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration") %>>
+              <li>
                 <a href="/docs/enterprise/saml/identity-provider-configuration.html">Identity Provider Configuration</a>
                 <ul class="nav">
-                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-adfs") %>>
+                  <li>
                     <a href="/docs/enterprise/saml/identity-provider-configuration-adfs.html">ADFS</a>
                   </li>
-                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-aad") %>>
+                  <li>
                     <a href="/docs/enterprise/saml/identity-provider-configuration-aad.html">Azure Active Directory</a>
                   </li>
-                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-okta") %>>
+                  <li>
                     <a href="/docs/enterprise/saml/identity-provider-configuration-okta.html">Okta</a>
                   </li>
-                  <li<%= sidebar_current("docs-enterprise2-private-saml-identity-provider-configuration-onelogin") %>>
+                  <li>
                     <a href="/docs/enterprise/saml/identity-provider-configuration-onelogin.html">OneLogin</a>
                   </li>
                 </ul>
               </li>
-              <li<%= sidebar_current("docs-enterprise2-private-saml-troubleshooting") %>>
+              <li>
                 <a href="/docs/enterprise/saml/troubleshooting.html">Troubleshooting</a>
               </li>
             </ul>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-reliability-availability") %>>
+          <li>
             <a href="/docs/enterprise/private/reliability-availability.html">Reliability &amp; Availability</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-data-security") %>>
+          <li>
             <a href="/docs/enterprise/private/data-security.html">Data Security</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-logging") %>>
+          <li>
             <a href="/docs/enterprise/private/logging.html">Logging</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-monitoring") %>>
+          <li>
             <a href="/docs/enterprise/private/monitoring.html">Monitoring</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-diagnostics") %>>
+          <li>
             <a href="/docs/enterprise/private/diagnostics.html">Diagnostics</a>
           </li>
-          <li<%= sidebar_current("docs-enterprise2-private-faq") %>>
+          <li>
             <a href="/docs/enterprise/private/faq.html">FAQs</a>
           </li>
         </ul>
@@ -452,7 +452,7 @@
 
       <hr>
 
-      <li<%= sidebar_current("docs-enterprise-home") %>>
+      <li>
         <a class="back" href="/docs/enterprise-legacy/index.html">Terraform Enterprise (legacy)</a>
       </li>
     </ul>

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -2,11 +2,14 @@
 <div class="container">
   <div class="row">
     <div id="docs-sidebar" class="col-sm-4 col-md-3 col-xs-12 hidden-print" role="complementary">
-      <% sidebar_text = yield_content(:sidebar) || ''
-         fuzzy_url = current_page.url.sub(%r{(/|/index\.html)$}, '/(index\.html)?')
-         sidebar_text.gsub!(/href=["']#{fuzzy_url}['"]/, '\0 class="current-page"')
+      <% if content_for?(:sidebar) %>
+      <%
+        sidebar_text = yield_content(:sidebar)
+        fuzzy_url = current_page.url.sub(%r{(/|/index\.html)$}, '/(index\.html)?')
+        sidebar_text.gsub!(/href=["']#{fuzzy_url}['"]/, '\0 class="current-page"')
       %>
       <%= sidebar_text %>
+      <% end %>
     </div>
 
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -2,7 +2,11 @@
 <div class="container">
   <div class="row">
     <div id="docs-sidebar" class="col-sm-4 col-md-3 col-xs-12 hidden-print" role="complementary">
-      <%= yield_content :sidebar %>
+      <% sidebar_text = yield_content :sidebar
+         fuzzy_url = current_page.url.sub(%r{(/|/index\.html)$}, '/(index\.html)?')
+         sidebar_text.gsub!(/href=["']#{fuzzy_url}['"]/, '\0 class="current-page"')
+      %>
+      <%= sidebar_text %>
     </div>
 
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="row">
     <div id="docs-sidebar" class="col-sm-4 col-md-3 col-xs-12 hidden-print" role="complementary">
-      <% sidebar_text = yield_content :sidebar
+      <% sidebar_text = yield_content(:sidebar) || ''
          fuzzy_url = current_page.url.sub(%r{(/|/index\.html)$}, '/(index\.html)?')
          sidebar_text.gsub!(/href=["']#{fuzzy_url}['"]/, '\0 class="current-page"')
       %>


### PR DESCRIPTION
It's time to stop using `sidebar_current` in any capacity and just auto-detect which sidebar nav sections should be activated based on the current URL. This PR does so, by adding a class to any sidebar links pointed at the current page during the Middleman build and then using JQuery to ensure the current page's parent sections are activated. 

The code in this PR works everywhere on the site with better accuracy than the current status quo, both on initial load and on subsequent click-through navigation. It respects the `.nav-visible` hack used for sections that always remain open, as used extensively in the provider docs (among other places). In the event that a user has JavaScript disabled, it displays the entire sidebar navigation in expanded mode to ensure the site stays usable. In my testing it does not appear to cause any additional jank.

### Why

`sidebar_current` functions primarily as a cruel prank on the people I rely on to help keep the docs updated.

- **`sidebar_current` is pointless.** After a year and a half working in the Terraform docs, I can confidently say there is _no_ situation in which we purposely use `sidebar_current` to activate anything other than the current page and all of its parent lists. The double-bookkeeping buys us nothing.
- **`sidebar_current` is error-prone.** Just this week we shipped new provider docs for JDCloud, and they helpfully illustrate several of the ways sidebar_current constantly goes wrong: 
    - [Non-activation](https://www.terraform.io/docs/providers/jdcloud/jdcloud_network_acl.html): Make a typo, and your sidebar breaks. 
    - Non-activation with children (doesn't happen in this provider thankfully): If the page you typoed is an index page with a sub-list of children, all those child pages become completely inaccessible.
    - [Double-activation](https://www.terraform.io/docs/providers/jdcloud/jdcloud_network_interface_attachment.html): Since the slug check uses a naïve `.start_with?()` check, it's easy to accidentally activate siblings. 
- **Fixing these errors wastes disproportionate time.** Provider docs are the place where people are most likely to screw this up (since provider maintainers spend less time editing the website than I do, and thus haven't internalized all these unnecessary nonsense rules). Fixing provider docs involves cloning and PR-ing a new repo and getting approval from a new set of maintainers, then cherry-picking the fix onto stable-website once it's merged. Acceptable for a meaningful edit, but maddening for problems that shouldn't have been possible in the first place. 

### Review

Here are the types of PR feedback I'm most interested in:

- "Here is a patch to do the DOM manipulation part of this in the static build instead of client-side, along with proof that it doesn't cause an unacceptable spike in build/deploy times."
    - (I know I could do this with Nokogiri, but prior experience told me to Don't. If you have a better way, I 100% want to hear it.)
- "Here is where to put that JS snippet such that `application.js` stays clean and our other sites that are still on old-school middleman can trivially use it."
- "Here is video evidence of new visible jank caused by this patch."

I'd like to keep discussion here focused. Suggestions for other theoretical improvements (auto-generating navs or portions of navs, creating a DSL for expressing navs more succinctly, etc.) are appreciated, but should go in follow-up issues or PRs.