### PR TITLE
docs menu for real

### DIFF
--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -2,43 +2,43 @@
   background: $header-background-color;
 
   // Kind of gnarly override for bootstrap's nav toggle behavior
-  @media (max-width: 991px) {
-    .navbar-header {
-      float: none;
-    }
-    .navbar-left,
-    .navbar-right {
-      float: none !important;
-    }
-    .navbar-toggle {
-      display: block;
-    }
-    .navbar-collapse {
-      border-top: 1px solid transparent;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    }
-    .navbar-fixed-top {
-      top: 0;
-      border-width: 0 0 1px;
-    }
-    .navbar-collapse.collapse {
-      display: none !important;
-    }
-    .navbar-nav {
-      float: none !important;
-      margin-top: 7.5px;
-    }
-    .navbar-nav > li {
-      float: none;
-    }
-    .navbar-nav > li > a {
-      padding-top: 10px;
-      padding-bottom: 10px;
-    }
-    .collapse.in {
-      display: block !important;
-    }
-  }
+//   @media (max-width: 991px) {
+//     .navbar-header {
+//       float: none;
+//     }
+//     .navbar-left,
+//     .navbar-right {
+//       float: none !important;
+//     }
+//     .navbar-toggle {
+//       display: block;
+//     }
+//     .navbar-collapse {
+//       border-top: 1px solid transparent;
+//       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+//     }
+//     .navbar-fixed-top {
+//       top: 0;
+//       border-width: 0 0 1px;
+//     }
+//     .navbar-collapse.collapse {
+//       display: none !important;
+//     }
+//     .navbar-nav {
+//       float: none !important;
+//       margin-top: 7.5px;
+//     }
+//     .navbar-nav > li {
+//       float: none;
+//     }
+//     .navbar-nav > li > a {
+//       padding-top: 10px;
+//       padding-bottom: 10px;
+//     }
+//     .collapse.in {
+//       display: block !important;
+//     }
+//   }
 
   .navbar-toggle {
     height: $header-height;

--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -1,6 +1,45 @@
 #header {
   background: $header-background-color;
 
+  // Kind of gnarly override for bootstrap's nav toggle behavior
+  @media (max-width: 991px) {
+    .navbar-header {
+      float: none;
+    }
+    .navbar-left,
+    .navbar-right {
+      float: none !important;
+    }
+    .navbar-toggle {
+      display: block;
+    }
+    .navbar-collapse {
+      border-top: 1px solid transparent;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    }
+    .navbar-fixed-top {
+      top: 0;
+      border-width: 0 0 1px;
+    }
+    .navbar-collapse.collapse {
+      display: none !important;
+    }
+    .navbar-nav {
+      float: none !important;
+      margin-top: 7.5px;
+    }
+    .navbar-nav > li {
+      float: none;
+    }
+    .navbar-nav > li > a {
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+    .collapse.in {
+      display: block !important;
+    }
+  }
+
   .navbar-toggle {
     height: $header-height;
     margin: 0;
@@ -28,7 +67,9 @@
         transition: opacity 0.15s ease-in-out;
         @extend svg.logo.white;
 
-        &:hover, &:focus, &:active {
+        &:hover,
+        &:focus,
+        &:active {
           opacity: 0.6;
           outline: 0;
           text-decoration: none;
@@ -39,18 +80,20 @@
 
   ul.nav {
     li {
-      a {
+      height: $header-height;
+      margin: 0;
+      padding-top: 20px;
+      a,
+      span {
         color: $header-link-color;
         font-size: $header-font-size;
         font-family: $font-family-open-sans;
         font-weight: $font-weight-bold;
-        height: $header-height;
-        line-height: $header-height;
-        padding: 0 10px;
-        margin: 0;
         text-decoration: none;
 
-        &:hover, &:focus, &:active {
+        &:hover,
+        &:focus,
+        &:active {
           background-color: transparent;
           color: $header-link-color-hover;
           outline: 0;
@@ -59,14 +102,73 @@
             fill: $header-link-color-hover;
           }
         }
+      }
+
+      span {
+        display: block;
+        padding: 15px;
+        line-height: 20px;
 
         svg {
           fill: $header-link-color;
           position: relative;
-          top: 2px;
-          width: 14px;
-          height: 14px;
-          margin-right: 3px;
+          top: -2px;
+          width: 9px;
+          height: 5px;
+          margin-left: 7px;
+        }
+      }
+
+      svg {
+        fill: $header-link-color;
+        position: relative;
+        top: 2px;
+        width: 14px;
+        height: 14px;
+        margin-right: 3px;
+      }
+
+      &:hover {
+        cursor: pointer;
+
+        & > ul {
+          visibility: visible;
+          opacity: 1;
+          display: block;
+          transition: all 0.5s ease;
+        }
+      }
+
+      ul {
+        visibility: hidden;
+        opacity: 0;
+        transition: all 0.5s ease;
+        min-width: 22rem;
+        box-shadow: 0px 4px 12px -2px rgba(63, 68, 85, 0.5);
+        border-radius: 3px;
+        padding: 2rem;
+        position: absolute;
+        height: 160px;
+        z-index: 1;
+        background-color: $header-background-color;
+        margin-left: -15px;
+
+        &:hover {
+          visibility: visible;
+          opacity: 1;
+        }
+
+        li {
+          clear: both;
+          width: 100%;
+          display: block;
+          padding: 1rem;
+          position: relative;
+          height: 44px;
+
+          a {
+            text-decoration: none;
+          }
         }
       }
     }

--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -1,45 +1,6 @@
 #header {
   background: $header-background-color;
 
-  // Kind of gnarly override for bootstrap's nav toggle behavior
-//   @media (max-width: 991px) {
-//     .navbar-header {
-//       float: none;
-//     }
-//     .navbar-left,
-//     .navbar-right {
-//       float: none !important;
-//     }
-//     .navbar-toggle {
-//       display: block;
-//     }
-//     .navbar-collapse {
-//       border-top: 1px solid transparent;
-//       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-//     }
-//     .navbar-fixed-top {
-//       top: 0;
-//       border-width: 0 0 1px;
-//     }
-//     .navbar-collapse.collapse {
-//       display: none !important;
-//     }
-//     .navbar-nav {
-//       float: none !important;
-//       margin-top: 7.5px;
-//     }
-//     .navbar-nav > li {
-//       float: none;
-//     }
-//     .navbar-nav > li > a {
-//       padding-top: 10px;
-//       padding-bottom: 10px;
-//     }
-//     .collapse.in {
-//       display: block !important;
-//     }
-//   }
-
   .navbar-toggle {
     height: $header-height;
     margin: 0;

--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -148,7 +148,6 @@
         border-radius: 3px;
         padding: 2rem;
         position: absolute;
-        height: 160px;
         z-index: 1;
         background-color: $header-background-color;
         margin-left: -15px;

--- a/content/source/assets/stylesheets/_home.scss
+++ b/content/source/assets/stylesheets/_home.scss
@@ -19,7 +19,8 @@
 
     ul.nav {
       li {
-        a {
+        a,
+        span {
           color: $home-header-link-color;
 
           &:hover, &:focus, &:active {
@@ -30,10 +31,20 @@
               fill: $home-header-link-color-hover;
             }
           }
+        }
 
+        span {
           svg {
             fill: $home-header-link-color;
           }
+        }
+
+        svg {
+          fill: $home-header-link-color;
+        }
+
+        ul {
+          background-color: $home-header-background-color;
         }
       }
     }

--- a/content/source/assets/stylesheets/_variables.scss
+++ b/content/source/assets/stylesheets/_variables.scss
@@ -29,7 +29,7 @@ $body-font-color: $gray-darker;
 $body-link-color: $terraform-purple;
 
 // Home
-$home-header-background-color: transparent;
+$home-header-background-color: $white;
 $home-header-link-color: $gray-darker;
 $home-header-link-color-hover: $black;
 

--- a/content/source/layouts/_sidebar.erb
+++ b/content/source/layouts/_sidebar.erb
@@ -8,9 +8,7 @@
   <ul class="nav sidebar-nav">
     <li><a href="/intro/index.html">Intro</a></li>
     <li><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
-    <li><a href="/docs/index.html">Docs</a></li>
-    <li><a href="/guides/index.html">Guides</a></li>
-    <li><a href="/docs/extend/index.html">Extend</a></li>
+    <li><a href="/community.html">Community</a></li>
     <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
   </ul>
 
@@ -28,4 +26,12 @@
       </a>
     </li>
   </ul>
+
+  <div class="divider"></div>
+
+  <ul class="nav sidebar-nav">
+    <li><a href="/docs/index.html">Docs:</a></li>
+    <%= docs_items %>
+  </ul>
+
 </aside>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -86,15 +86,23 @@
             <div class="buttons hidden-xs">
               <nav class="navigation-links" role="navigation">
                 <ul class="main-links nav navbar-nav navbar-right">
-                  <li><a href="/intro/index.html">Intro</a></li>
-                  <li><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
+                  <li class="visible-sm"><span><a href="/index.html">Info</a><svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span>
+                    <ul class="dropdown">
+                      <li><a href="/intro/index.html">Intro</a></li>
+                      <li><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
+                      <li><a href="/community.html">Community</a></li>
+                      <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
+                    </ul>
+                  </li>
+                  <li class="hidden-sm"><a href="/intro/index.html">Intro</a></li>
+                  <li class="hidden-sm"><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
                   <li><span><a href="/docs/index.html">Docs</a><svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span>
                     <ul class="dropdown">
                       <%= docs_items %>
                     </ul>
                   </li>
-                  <li><a href="/community.html">Community</a></li>
-                  <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
+                  <li class="hidden-sm"><a href="/community.html">Community</a></li>
+                  <li class="hidden-sm"><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
                   <li>
                     <a href="/downloads.html">
                       <%= inline_svg "download.svg" %> Download

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -73,9 +73,13 @@
                 <ul class="main-links nav navbar-nav navbar-right">
                   <li><a href="/intro/index.html">Intro</a></li>
                   <li><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
-                  <li><a href="/docs/index.html">Docs</a></li>
-                  <li><a href="/guides/index.html">Guides</a></li>
-                  <li><a href="/docs/extend/index.html">Extend</a></li>
+                  <li><span>Docs<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill="#252937" fill-rule="evenodd"/></svg></span>
+                    <ul class="dropdown">
+                      <li><a href="/docs/index.html">Docs Home</a></li>
+                      <li><a href="/guides/index.html">Guides</a></li>
+                      <li><a href="/docs/extend/index.html">Extend</a></li>
+                    </ul>
+                  </li>
                   <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
                   <li>
                     <a href="/downloads.html">

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -73,7 +73,7 @@
                 <ul class="main-links nav navbar-nav navbar-right">
                   <li><a href="/intro/index.html">Intro</a></li>
                   <li><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
-                  <li><span>Docs<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill="#252937" fill-rule="evenodd"/></svg></span>
+                  <li><span>Docs<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span>
                     <ul class="dropdown">
                       <li><a href="/docs/index.html">Docs Home</a></li>
                       <li><a href="/guides/index.html">Guides</a></li>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -68,18 +68,32 @@
                 <span class="icon-bar"></span>
               </button>
             </div>
+
+            <%
+              docs_items = <<-EOT
+                <li><a href="/docs/index.html">Docs Home</a></li>
+                <li><a href="/docs/cli-index.html">Terraform CLI</a></li>
+                <li><a href="/docs/enterprise/index.html">Terraform Enterprise</a></li>
+                <li><a href="/docs/providers/index.html">Providers</a></li>
+                <li><a href="/docs/glossary.html">Glossary</a></li>
+                <li><a href="/guides/index.html">Guides and Whitepapers</a></li>
+                <li><a href="/docs/registry/index.html">Registry</a></li>
+                <li><a href="/docs/github-actions/index.html">GitHub Actions</a></li>
+                <li><a href="/docs/extend/index.html">Extending Terraform</a></li>
+              EOT
+            %>
+
             <div class="buttons hidden-xs">
               <nav class="navigation-links" role="navigation">
                 <ul class="main-links nav navbar-nav navbar-right">
                   <li><a href="/intro/index.html">Intro</a></li>
                   <li><a href="https://learn.hashicorp.com/terraform/">Learn</a></li>
-                  <li><span>Docs<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span>
+                  <li><span><a href="/docs/index.html">Docs</a><svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span>
                     <ul class="dropdown">
-                      <li><a href="/docs/index.html">Docs Home</a></li>
-                      <li><a href="/guides/index.html">Guides</a></li>
-                      <li><a href="/docs/extend/index.html">Extend</a></li>
+                      <%= docs_items %>
                     </ul>
                   </li>
+                  <li><a href="/community.html">Community</a></li>
                   <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
                   <li>
                     <a href="/downloads.html">
@@ -99,7 +113,7 @@
       </div>
     </div>
 
-    <%= partial "layouts/sidebar" %>
+    <%= partial("layouts/sidebar", locals: {docs_items: docs_items}) %>
 
     <%= yield %>
 


### PR DESCRIPTION
Draft PR stealing the header nav dropdown menu from consul.io. @mwickett did the original commit that I ganked this from. 

I have ideas on how to improve the resize behavior, so this isn't a final PR yet. Basically I think we should collapse the intro/enterprise/learn/community links into another dropdown for the uncanny valley between 768 and 992.

![Screen Shot 2019-03-29 at 6 32 18 PM](https://user-images.githubusercontent.com/484309/55269488-44b43480-5251-11e9-8528-59037fddca49.png)

![Screen Shot 2019-03-29 at 6 32 20 PM](https://user-images.githubusercontent.com/484309/55269489-44b43480-5251-11e9-90d2-ce7796512d4f.png)

![Screen Shot 2019-03-29 at 6 32 11 PM](https://user-images.githubusercontent.com/484309/55269490-44b43480-5251-11e9-8c5c-77e9e46d7098.png)

![Screen Shot 2019-03-29 at 6 32 09 PM](https://user-images.githubusercontent.com/484309/55269491-44b43480-5251-11e9-8d88-f3d5ba3afd6a.png)
