### PR TITLE
Adjust styling of code spans

### DIFF
--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -1,13 +1,4 @@
 #inner {
-  p a code {
-    text-decoration: underline;
-  }
-
-  p code {
-    background-color: $terraform-purple-light;
-    color: $terraform-purple;
-  }
-  
   p, li, .alert {
     font-size: $font-size;
     font-family: $font-family-open-sans;
@@ -23,11 +14,15 @@
 
   pre,
   code,
-  pre code,
   tt {
     font-family: $font-family-monospace;
-    font-size: $font-size - 2;
+    font-size: 90%;
     line-height: 1.6;
+  }
+
+  code {
+    background-color: $terraform-purple-light;
+    color: inherit;
   }
 
   pre {
@@ -39,6 +34,9 @@
     code {
       overflow-wrap: normal;
       white-space: pre;
+      background-color: transparent;
+      // Fix too-small default font size for pre
+      font-size: $font-size - 2;
     }
   }
 
@@ -51,7 +49,6 @@
     }
 
     code {
-      background: inherit;
       color: $body-link-color;
     }
   }
@@ -76,24 +73,6 @@
   h2 {
     padding-bottom: 3px;
     border-bottom: 1px solid $gray-light;
-  }
-
-  h1 > code,
-  h2 > code,
-  h3 > code,
-  h4 > code,
-  h5 > code
-  h6 > code,
-  li code,
-  table code,
-  p code,
-  tt,
-  .alert code {
-    font-family: $font-family-monospace;
-    font-size: 90%;
-    background-color: transparent;
-    color: inherit;
-    padding: 0;
   }
 
   table {

--- a/content/source/assets/stylesheets/_variables.scss
+++ b/content/source/assets/stylesheets/_variables.scss
@@ -9,7 +9,7 @@ $packer-blue: #1DAEFF;
 $packer-blue-dark: #1D94DD;
 $terraform-purple: #5C4EE5;
 $terraform-purple-dark: #4040B2;
-$terraform-purple-light: #EFEEF7;
+$terraform-purple-light: lighten( $terraform-purple, 35% );
 $vagrant-blue: #1563FF;
 $vagrant-blue-dark: #104EB2;
 $vault-black: #000000;


### PR DESCRIPTION
> Brief summary: 
> 
> - It's beneficial to have code spans stand out; by definition, we're trying to indicate that something is special about that text.
> - Our current fonts look just a little too similar for most people to make them out comfortably. Adding a background helps.
> - The Vault site (newest of our web properties) does this (with a grey background). 

This was previously a community contribution that I approved and merged:
https://github.com/hashicorp/terraform-website/pull/397

But it was glitchy, and didn't end up hitting the elements it was aiming for.
This commit fixes the interfering rules, and tweaks the styling a bit:

- It uses a slightly different color for the background purple, derived from the
  main purple with SCSS's `lighten()` function.
- It leaves the text of code spans text-colored instead of making it
  link-colored. On second review, I found that too confusing. Also, this way it
  isn't necessary to decorate linked code runs with underlines.
- It affects all code spans, not just those in paragraphs. (We use code spans in
  `<ul>/<ol>`s, `<table>`s, etc.)
- It leaves `<pre><code>` blocks alone.

### Screenshots:

Normal code spans, linked code spans, and a syntax-highlighted `<pre><code>` (triple-backtick) block being left alone:

![Screenshot_2019-04-01 Expressions - Configuration Language - Terraform by HashiCorp(1)](https://user-images.githubusercontent.com/484309/55367226-d665b100-54a0-11e9-919a-9c7e88bc037c.png)

A code span in a header:

![Screenshot_2019-04-01 Expressions - Configuration Language - Terraform by HashiCorp](https://user-images.githubusercontent.com/484309/55367232-dc5b9200-54a0-11e9-81d2-0207e1d64293.png)
