### PR TITLE
In-page quick-nav menu

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -23,27 +23,32 @@ document.addEventListener("turbolinks:load", function() {
     // H2/H3/H4 headers.
     var headers = $('#inner').find('h2, h3, h4');
     if (headers.length > 0) {
+        // Build the quick-nav HTML:
         $("#inner #inner-quicknav").html(
             '<span id="inner-quicknav-trigger">Page Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
         );
-        var quickNavTrigger = $('#inner-quicknav #inner-quicknav-trigger');
         var quickNav = $('#inner-quicknav > ul.dropdown');
         headers.each(function(index, element) {
             var level = element.nodeName.toLowerCase();
             var header_text = $(element).text();
             var header_id = $(element).attr('id');
-            quickNav.append(`<li class="level-${level}"><a href="#${header_id}">${header_text}</a></li>`);
+            quickNav.append('<li class="level-' + level + '"><a href="#' + header_id + '">' + header_text + '</a></li>');
         });
-        quickNavTrigger.on('click', function(e) {
+        // Attach event listeners:
+        // Trigger opens and closes.
+        $('#inner-quicknav #inner-quicknav-trigger').on('click', function(e) {
             $(this).siblings('ul').toggleClass('active');
             e.stopPropagation();
         });
+        // Clicking inside the quick-nav doesn't close it.
         quickNav.on('click', function(e) {
             e.stopPropagation();
         });
+        // Jumping to a section means you're done with the quick-nav.
         quickNav.find('li a').on('click', function() {
             quickNav.removeClass('active');
         });
+        // Clicking outside the quick-nav closes it.
         $('body').on('click', function() {
             quickNav.removeClass('active');
         });

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -7,20 +7,20 @@
 
 //= require analytics
 
-// In navigation sidebars, hide most sub-lists and reveal any that contain the
-// current page. The a.current-page class is added during build by
-// layouts/inner.erb.
+// Set up terraform.io UI helpers
 document.addEventListener("turbolinks:load", function() {
     "use strict";
+
+    // In navigation sidebars, hide most sub-lists and reveal any that contain the
+    // current page. The a.current-page class is added during build by
+    // layouts/inner.erb.
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
     docsSidebar.find("ul.nav").addClass("nav-hidden");
     docsSidebar.find("li").has("a.current-page").addClass("active");
-});
 
-// On docs/content pages, add a hierarchical quick nav menu if there are any
-// H2/H3/H4 headers.
-document.addEventListener("turbolinks:load", function() {
-    "use strict";
+
+    // On docs/content pages, add a hierarchical quick nav menu if there are any
+    // H2/H3/H4 headers.
     var headers = $('#inner').find('h2, h3, h4');
     if (headers.length > 0) {
         $("#inner #inner-quicknav").html(
@@ -28,7 +28,7 @@ document.addEventListener("turbolinks:load", function() {
         );
         var quickNavTrigger = $('#inner-quicknav #inner-quicknav-trigger');
         var quickNav = $('#inner-quicknav > ul.dropdown');
-        headers.each( function(index, element) {
+        headers.each(function(index, element) {
             var level = element.nodeName.toLowerCase();
             var header_text = $(element).text();
             var header_id = $(element).attr('id');

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -13,3 +13,32 @@ document.addEventListener("turbolinks:load", function() {
     docsSidebar.find("ul.nav").addClass("nav-hidden");
     docsSidebar.find("li").has("a.current-page").addClass("active");
 });
+
+document.addEventListener("turbolinks:load", function() {
+    "use strict";
+    $("#inner #inner-quicknav").html(
+        '<span id="inner-quicknav-trigger">Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
+    );
+    var quickNavTrigger = $('#inner-quicknav #inner-quicknav-trigger');
+    var quickNav = $('#inner-quicknav > ul.dropdown');
+    var headers = $('#inner').find('h2, h3, h4');
+    headers.each( function(index, element) {
+        var level = element.nodeName.toLowerCase();
+        var header_text = $(element).text();
+        var header_id = $(element).attr('id');
+        quickNav.append(`<li class="level-${level}"><a href="#${header_id}">${header_text}</a></li>`);
+    });
+    quickNavTrigger.on('click', function(e) {
+        $(this).siblings('ul').toggleClass('active');
+        e.stopPropagation();
+    });
+    quickNav.on('click', function(e) {
+        e.stopPropagation();
+    });
+    quickNav.find('li a').on('click', function() {
+        quickNav.removeClass('active');
+    });
+    $('body').on('click', function() {
+        quickNav.removeClass('active');
+    });
+});

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -16,29 +16,31 @@ document.addEventListener("turbolinks:load", function() {
 
 document.addEventListener("turbolinks:load", function() {
     "use strict";
-    $("#inner #inner-quicknav").html(
-        '<span id="inner-quicknav-trigger">Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
-    );
-    var quickNavTrigger = $('#inner-quicknav #inner-quicknav-trigger');
-    var quickNav = $('#inner-quicknav > ul.dropdown');
     var headers = $('#inner').find('h2, h3, h4');
-    headers.each( function(index, element) {
-        var level = element.nodeName.toLowerCase();
-        var header_text = $(element).text();
-        var header_id = $(element).attr('id');
-        quickNav.append(`<li class="level-${level}"><a href="#${header_id}">${header_text}</a></li>`);
-    });
-    quickNavTrigger.on('click', function(e) {
-        $(this).siblings('ul').toggleClass('active');
-        e.stopPropagation();
-    });
-    quickNav.on('click', function(e) {
-        e.stopPropagation();
-    });
-    quickNav.find('li a').on('click', function() {
-        quickNav.removeClass('active');
-    });
-    $('body').on('click', function() {
-        quickNav.removeClass('active');
-    });
+    if (headers.length > 0) {
+        $("#inner #inner-quicknav").html(
+            '<span id="inner-quicknav-trigger">Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
+        );
+        var quickNavTrigger = $('#inner-quicknav #inner-quicknav-trigger');
+        var quickNav = $('#inner-quicknav > ul.dropdown');
+        headers.each( function(index, element) {
+            var level = element.nodeName.toLowerCase();
+            var header_text = $(element).text();
+            var header_id = $(element).attr('id');
+            quickNav.append(`<li class="level-${level}"><a href="#${header_id}">${header_text}</a></li>`);
+        });
+        quickNavTrigger.on('click', function(e) {
+            $(this).siblings('ul').toggleClass('active');
+            e.stopPropagation();
+        });
+        quickNav.on('click', function(e) {
+            e.stopPropagation();
+        });
+        quickNav.find('li a').on('click', function() {
+            quickNav.removeClass('active');
+        });
+        $('body').on('click', function() {
+            quickNav.removeClass('active');
+        });
+    }
 });

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -7,6 +7,9 @@
 
 //= require analytics
 
+// In navigation sidebars, hide most sub-lists and reveal any that contain the
+// current page. The a.current-page class is added during build by
+// layouts/inner.erb.
 document.addEventListener("turbolinks:load", function() {
     "use strict";
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
@@ -14,6 +17,8 @@ document.addEventListener("turbolinks:load", function() {
     docsSidebar.find("li").has("a.current-page").addClass("active");
 });
 
+// On docs/content pages, add a hierarchical quick nav menu if there are any
+// H2/H3/H4 headers.
 document.addEventListener("turbolinks:load", function() {
     "use strict";
     var headers = $('#inner').find('h2, h3, h4');

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -19,7 +19,7 @@ document.addEventListener("turbolinks:load", function() {
     var headers = $('#inner').find('h2, h3, h4');
     if (headers.length > 0) {
         $("#inner #inner-quicknav").html(
-            '<span id="inner-quicknav-trigger">Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
+            '<span id="inner-quicknav-trigger">Page Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
         );
         var quickNavTrigger = $('#inner-quicknav #inner-quicknav-trigger');
         var quickNav = $('#inner-quicknav > ul.dropdown');

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -1,4 +1,68 @@
 #inner {
+
+  #inner-quicknav {
+    margin-top: 35px;
+    &+h1 {
+      margin-top: 20px;
+    }
+
+    span {
+      line-height: 20px;
+      cursor: pointer;
+
+      svg {
+        fill: black;
+        position: relative;
+        top: -2px;
+        width: 9px;
+        height: 5px;
+        margin-left: 7px;
+      }
+    }
+
+    ul {
+      visibility: hidden;
+      opacity: 0;
+      transition: all 0.5s ease;
+      width: 80%;
+      box-shadow: 0px 4px 12px -2px rgba(63, 68, 85, 0.5);
+      border-radius: 3px;
+      padding: 2rem;
+      position: absolute;
+      z-index: 1;
+      background-color: $home-header-background-color;
+      margin-left: -15px;
+
+      &.active {
+        visibility: visible;
+        opacity: 1;
+        display: block;
+        transition: all 0.5s ease;
+      }
+
+      li {
+        clear: both;
+        width: 100%;
+        display: block;
+        position: relative;
+        margin-bottom: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+
+        $toc-indent: 30px;
+        &.level-h2 { margin-left: $toc-indent * 0 }
+        &.level-h3 { margin-left: $toc-indent * 1 }
+        &.level-h4 { margin-left: $toc-indent * 2 }
+        &.level-h5 { margin-left: $toc-indent * 3 }
+        &.level-h6 { margin-left: $toc-indent * 4 }
+
+        a {
+          text-decoration: none;
+        }
+      }
+    }
+  }
+
   p, li, .alert {
     font-size: $font-size;
     font-family: $font-family-open-sans;

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -11,7 +11,7 @@
       cursor: pointer;
 
       svg {
-        fill: black;
+        fill: $body-font-color;
         position: relative;
         top: -2px;
         width: 9px;

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -46,15 +46,16 @@
         display: block;
         position: relative;
         margin-bottom: 0;
+        margin-left: 0;
         padding-top: 0;
         padding-bottom: 0;
 
         $toc-indent: 30px;
-        &.level-h2 { margin-left: $toc-indent * 0 }
-        &.level-h3 { margin-left: $toc-indent * 1 }
-        &.level-h4 { margin-left: $toc-indent * 2 }
-        &.level-h5 { margin-left: $toc-indent * 3 }
-        &.level-h6 { margin-left: $toc-indent * 4 }
+        &.level-h2 { padding-left: $toc-indent * 0 }
+        &.level-h3 { padding-left: $toc-indent * 1 }
+        &.level-h4 { padding-left: $toc-indent * 2 }
+        &.level-h5 { padding-left: $toc-indent * 3 }
+        &.level-h6 { padding-left: $toc-indent * 4 }
 
         a {
           text-decoration: none;

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -13,6 +13,7 @@
     </div>
 
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">
+      <div id="inner-quicknav"></div>
       <%= yield %>
     </div>
   </div>


### PR DESCRIPTION
This adds a small drop-down menu at the top of each page. When clicked,
it reveals an in-page hierarchical TOC which you can use to jump directly to any
of the H2, H3, or H4 headers in the primary content. The TOC can be dismissed by
clicking outside it or by re-clicking the trigger.

**gif:** 

![quicknav](https://user-images.githubusercontent.com/484309/55442350-0f665a00-5563-11e9-9fae-fa00bbc64c3a.gif)

**desktop:** 

![Screenshot_2019-04-02 Workspaces - API Docs - Terraform Enterprise - Terraform by HashiCorp(1)](https://user-images.githubusercontent.com/484309/55442368-20af6680-5563-11e9-8d18-8ac2a8fa5c1e.png)

**mobile:**

<img src="https://user-images.githubusercontent.com/484309/55442881-4fc6d780-5565-11e9-9ece-5e3407a5ce70.png" width="320" height="auto">

This re-uses the SCSS from the top-nav dropdown, and uses a little bit of JQuery
to do the rest of the lifting.