### PR TITLE
Expandable sidebars

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -15,11 +15,10 @@ document.addEventListener("turbolinks:load", function() {
     // current page. The a.current-page class is added during build by
     // layouts/inner.erb.
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
-    docsSidebar.find("ul.nav").addClass("nav-hidden");
-    docsSidebar.find("li").has("a.current-page, ul.nav-visible").addClass("active");
+    docsSidebar.find("li").has(".current-page, .nav-visible").addClass("active");
+    var subNavs = docsSidebar.find("ul").addClass("nav-hidden").parent("li");
 
     // Make sidebar navs expandable
-    var subNavs = $("ul.nav.docs-sidenav li").has("ul");
     subNavs.addClass("has-subnav");
     subNavs.on("click", function(e) {
         if (e.target == this) {

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -16,7 +16,17 @@ document.addEventListener("turbolinks:load", function() {
     // layouts/inner.erb.
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
     docsSidebar.find("ul.nav").addClass("nav-hidden");
-    docsSidebar.find("li").has("a.current-page").addClass("active");
+    docsSidebar.find("li").has("a.current-page, ul.nav-visible").addClass("active");
+
+    // Make sidebar navs expandable
+    var subNavs = $("ul.nav.docs-sidenav li").has("ul");
+    subNavs.addClass("has-subnav");
+    subNavs.on("click", function(e) {
+        if (e.target == this) {
+            $(this).toggleClass("active");
+        }
+        e.stopPropagation();
+    });
 
 
     // On docs/content pages, add a hierarchical quick nav menu if there are any

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -26,9 +26,23 @@ document.addEventListener("turbolinks:load", function() {
         }
         e.stopPropagation();
     });
+    // For subnavs that don't link to a page, use the whole header as a toggle.
     docsSidebar.find("a[href^='#']").on("click", function(e) {
         e.preventDefault();
         $(this).parent("li").trigger("click");
+    });
+    // Navs can include an optional global toggle like this:
+    // <a href="#" class="subnav-toggle">(Expand/collapse all)</a>
+    // Navs that don't want that can leave it out.
+    var globalExpand = true;
+    $("#docs-sidebar a.subnav-toggle").on("click", function(e) {
+        e.preventDefault();
+        if (globalExpand) {
+            subNavs.addClass("active");
+        } else {
+            subNavs.removeClass("active");
+        }
+        globalExpand = !globalExpand;
     });
 
 

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -26,6 +26,10 @@ document.addEventListener("turbolinks:load", function() {
         }
         e.stopPropagation();
     });
+    docsSidebar.find("a[href^='#']").on("click", function(e) {
+        e.preventDefault();
+        $(this).parent("li").trigger("click");
+    });
 
 
     // On docs/content pages, add a hierarchical quick nav menu if there are any

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -18,29 +18,6 @@
     padding-top: 10px;
 
     li {
-      &:before {
-        color: $sidebar-link-color-active;
-        content: '\2022';
-        font-size: 1em;
-        left: -3px;
-        top: -3px;
-        opacity: 0.4;
-        position: absolute;
-      }
-      &.active:before {
-        opacity: 1;
-      }
-      &.has-subnav {
-        &:before {
-          content: '\276F';
-          cursor: pointer;
-          transition: transform .1s linear;
-        }
-        &.active:before {
-          transform: rotate(90deg);
-        }
-      }
-
       a {
         color: $sidebar-link-color;
         font-size: $sidebar-font-size;
@@ -54,21 +31,41 @@
           color: $sidebar-link-color-hover;
         }
       }
-    }
 
-    li.active {
-      > a {
+      &:before {
         color: $sidebar-link-color-active;
+        content: '\2022';
+        font-size: 1em;
+        left: -3px;
+        top: -3px;
+        opacity: 0.4;
+        position: absolute;
+      }
 
+      &.has-subnav {
+        &:before {
+          content: '\276F';
+          cursor: pointer;
+          transition: transform .1s linear;
+        }
+        &.active:before {
+          transform: rotate(90deg);
+        }
+      }
+
+      &.active {
+        > a {
+          color: $sidebar-link-color-active;
+        }
+        // Open nested navigations
+        > ul.nav {
+          display: block;
+        }
         &:before {
           opacity: 1;
         }
       }
 
-      // Open nested navigations
-      > ul.nav {
-        display: block;
-      }
     }
 
     // subnav

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -34,6 +34,7 @@
         &:before {
           content: '\276F';
           cursor: pointer;
+          transition: transform .1s linear;
         }
         &.active:before {
           transform: rotate(90deg);

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -12,6 +12,24 @@
     margin-top: 30px;
   }
 
+  %sidebar-link {
+    color: $sidebar-link-color;
+    font-size: $sidebar-font-size;
+    overflow-wrap: break-word;
+    margin: 0 0 0 15px;
+    padding: 0 0 11px 0;
+
+    &:focus,
+    &:hover {
+      background-color: transparent;
+      color: $sidebar-link-color-hover;
+    }
+  }
+
+  a.subnav-toggle {
+    @extend %sidebar-link;
+  }
+
   ul.nav.docs-sidenav {
     display: block;
     padding-bottom: 15px;
@@ -19,17 +37,7 @@
 
     li {
       a {
-        color: $sidebar-link-color;
-        font-size: $sidebar-font-size;
-        overflow-wrap: break-word;
-        margin: 0 0 0 15px;
-        padding: 0 0 11px 0;
-
-        &:focus,
-        &:hover {
-          background-color: transparent;
-          color: $sidebar-link-color-hover;
-        }
+        @extend %sidebar-link;
       }
 
       &:before {

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -20,10 +20,10 @@
     li {
       &:before {
         color: $sidebar-link-color-active;
-        content: '\276f';
-        font-size: .8em;
+        content: '\2022';
+        font-size: 1em;
         left: -3px;
-        top: 1px;
+        top: -3px;
         opacity: 0.4;
         position: absolute;
       }
@@ -32,11 +32,11 @@
       }
       &.has-subnav {
         &:before {
-          content: '\25b6\fe0e';
+          content: '\276F';
           cursor: pointer;
         }
         &.active:before {
-          content: '\25bc';
+          transform: rotate(90deg);
         }
       }
 

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -15,48 +15,43 @@
   ul.nav.docs-sidenav {
     display: block;
     padding-bottom: 15px;
+    padding-top: 10px;
 
     li {
+      &:before {
+        color: $sidebar-link-color-active;
+        content: '\276f';
+        font-size: .8em;
+        left: -3px;
+        top: 1px;
+        opacity: 0.4;
+        position: absolute;
+      }
+      &.active:before {
+        opacity: 1;
+      }
+      &.has-subnav {
+        &:before {
+          content: '\25b6\fe0e';
+          cursor: pointer;
+        }
+        &.active:before {
+          content: '\25bc';
+        }
+      }
+
       a {
         color: $sidebar-link-color;
         font-size: $sidebar-font-size;
         overflow-wrap: break-word;
-        padding: 10px 0 10px 15px;
-
-        &:before {
-          color: $sidebar-link-color-active;
-          content: '\203A';
-          font-size: $font-size;
-          left: 0;
-          line-height: 100%;
-          opacity: 0.4;
-          position: absolute;
-
-          height: 100%;
-          width: 8px
-        }
+        margin: 0 0 0 15px;
+        padding: 0 0 11px 0;
 
         &:focus,
         &:hover {
           background-color: transparent;
           color: $sidebar-link-color-hover;
-
-          &:before {
-            opacity: 1;
-          }
         }
-
-        &.back {
-          &:before {
-            content: '\2039';
-          }
-        }
-      }
-
-      // For forcing sub-navs to appear - in the long term, this should not
-      // be a thing anymore...
-      > ul.nav-visible {
-        display: block;
       }
     }
 
@@ -80,14 +75,10 @@
       display: none;
     }
     ul.nav {
-      margin: 10px;
+      padding: 10px;
 
       li {
         margin-left: 10px;
-
-        a {
-          padding: 6px 15px;
-        }
       }
     }
   }

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -2,6 +2,8 @@
   <% content_for :sidebar do %>
     <h4><a href="/docs/enterprise/index.html">Terraform Enterprise</a></h4>
 
+    <a href="#" class="subnav-toggle">(Expand/collapse all)</a>
+
     <ul class="nav docs-sidenav">
       <li>
         <a href="/docs/enterprise/getting-started/index.html">Getting Started</a>


### PR DESCRIPTION
This PR makes the nav sidebars expandable/collapsable. 

- Chevrons only appear on nav items with subnavs. Normal nav items just have dots.
- Clicking the chevrons opens and closes the subnavs without navigating anywhere.
- Links work like they always have (navigate to destination AND expand subnav once there). Need this for backward compatibility.
    - Dummy subnav headers (links that don't go anywhere because their href starts with `#`) are a special case -- they have the same effect as clicking the chevron. (Previous behavior: probably jump you to the top of the page and lose your spot. See aws provider in the prod site for example.)

        This means our dummy headers now work the same way as subnav headers in the new sidebar component on vaultproject.io. (They use a pattern where subnavs are _only_ folders, and the index.html file goes in an "overview" item at the top of the sub-list.) That gives us the option of incrementally transitioning to that style of sidebar nav.

        (Why does vaultproject.io use that style? Better discoverability of the nav collapse/expand, more consistent overall behavior, and easier targeting on mobile.)
- Subnavs that are marked as always-open in their .erb file work like they always have, except now the user can temporarily close them if they're in the way (like that "data sources" section in the aws provider always is). 

### Questions for reviewers:

@phinze and @armchairlinguist and @rkst @apparentlymart and anyone else involved in Terraform docs: 

- Is this good to have? 
- Is the behavior what you'd expect?

@mwickett or anyone else with JavaScript chops:

- Is this code OK to check in? 
- Is there a better way to do any of this?

### Criteria

If I get consensus that this is good to have, plus a head nod from web platform, I'll treat that as approval to rebase and merge. 

### Gif

![rotate2](https://user-images.githubusercontent.com/484309/55584534-3e064100-56d9-11e9-802d-eec5306b3db5.gif)