### PR TITLE
Fix Sass "extend compound selector" deprecation warnings on preview and build

### DIFF
--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -26,7 +26,7 @@
 
       svg.logo {
         transition: opacity 0.15s ease-in-out;
-        @extend svg.logo.white;
+        @extend %logo-white;
 
         &:hover,
         &:focus,

--- a/content/source/assets/stylesheets/_logos.scss
+++ b/content/source/assets/stylesheets/_logos.scss
@@ -1,41 +1,43 @@
+%logo-color {
+  opacity: 1.0;
+
+  path.text {
+    fill: $black;
+    opacity: 1.0;
+  }
+
+  path.rect-light {
+    fill: $terraform-purple;
+    opacity: 1.0;
+  }
+
+  path.rect-dark {
+    fill: $terraform-purple-dark;
+    opacity: 1.0;
+  }
+}
+
+%logo-white {
+  opacity: 1.0;
+
+  path.text {
+    fill: $white;
+  }
+
+  path.rect-light {
+    fill: $white;
+    opacity: 1.0;
+  }
+
+  path.rect-dark {
+    fill: $white;
+    opacity: 0.7;
+  }
+}
+
 svg.logo {
-  &.color {
-    opacity: 1.0;
-
-    path.text {
-      fill: $black;
-      opacity: 1.0;
-    }
-
-    path.rect-light {
-      fill: $terraform-purple;
-      opacity: 1.0;
-    }
-
-    path.rect-dark {
-      fill: $terraform-purple-dark;
-      opacity: 1.0;
-    }
-  }
-
   // The default logo class is the colored version
-  @extend .color;
-
-  &.white {
-    opacity: 1.0;
-
-    path.text {
-      fill: $white;
-    }
-
-    path.rect-light {
-      fill: $white;
-      opacity: 1.0;
-    }
-
-    path.rect-dark {
-      fill: $white;
-      opacity: 0.7;
-    }
-  }
+  @extend %logo-color;
+  &.color { @extend %logo-color; }
+  &.white { @extend %logo-white; }
 }


### PR DESCRIPTION
Sass has been giving us sass about using deprecated syntax. (For details, see
https://github.com/sass/sass/issues/1599.) This commit just moves the affected
rules into placeholder classes and extends those, which silences the warnings
while giving the exact same behavior.

(We could probably just put up with it until we jump off this sinking ship, but
we _did_ get an unexpected Sass update recently while doing some security fixes,
and I can't guarantee that won't happen again before we're on the new platform.)