### PR TITLE
Clean up some fussy details of how the "other docs" sidebar section works

### DIFF
--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -1,5 +1,8 @@
-<%# Call with partial("layouts/otherdocs", :locals => { :skip => "Terraform CLI" }) -%>
-<% other_docs = {
+<%# Call with partial("layouts/otherdocs", locals: { skip: "Terraform CLI", header: "Optional Header" }) -%>
+<%
+  skip ||= ""
+  header ||= "Other Docs"
+  other_docs = {
     "Terraform CLI" => "/docs/cli-index.html",
     "Terraform Enterprise" => "/docs/enterprise/index.html",
     "Provider References" => "/docs/providers/index.html",
@@ -9,8 +12,9 @@
     "Terraform Registry" => "/docs/registry/index.html",
     "Terraform GitHub Actions" => "/docs/github-actions/index.html",
     "Extending Terraform" => "/docs/extend/index.html"
-} -%>
-    <h4>Other Docs</h4>
+  }
+-%>
+    <h4><%= header %></h4>
 
     <ul class="nav docs-sidenav">
 <% other_docs.each do |name, path| -%>

--- a/content/source/layouts/docs-frontpage.erb
+++ b/content/source/layouts/docs-frontpage.erb
@@ -1,10 +1,7 @@
 <% wrap_layout :inner do %>
   <% content_for :sidebar do %>
-    <h4><a href="/docs/index.html">Terraform Docs</a></h4>
 
-    <%= partial(
-                "layouts/otherdocs", :locals => { :skip => "none" }
-        ).sub(%r{^ *<h4>Other Docs</h4> *$}, '').gsub(/class="back" /, '') %>
+    <%= partial("layouts/otherdocs", locals: { header: "Terraform Docs" }) %>
 
   <% end %>
 


### PR DESCRIPTION
This had two problems:

- I wanted to replace the header on the docs homepage, and was doing it in a
  fairly dirty way to avoid causing havoc in other pages that need that snippet.
- The snippet would blow up if you invoked it without passing a value for
  `skip` (NilClass doesn't have `#downcase`), which meant you had to make up
  some nonsense if you didn't want to skip anything.