### PR TITLE
Add "jump to content" link on mobile

### DIFF
--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -2,6 +2,7 @@
 <div class="container">
   <div class="row">
     <div id="docs-sidebar" class="col-sm-4 col-md-3 col-xs-12 hidden-print" role="complementary">
+      <a href="#inner" class="visible-xs">(Jump to content ⤵︎)</a>
       <% if content_for?(:sidebar) %>
       <%
         sidebar_text = yield_content(:sidebar)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/484309/55758418-9a37d080-5a0b-11e9-8a7e-6d565eaa5a50.png)

This link is only visible if the viewport is narrow enough that the nav sidebar
collapses. At that point, you need to scroll past the entire nav content before
you reach the page content, which makes the site very tiring on mobile.

Having to tap an extra link before reading still isn't the best of experiences,
but it's nicer than scrolling all that way.