### PR TITLE
Increase text contrast

### DIFF
--- a/content/source/assets/stylesheets/_variables.scss
+++ b/content/source/assets/stylesheets/_variables.scss
@@ -1,7 +1,7 @@
 // Colors
 $white: #FFFFFF;
 $black: #000000;
-$gray-darker: #555555;
+$gray-darker: #333333;
 
 $consul-pink: #D62783;
 $consul-pink-dark: #961D59;


### PR DESCRIPTION
Users have sometimes pointed out that the text contrast on terraform.io
is low. More recent updates to our web properties use text colors in
the #3x3x3x sort of range (for example, vaultproject.io uses #373942),
which feels like a better fit for us as well.

**before/after:** 

![contrast](https://user-images.githubusercontent.com/484309/55762764-0f5dd280-5a19-11e9-884c-d7bf6c76bb62.png)