### PR TITLE
Filterable sidebar navs

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -11,28 +11,36 @@
 document.addEventListener("turbolinks:load", function() {
     "use strict";
 
-    // In navigation sidebars, hide most sub-lists and reveal any that contain the
+    // SIDEBAR STUFF:
+    // - "subNavs" are <li> elements with a nested <ul> as a direct child.
+    // - The <a> child is the "header" of the subnav, and the <ul> is its "content."
+    // - Subnavs are collapsed (<ul> hidden) or expanded (<ul> visible).
+    // - Collapse/expand is managed by the "active" class on the <li>.
+
+    // Collapse most subnavs, but reveal any that contain the
     // current page. The a.current-page class is added during build by
     // layouts/inner.erb.
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
     var subNavs = docsSidebar.find("ul").addClass("nav-hidden").parent("li");
         // we leave the nav-hidden class alone after this.
-    var sidebarReset = function() {
+    var resetActiveSubnavs = function() {
         subNavs.removeClass("active");
         // Activate current page, locked-open navs, and all their parents:
         docsSidebar.find("li").has(".current-page, .nav-visible").addClass("active");
     };
-    sidebarReset();
+    resetActiveSubnavs();
 
-    // Make sidebar navs expandable
+    // CSS class that adds toggle controls:
     subNavs.addClass("has-subnav");
+    // Toggle subnav expansion when clicking an area that isn't claimed by the
+    // header or content (usually the :before pseudo-element)
     subNavs.on("click", function(e) {
         if (e.target == this) {
             $(this).toggleClass("active");
         }
         e.stopPropagation();
     });
-    // For subnavs that don't link to a page, use the whole header as a toggle.
+    // If the subnav header doesn't link to a different page, use it as a toggle.
     docsSidebar.find("a[href^='#']").on("click", function(e) {
         e.preventDefault();
         $(this).parent("li").trigger("click");
@@ -68,7 +76,7 @@ document.addEventListener("turbolinks:load", function() {
                 filterField.val("");
                 filterField.trigger("blur");
                 sidebarLinks.parent("li").show();
-                sidebarReset();
+                resetActiveSubnavs();
                 $(this).html("Expand all");
             },
             "click": function(e) {
@@ -82,7 +90,11 @@ document.addEventListener("turbolinks:load", function() {
             }
         });
 
-        // Filter as you type:
+        // Filter as you type. This alters three things:
+        // - "active" class on subnavs
+        // - direct show/hide of <li>s
+        // - state of subnavToggle button
+        // We rely on subnavToggle's "reset" event to clean up when done.
         filterField.on('keyup', function(e) {
             if (e.keyCode === 27) { // escape key
                 subnavToggle.trigger("reset");

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -53,8 +53,8 @@ document.addEventListener("turbolinks:load", function() {
         if ($("#sidebar-controls").length === 0) { // then add it!
             var sidebarControlsHTML =
                 '<div id="sidebar-controls">' +
-                    '<label for="sidebar-filter-field">Filter page titles</label>' +
-                    '<input type="text" id="sidebar-filter-field" name="sidebar-filter-field" />' +
+                    '<span class="glyphicon glyphicon-search"></span>' +
+                    '<input type="search" id="sidebar-filter-field" class="form-control" name="sidebar-filter-field" role="search" placeholder="Filter page titles" />' +
                     '<a href="#" class="subnav-toggle btn btn-default" role="button">Expand all</a>' +
                 '</div>';
             if ($("#docs-sidebar a.subnav-toggle").length === 0) { // ...in default location

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -46,10 +46,10 @@ document.addEventListener("turbolinks:load", function() {
     });
 
 
-    // On docs/content pages, add a hierarchical quick nav menu if there are any
-    // H2/H3/H4 headers.
+    // On docs/content pages, add a hierarchical quick nav menu if there are
+    // more than two H2/H3/H4 headers.
     var headers = $('#inner').find('h2, h3, h4');
-    if (headers.length > 0) {
+    if (headers.length > 2) {
         // Build the quick-nav HTML:
         $("#inner #inner-quicknav").html(
             '<span id="inner-quicknav-trigger">Page Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -45,10 +45,8 @@ document.addEventListener("turbolinks:load", function() {
         if ($("#sidebar-controls").length === 0) { // then add it!
             var sidebarControlsHTML =
                 '<div id="sidebar-controls">' +
-                    '<div id="sidebar-filter">' +
-                        '<label for="sidebar-filter-field">Filter page titles</label>' +
-                        '<input type="text" id="sidebar-filter-field" name="sidebar-filter-field" />' +
-                    '</div>' +
+                    '<label for="sidebar-filter-field">Filter page titles</label>' +
+                    '<input type="text" id="sidebar-filter-field" name="sidebar-filter-field" />' +
                     '<a href="#" class="subnav-toggle btn btn-default" role="button">Expand all</a>' +
                 '</div>';
             if ($("#docs-sidebar a.subnav-toggle").length === 0) { // ...in default location

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -113,12 +113,13 @@ document.addEventListener("turbolinks:load", function() {
             }
         });
         // Type slash to focus sidebar filter:
-        $(document).keydown(function(e) {
+        $("body").keydown(function(e) {
+            // 191 = / (forward slash) key
+            if (e.keyCode !== 191) {
+                return;
+            }
             var focusedElementType = $(document.activeElement).get(0).tagName.toLowerCase();
-            var inputting = focusedElementType === "textarea" || focusedElementType === "input";
-
-            // / (forward slash) key = search
-            if (!inputting && e.keyCode === 191) {
+            if (focusedElementType !== "textarea" && focusedElementType !== "input") {
                 e.preventDefault();
                 filterField.focus();
             }

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -122,7 +122,11 @@ document.addEventListener("turbolinks:load", function() {
     if (headers.length > 2) {
         // Build the quick-nav HTML:
         $("#inner #inner-quicknav").html(
-            '<span id="inner-quicknav-trigger">Page Quick Nav<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg></span><ul class="dropdown"></ul>'
+            '<span id="inner-quicknav-trigger">' +
+                'Page Quick Nav' +
+                '<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg>' +
+            '</span>' +
+            '<ul class="dropdown"></ul>'
         );
         var quickNav = $('#inner-quicknav > ul.dropdown');
         headers.each(function(index, element) {

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -51,7 +51,7 @@ document.addEventListener("turbolinks:load", function() {
             '</div>';
         if ($("#sidebar-controls").length === 0) { // then add it!
             if ($("#docs-sidebar a.subnav-toggle").length === 0) { // ...in default location
-                $("#docs-sidebar").prepend(sidebarControlsHTML);
+                $("#docs-sidebar #controls-placeholder").replaceWith(sidebarControlsHTML);
             } else { // ...at a manually chosen location
                 $("#docs-sidebar a.subnav-toggle").replaceWith(sidebarControlsHTML);
             }

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -23,11 +23,11 @@ document.addEventListener("turbolinks:load", function() {
     var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav");
     var subNavs = docsSidebar.find("ul").addClass("nav-hidden").parent("li");
         // we leave the nav-hidden class alone after this.
-    var resetActiveSubnavs = function() {
+    function resetActiveSubnavs() {
         subNavs.removeClass("active");
         // Activate current page, locked-open navs, and all their parents:
         docsSidebar.find("li").has(".current-page, .nav-visible").addClass("active");
-    };
+    }
     resetActiveSubnavs();
 
     // CSS class that adds toggle controls:

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -1,6 +1,6 @@
 #docs-sidebar {
   margin-bottom: 30px;
-  margin-top: 50px;
+  margin-top: 20px;
   overflow: hidden;
 
   h1,

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -27,7 +27,20 @@
   }
 
   a.subnav-toggle {
-    @extend %sidebar-link;
+    margin-top: 4px;
+  }
+  div#sidebar-filter {
+    a#sidebar-filter-field-clear {
+      border: 1px solid $terraform-purple-dark;
+      border-radius: 2px;
+      padding: 3px;
+      margin-left: 3px;
+      width: 1em;
+      @extend %sidebar-link;
+    }
+    label {
+      font-size: .8em;
+    }
   }
 
   ul.nav.docs-sidenav {

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -58,6 +58,8 @@
         }
         &.active:before {
           transform: rotate(90deg);
+          left: -1px;
+          top: -1px;
         }
       }
 

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -37,20 +37,15 @@
       z-index: -1;
     }
     input {
-      display: inline-block;
       font-size: 1rem;
       height: 100%;
-      width: 61%;
-      margin-right: 1%;
       margin-bottom: 1px;
       padding-left: 28px;
       background: transparent;
     }
     a.subnav-toggle {
-      display: inline-block;
       font-size: 1rem;
-      width: 38%;
-      padding: .4em 0;
+      padding: .2em 1.4em;
     }
   }
 

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -26,19 +26,25 @@
     }
   }
 
-  a.subnav-toggle {
-    margin-top: 4px;
-  }
-  div#sidebar-filter {
-    align-content: center;
-    a#sidebar-filter-field-clear {
-      margin-left: 3px;
-      padding-top: 3px;
-      padding-bottom: 3px;
-      vertical-align: baseline;
-    }
+  div#sidebar-controls {
+    box-sizing: border-box;
     label {
-      font-size: .8em;
+      display: block;
+      font-size: 1rem;
+    }
+    input {
+      display: inline-block;
+      font-size: 1rem;
+      height: 100%;
+      width: 61%;
+      margin-right: 1%;
+      margin-bottom: 1px;
+    }
+    a.subnav-toggle {
+      display: inline-block;
+      font-size: 1rem;
+      width: 38%;
+      padding: .4em 0;
     }
   }
 

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -28,9 +28,13 @@
 
   div#sidebar-controls {
     box-sizing: border-box;
-    label {
-      display: block;
-      font-size: 1rem;
+    position: relative;
+    .glyphicon-search {
+      position: absolute;
+      top: 7px;
+      left: 7px;
+      opacity: .7;
+      z-index: -1;
     }
     input {
       display: inline-block;
@@ -39,6 +43,8 @@
       width: 61%;
       margin-right: 1%;
       margin-bottom: 1px;
+      padding-left: 28px;
+      background: transparent;
     }
     a.subnav-toggle {
       display: inline-block;

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -30,13 +30,12 @@
     margin-top: 4px;
   }
   div#sidebar-filter {
+    align-content: center;
     a#sidebar-filter-field-clear {
-      border: 1px solid $terraform-purple-dark;
-      border-radius: 2px;
-      padding: 3px;
       margin-left: 3px;
-      width: 1em;
-      @extend %sidebar-link;
+      padding-top: 3px;
+      padding-bottom: 3px;
+      vertical-align: baseline;
     }
     label {
       font-size: .8em;

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -9,7 +9,7 @@
   h4,
   h5,
   h6 {
-    margin-top: 30px;
+    margin-top: 10px;
   }
 
   %sidebar-link {

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -3,6 +3,7 @@
   <div class="row">
     <div id="docs-sidebar" class="col-sm-4 col-md-3 col-xs-12 hidden-print" role="complementary">
       <a href="#inner" class="visible-xs">(Jump to content ⤵︎)</a>
+      <div id="controls-placeholder"></div>
       <% if content_for?(:sidebar) %>
       <%
         sidebar_text = yield_content(:sidebar)


### PR DESCRIPTION
Full behavior of this should hopefully be completely intuitive, but it takes a moment to explain, so let's start with the customary gif. 

![filter15](https://user-images.githubusercontent.com/484309/55849598-131b5300-5b06-11e9-9e26-d4887a4450b7.gif)

### ok, so,

- We now automatically add expand/filter controls to "large sidebars." Currently that's defined as sidebars with more than 30 links in them.
    - You can choose a place for the controls (like putting them below a header) or let them take their default place. (Probably best to let them default.)
- The expand all/collapse all control has changed its behavior slightly: 
    - "Collapse all" is replaced by "reset," which always returns the sidebar to its initial state (current page, default-open subnavs, and their parents are activated). 
    - It's a button.
    - It displays its current mode, so you know what it's going to do when you click.
- There's a ✨filter field✨.
    - Focus by clicking in it, or by typing slash (/) on the page while not inside a text field. 
        - Squatting on slash is somewhat aggressive and overrides a power-user Firefox feature, but it's also a well-trodden path that power-users generally understand by now. Try typing slash on GitHub, Gmail, most other Google properties, DuckDuckGo, Twitter, and more. (Or `less`.)
    - Type to filter. Filter text matches against _the text of the sidebar links,_ not deep page content or anything. 
    - While filtering, sidebar items default to hidden. 
    - Items that match the filter are shown, as are all of their parents. 
    - If a filter matches a subnav header (like "API" or EC2 in the example gif), that also reveals all the _direct_ children of that subnav even if they don't match the filter, since we assume all of those items are relevant to the filter that matched their parent. (That all sounds complicated, but it's just crossing the Ts and dotting the Is to make it act the way you were already expecting it to.)
    - To clear a filter, either click the "reset" button or press your "esc" key. (This triggers the button's "reset" action.) 
    - Using the filter form changes the button's mode to "reset."