### PR TITLE
Prevent mobile Webkit/Blink from auto-zooming sidebar filter

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -42,6 +42,9 @@
       margin-bottom: 1px;
       padding-left: 28px;
       background: transparent;
+      @media (pointer: coarse) {
+        font-size: 16px;
+      }
     }
     a.subnav-toggle {
       font-size: 1rem;


### PR DESCRIPTION
If a form field has a font-size of less than 16px, telephone browsers
will auto-zoom the screen to them on focus. So, that's obnoxious.
But the pointer media query seems like a solid good-enough way to guess
whether we need to guard against that.