### PR TITLE
Two minor CSS fixes for sidebar nav

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -10,6 +10,9 @@
   h5,
   h6 {
     margin-top: 10px;
+    a {
+        color: $body-link-color;
+    }
   }
 
   %sidebar-link {

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -76,9 +76,9 @@
       }
 
       &.has-subnav {
+        cursor: pointer;
         &:before {
           content: '\276F';
-          cursor: pointer;
           transition: transform .1s linear;
         }
         &.active:before {


### PR DESCRIPTION
- Make the header links purple, not bootstrap-blue. 
- Make the cursor look clicky on Safari.

![Screen Shot 2019-04-22 at 10 49 12 AM](https://user-images.githubusercontent.com/484309/56515296-6d47eb00-64ec-11e9-99d6-b3b0e9535d03.png)

vs. this: 

![Screen Shot 2019-04-10 at 1 30 57 PM](https://user-images.githubusercontent.com/484309/56515340-89e42300-64ec-11e9-9672-6e052eb01542.png)
