### PR TITLE
api: 404 on OAuth clients index endpoint only on org not found

### DIFF
--- a/content/source/docs/enterprise/api/oauth-clients.html.md
+++ b/content/source/docs/enterprise/api/oauth-clients.html.md
@@ -40,7 +40,7 @@ This endpoint allows you to list VCS connections between an organization and a V
 Status  | Response                                     | Reason
 --------|----------------------------------------------|----------
 [200][] | [JSON API document][] (`type: "oauth-clients"`) | Success
-[404][] | [JSON API error object][]                    | Organization not found, or user unauthorized to perform action
+[404][] | [JSON API error object][]                    | Organization not found
 
 ### Sample Request
 


### PR DESCRIPTION
This error code is erroneous as the API does not respond to index
requests this way.

Index requests are scoped to the parent object of the association in
question. Any resources that the user/token does not have access to
are skipped. If the user does not have access to any of the resources
in the association, an empty list will be returned, not an error.

However, the 404 is still returned in the event that the organization
is not found.
