### PR TITLE
CSS: Fix alignment of nav sidebar chevrons/bullets on Safari

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -1,7 +1,17 @@
 #docs-sidebar {
   margin-bottom: 30px;
   margin-top: 20px;
-  overflow: hidden;
+
+  // Re-using the .nav class name on lists means we inherit some
+  // unfortunate behavior from Bootstrap, so reset all that.
+  ul, li, a {
+    float: none;
+    position: static;
+    padding: 0;
+  }
+  ul { display: block; }
+  li { display: list-item; }
+  a { display: inline; }
 
   h1,
   h2,
@@ -19,8 +29,6 @@
     color: $sidebar-link-color;
     font-size: $sidebar-font-size;
     overflow-wrap: break-word;
-    margin: 0 0 0 15px;
-    padding: 0 0 11px 0;
 
     &:focus,
     &:hover {
@@ -61,18 +69,21 @@
     padding-top: 10px;
 
     li {
+      padding: 0 0 11px 0;
+
       a {
         @extend %sidebar-link;
+        padding-left: 6px;
+        display: table-cell;
       }
 
       &:before {
         color: $sidebar-link-color-active;
         content: '\2022';
         font-size: 1em;
-        left: -3px;
-        top: -3px;
         opacity: 0.4;
-        position: absolute;
+        position: relative;
+        display: table-cell;
       }
 
       &.has-subnav {
@@ -83,8 +94,7 @@
         }
         &.active:before {
           transform: rotate(90deg);
-          left: -1px;
-          top: -1px;
+          top: 2px;
         }
       }
 
@@ -108,7 +118,8 @@
       display: none;
     }
     ul.nav {
-      padding: 10px;
+      padding-top: 10px;
+      padding-left: 10px;
 
       li {
         margin-left: 10px;


### PR DESCRIPTION
Some wacky inherited behavior was making it really difficult to get these
bullets aligned right cross-browser, ensuring that they'd look wack on either
Safari or Firefox. I think I've found the weirdnesses we need to reset, so we
should be good now.

**Safari:** 

![Screen Shot 2019-04-30 at 4 55 39 PM](https://user-images.githubusercontent.com/484309/57000616-5860fc80-6b69-11e9-88de-e7b563081275.png)

**Firefox:**

![Screen Shot 2019-04-30 at 4 56 06 PM](https://user-images.githubusercontent.com/484309/57000621-6020a100-6b69-11e9-8789-43f87b9f93e1.png)