### PR TITLE
Remove link to OAuth clients API

### DIFF
--- a/content/source/docs/enterprise/vcs/bitbucket-cloud.html.md
+++ b/content/source/docs/enterprise/vcs/bitbucket-cloud.html.md
@@ -20,8 +20,6 @@ Approve access request. | &nbsp;
 
 The rest of this page explains the Bitbucket Cloud-specific versions of these steps.
 
--> **Note:** Alternately, you can skip the OAuth configuration process and authenticate with an app password. This requires using TFE's API. For details, see [the OAuth Clients API page](../api/oauth-clients.html).
-
 ## Step 1: On Bitbucket Cloud, Create a New OAuth Consumer
 
 1. Open [Bitbucket Cloud](https://bitbucket.org) in your browser and log in as whichever account you want TFE to act as. For most organizations this should be a dedicated service user, but a personal account will also work.

--- a/content/source/docs/enterprise/vcs/bitbucket-server.html.md
+++ b/content/source/docs/enterprise/vcs/bitbucket-server.html.md
@@ -15,8 +15,6 @@ Note that Bitbucket Server requires both OAuth authentication and an SSH key. Th
 
 ~> **Important:** TFE needs to contact your Bitbucket Server instance during setup and during normal operation. For the SaaS version of TFE, this means Bitbucket Server must be internet-accessible; for private installs of TFE, you must have network connectivity between your TFE and Bitbucket Server instances over HTTP or HTTPS and SSH. Bitbucket Server repository clone operations are performed over SSH on the port the Bitbucket Server instance uses.
 
--> **Note:** Alternately, you can skip the OAuth configuration process and authenticate with a personal access token. This requires using TFE's API. For details, see [the OAuth Clients API page](../api/oauth-clients.html).
-
 ## Step 1: On Bitbucket Server, Ensure the Webhooks Plugin is Installed
 
 TFE uses webhooks to get new configurations. To support this, Bitbucket Server needs Atlassian's webhooks plugin.


### PR DESCRIPTION
Bitbucket doesn't support the API method of connection, so let's not link to it from this page.