### PR TITLE
API stability policy

### DIFF
--- a/content/source/docs/enterprise/api/account.md
+++ b/content/source/docs/enterprise/api/account.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-account"
 
 # Account API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 Account represents the current user interacting with Terraform. It returns the same type of object as the [Users](./users.html) API, but also includes an email address, which is hidden when viewing info about other users.
 
 ## Get your account details

--- a/content/source/docs/enterprise/api/admin/index.html.md
+++ b/content/source/docs/enterprise/api/admin/index.html.md
@@ -6,8 +6,6 @@ sidebar_current: "docs-enterprise2-api-admin"
 
 # Private Terraform Enterprise Admin API Documentation
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.
 
 Private Terraform Enterprise provides an API to allow administrators to configure and support their installation.

--- a/content/source/docs/enterprise/api/admin/organizations.html.md
+++ b/content/source/docs/enterprise/api/admin/organizations.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-admin-organizations"
 
 # Admin Organizations API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.
 
 The Organizations Admin API contains endpoints to help site administrators manage organizations.

--- a/content/source/docs/enterprise/api/admin/runs.html.md
+++ b/content/source/docs/enterprise/api/admin/runs.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-admin-runs"
 
 # Admin Runs API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.
 
 The Runs Admin API contains endpoints to help site administrators manage runs.

--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-admin-settings"
 
 # Private Terraform Enterprise Settings API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> **Note**: These endpoints are only available in Private Terraform instances and only accessible by site administrators.
 
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.

--- a/content/source/docs/enterprise/api/admin/terraform-versions.html.md
+++ b/content/source/docs/enterprise/api/admin/terraform-versions.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-admin-terraform-versions"
 
 # Admin Terraform Versions API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.
 
 The Terraform Versions Admin API contains endpoints to help site administrators manage known versions of Terraform.

--- a/content/source/docs/enterprise/api/admin/users.html.md
+++ b/content/source/docs/enterprise/api/admin/users.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-admin-users"
 
 # Admin Users API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.
 
 The Users Admin API contains endpoints to help site administrators manage user accounts.

--- a/content/source/docs/enterprise/api/admin/workspaces.html.md
+++ b/content/source/docs/enterprise/api/admin/workspaces.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-admin-workspaces"
 
 # Admin Workspaces API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> These API endpoints are available in Private Terraform Enterprise as of version 201807-1.
 
 The Workspaces Admin API contains endpoints to help site administrators manage workspaces.

--- a/content/source/docs/enterprise/api/applies.md
+++ b/content/source/docs/enterprise/api/applies.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-applies"
 
 # Applies API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 An apply represents the results of applying a Terraform Run's execution plan.
 
 ## Show an apply

--- a/content/source/docs/enterprise/api/configuration-versions.html.md
+++ b/content/source/docs/enterprise/api/configuration-versions.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-configuration-versions"
 
 # Configuration Versions API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> **Note:** Before working with the runs or configuration versions APIs, read the [API-driven run workflow](../run/api.html) page, which includes both a full overview of this workflow and a walkthrough of a simple implementation of it.
 
 A configuration version (`configuration-version`) is a resource used to reference the uploaded configuration files. It is associated with the run to use the uploaded configuration files for performing the plan and apply.

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -29,7 +29,7 @@ See the navigation sidebar for the list of available endpoints.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](/docs/providers/tfe/index.html) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 
-HashiCorp provides a [stability promise](./stability-promise.html) for the Terraform Enterprise API, ensuring backwards compatibility for stable endpoints.
+HashiCorp provides a [stability policy](./stability-policy.html) for the Terraform Enterprise API, ensuring backwards compatibility for stable endpoints.
 
 ## Authentication
 

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -42,6 +42,10 @@ The following changes are considered to be backwards compatible:
 
 Any endpoints that are not generally available (i.e., endpoints that are in beta), incorrect, or suspectible to security vulnerabilities are subject to change without notice.
 
+## Deprecation policy
+
+The deprecation policy provides users the opportunity to continue to consume API endpoints for a period of time after they have been superseded. Deprecation notices for endpoints should be readily available through various channels of communication, including documentation and HTTP responses. An endpoint should be available for at least three (3) months from the date on which it has been declared deprecated.
+
 ## Authentication
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, TFE responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -31,7 +31,7 @@ See the navigation sidebar for the list of available endpoints.
 
 ## Stability promise
 
-The TFE API is considered generally available. It promises that all generally available endpoints will be maintained in a backwards compatible manner. If a change is considered to be backwards incompatible, then a new endpoint will be created, while the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
+The TFE API will continue to evolve, but we consider it stable for general use, and HashiCorp will maintain all stable API endpoints in a backwards compatible manner. (Stable endpoints are any endpoints _not_ marked as beta.) If we need to make a change that we consider backwards incompatible, then we will create a new endpoint that serves the same purpose; the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
 
 The following changes are considered to be backwards compatible:
 

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -29,22 +29,7 @@ See the navigation sidebar for the list of available endpoints.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](/docs/providers/tfe/index.html) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 
-## Stability promise
-
-The TFE API will continue to evolve, but we consider it stable for general use, and HashiCorp will maintain all stable API endpoints in a backwards compatible manner. (Stable endpoints are any endpoints _not_ marked as beta.) If we need to make a change that we consider backwards incompatible, then we will create a new endpoint that serves the same purpose; the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
-
-The following changes are considered to be backwards compatible:
-
-* Adding new API endpoints.
-* Adding new attributes, links, or relationships to existing API responses.
-* Adding new optional query paramters to existing API requests.
-* ...
-
-Any endpoints that are not generally available (i.e., endpoints that are in beta), incorrect, or suspectible to security vulnerabilities are subject to change without notice.
-
-## Deprecation policy
-
-The deprecation policy provides users the opportunity to continue to consume API endpoints for a period of time after they have been superseded. Deprecation notices for endpoints should be readily available through various channels of communication, including documentation and HTTP responses. An endpoint should be available for at least three (3) months from the date on which it has been declared deprecated.
+HashiCorp provides a [stability promise](./stability-promise.html) for the Terraform Enterprise API, ensuring backwards compatibility for stable endpoints.
 
 ## Authentication
 

--- a/content/source/docs/enterprise/api/index.html.md
+++ b/content/source/docs/enterprise/api/index.html.md
@@ -23,18 +23,28 @@ sidebar_current: "docs-enterprise2-api"
 
 # Terraform Enterprise API Documentation
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 Terraform Enterprise (TFE) provides an API for a subset of its features. If you have any questions or want to request new API features, please email support@hashicorp.com.
 
 See the navigation sidebar for the list of available endpoints.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](/docs/providers/tfe/index.html) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 
+## Stability promise
+
+The TFE API is considered generally available. It promises that all generally available endpoints will be maintained in a backwards compatible manner. If a change is considered to be backwards incompatible, then a new endpoint will be created, while the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
+
+The following changes are considered to be backwards compatible:
+
+* Adding new API endpoints.
+* Adding new attributes, links, or relationships to existing API responses.
+* Adding new optional query paramters to existing API requests.
+* ...
+
+Any endpoints that are not generally available (i.e., endpoints that are in beta), incorrect, or suspectible to security vulnerabilities are subject to change without notice.
+
 ## Authentication
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, TFE responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.
-
 
 There are three kinds of token available:
 

--- a/content/source/docs/enterprise/api/notification-configurations.html.md
+++ b/content/source/docs/enterprise/api/notification-configurations.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-notification-configurations"
 
 # Notification Configurations API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 Terraform Enterprise can be configured to send notifications for run state transitions. The configuration allows you to specify a destination URL, request type, and what events will trigger the notification. Each workspace can have up to 20 notification configurations, and they apply to all runs for that workspace.
 
 ## Notification Triggers

--- a/content/source/docs/enterprise/api/oauth-clients.html.md
+++ b/content/source/docs/enterprise/api/oauth-clients.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-oauth-clients"
 
 # OAuth Clients API
 
--> **Note:** These API endpoints are in beta and are subject to change.
-
 An OAuth Client represents the connection between an organization and a VCS provider.
 
 ## List OAuth Clients

--- a/content/source/docs/enterprise/api/oauth-tokens.html.md
+++ b/content/source/docs/enterprise/api/oauth-tokens.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-oauth-tokens"
 
 # OAuth Tokens
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 The `oauth-token` object represents a VCS configuration which includes the OAuth connection and the associated OAuth token. This object is used when creating a workspace to identify which VCS connection to use.
 
 ## List OAuth Tokens

--- a/content/source/docs/enterprise/api/organization-tokens.html.md
+++ b/content/source/docs/enterprise/api/organization-tokens.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-organization-tokens"
 
 # Organization Token API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 ## Generate a new organization token
 
 `POST /organizations/:organization_name/authentication-token`

--- a/content/source/docs/enterprise/api/organizations.html.md
+++ b/content/source/docs/enterprise/api/organizations.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-organizations"
 
 # Organizations API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 The Organizations API is used to list, show, create, update, and destroy organizations.
 
 ## List Organizations

--- a/content/source/docs/enterprise/api/plan-exports.html.md
+++ b/content/source/docs/enterprise/api/plan-exports.html.md
@@ -6,8 +6,6 @@ sidebar_current: "docs-enterprise2-api-plan-exports"
 
 # Plans API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 Plan exports allow users to download data exported from the plan of a Run in a Terraform workspace. Currently, the only supported format for exporting plan data is to generate mock data for Sentinel.
 
 ## Create a plan export

--- a/content/source/docs/enterprise/api/plans.html.md
+++ b/content/source/docs/enterprise/api/plans.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-plans"
 
 # Plans API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 A plan represents the execution plan of a Run in a Terraform workspace.
 
 ## Show a plan

--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-policies"
 
 # Policies API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 [Sentinel Policy as Code](../sentinel/index.html) is an embedded policy as code framework integrated with Terraform Enterprise.
 
 Policies are configured on a per-organization level and are organized and grouped into [policy sets](../sentinel/manage-policies.html#organizing-policies-with-policy-sets), which define the workspaces on which policies are enforced during runs. In these workspaces, the plan's changes are validated against the relevant policies after the plan step. (For details, see [Run States and Stages](../run/states.html).)

--- a/content/source/docs/enterprise/api/policy-checks.html.md
+++ b/content/source/docs/enterprise/api/policy-checks.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-policy-checks"
 
 # Policy Checks API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 ## List policy checks
 
 This endpoint lists the policy checks in a run.

--- a/content/source/docs/enterprise/api/policy-sets.html.md
+++ b/content/source/docs/enterprise/api/policy-sets.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-policy-sets"
 
 # Policy Sets API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 [Sentinel Policy as Code](../sentinel/index.html) is an embedded policy as code framework integrated with Terraform Enterprise.
 
 Policy sets are groups of policies that are applied together to related workspaces. By using policy sets, you can group your policies by attributes such as environment or region. Individual policies that are members of policy sets will only be checked for workspaces that the policy set is attached to. In order for a policy to be active and checked during runs, it must be a member of at least one policy set that is attached to workspaces.

--- a/content/source/docs/enterprise/api/run.html.md
+++ b/content/source/docs/enterprise/api/run.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-run"
 
 # Runs API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 -> **Note:** Before working with the runs or configuration versions APIs, read the [API-driven run workflow](../run/api.html) page, which includes both a full overview of this workflow and a walkthrough of a simple implementation of it.
 
 Performing a run on a new configuration is a multi-step process.

--- a/content/source/docs/enterprise/api/ssh-keys.html.md
+++ b/content/source/docs/enterprise/api/ssh-keys.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-ssh-keys"
 
 # SSH Keys
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 The `ssh-key` object represents an SSH key which includes a name and the SSH private key. An organization can have multiple SSH keys available.
 
 SSH keys can be used in two places:

--- a/content/source/docs/enterprise/api/stability-policy.html.md
+++ b/content/source/docs/enterprise/api/stability-policy.html.md
@@ -3,7 +3,7 @@ page_title: "API Docs - Terraform Enterprise"
 layout: "enterprise2"
 ---
 
-# Stability promise
+# Stability policy
 
 The Terraform Enterprise API will continue to evolve, but we consider it stable for general use, and HashiCorp will maintain all stable API endpoints in a backwards compatible manner. (Stable endpoints are any endpoints _not_ marked as beta.) If we need to make a change that we consider backwards incompatible, then we will create a new endpoint that serves the same purpose; the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
 
@@ -13,7 +13,7 @@ The following changes are considered to be backwards compatible:
 * Adding new attributes, links, or relationships to existing API requests and responses.
 * Adding new optional query paramters to existing API requests.
 
-Security vulnerabilities are an exception to this stability promise; we will make backwards incompatible changes to stable endpoints if it is necessary to protect our security or the security of our users.
+Security vulnerabilities are an exception to this stability policy; we will make backwards incompatible changes to stable endpoints if it is necessary to protect our security or the security of our users.
 
 Endpoints that are in beta are subject to change without notice.
 

--- a/content/source/docs/enterprise/api/stability-policy.html.md
+++ b/content/source/docs/enterprise/api/stability-policy.html.md
@@ -1,9 +1,9 @@
 ---
-page_title: "API Docs - Terraform Enterprise"
+page_title: "API Docs - Terraform Enterprise - API Stability Policy"
 layout: "enterprise2"
 ---
 
-# Stability policy
+# API Stability Policy
 
 The Terraform Enterprise API will continue to evolve, but we consider it stable for general use, and HashiCorp will maintain all stable API endpoints in a backwards compatible manner. (Stable endpoints are any endpoints _not_ marked as beta.) If we need to make a change that we consider backwards incompatible, then we will create a new endpoint that serves the same purpose; the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
 
@@ -17,6 +17,6 @@ Security vulnerabilities are an exception to this stability policy; we will make
 
 Endpoints that are in beta are subject to change without notice.
 
-## Deprecation policy
+## Deprecation Policy
 
 The deprecation policy provides users the opportunity to continue to consume API endpoints for a period of time after they have been superseded. Deprecation notices for endpoints should be readily available through various channels of communication, including documentation and HTTP responses. An endpoint should be available for at least three (3) months from the date on which it has been declared deprecated. (This time is cited as a minimum; endpoint availability may be longer based on contracted agreements.)

--- a/content/source/docs/enterprise/api/stability-promise.html.md
+++ b/content/source/docs/enterprise/api/stability-promise.html.md
@@ -1,0 +1,21 @@
+---
+page_title: "API Docs - Terraform Enterprise"
+layout: "enterprise2"
+sidebar_current: "docs-enterprise2-api"
+---
+
+# Stability promise
+
+The Terraform Enterprise API will continue to evolve, but we consider it stable for general use, and HashiCorp will maintain all stable API endpoints in a backwards compatible manner. (Stable endpoints are any endpoints _not_ marked as beta.) If we need to make a change that we consider backwards incompatible, then we will create a new endpoint that serves the same purpose; the old endpoint will be maintained until declared [deprecated](#deprecation-policy).
+
+The following changes are considered to be backwards compatible:
+
+* Adding new API endpoints.
+* Adding new attributes, links, or relationships to existing API requests and responses.
+* Adding new optional query paramters to existing API requests.
+
+Any endpoints that are not stable (i.e., endpoints that are in beta), incorrect, or suspectible to security vulnerabilities are subject to change without notice.
+
+## Deprecation policy
+
+The deprecation policy provides users the opportunity to continue to consume API endpoints for a period of time after they have been superseded. Deprecation notices for endpoints should be readily available through various channels of communication, including documentation and HTTP responses. An endpoint should be available for at least three (3) months from the date on which it has been declared deprecated.

--- a/content/source/docs/enterprise/api/stability-promise.html.md
+++ b/content/source/docs/enterprise/api/stability-promise.html.md
@@ -14,7 +14,7 @@ The following changes are considered to be backwards compatible:
 * Adding new attributes, links, or relationships to existing API requests and responses.
 * Adding new optional query paramters to existing API requests.
 
-Any endpoints that are not stable (i.e., endpoints that are in beta), incorrect, or suspectible to security vulnerabilities are subject to change without notice.
+Any endpoints that are not stable (i.e., endpoints that are in beta) or suspectible to security vulnerabilities are subject to change without notice.
 
 ## Deprecation policy
 

--- a/content/source/docs/enterprise/api/stability-promise.html.md
+++ b/content/source/docs/enterprise/api/stability-promise.html.md
@@ -1,7 +1,6 @@
 ---
 page_title: "API Docs - Terraform Enterprise"
 layout: "enterprise2"
-sidebar_current: "docs-enterprise2-api"
 ---
 
 # Stability promise

--- a/content/source/docs/enterprise/api/stability-promise.html.md
+++ b/content/source/docs/enterprise/api/stability-promise.html.md
@@ -13,7 +13,9 @@ The following changes are considered to be backwards compatible:
 * Adding new attributes, links, or relationships to existing API requests and responses.
 * Adding new optional query paramters to existing API requests.
 
-Any endpoints that are not stable (i.e., endpoints that are in beta) or suspectible to security vulnerabilities are subject to change without notice.
+Security vulnerabilities are an exception to this stability promise; we will make backwards incompatible changes to stable endpoints if it is necessary to protect our security or the security of our users.
+
+Endpoints that are in beta are subject to change without notice.
 
 ## Deprecation policy
 

--- a/content/source/docs/enterprise/api/stability-promise.html.md
+++ b/content/source/docs/enterprise/api/stability-promise.html.md
@@ -19,4 +19,4 @@ Endpoints that are in beta are subject to change without notice.
 
 ## Deprecation policy
 
-The deprecation policy provides users the opportunity to continue to consume API endpoints for a period of time after they have been superseded. Deprecation notices for endpoints should be readily available through various channels of communication, including documentation and HTTP responses. An endpoint should be available for at least three (3) months from the date on which it has been declared deprecated.
+The deprecation policy provides users the opportunity to continue to consume API endpoints for a period of time after they have been superseded. Deprecation notices for endpoints should be readily available through various channels of communication, including documentation and HTTP responses. An endpoint should be available for at least three (3) months from the date on which it has been declared deprecated. (This time is cited as a minimum; endpoint availability may be longer based on contracted agreements.)

--- a/content/source/docs/enterprise/api/state-versions.html.md
+++ b/content/source/docs/enterprise/api/state-versions.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-state-versions"
 
 # State Versions API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 ## Create a State Version
 
 `POST /workspaces/:workspace_id/state-versions`

--- a/content/source/docs/enterprise/api/team-access.html.md
+++ b/content/source/docs/enterprise/api/team-access.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-team-access"
 
 # Team access API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 The team access APIs are used to associate a team to permissions on a workspace. A single `team-workspace` resource contains the relationship between the Team and Workspace, including the privileges the team has on the workspace.
 
 -> **Note**: A `team-workspace` resource represents a team's _local_ permissions on a specific workspace. Teams can also have _organization-level_ permissions that grant access to workspaces, and TFE uses whichever access level is higher. (For example: a team with the "manage workspaces" permission has admin access on all workspaces, even if their `team-workspace` on a particular workspace only grants read access.) For more information, see [Managing Workspace Access](../users-teams-organizations/teams.html#managing-workspace-access).

--- a/content/source/docs/enterprise/api/team-members.html.md
+++ b/content/source/docs/enterprise/api/team-members.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-team-members"
 
 # Team Membership API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 The Team Membership API is used to add or remove users from teams. The [Team API](./teams.html) is used to create or destroy teams.
 
 ## Add a User to Team

--- a/content/source/docs/enterprise/api/team-tokens.html.md
+++ b/content/source/docs/enterprise/api/team-tokens.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-team-tokens"
 
 # Team Token API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 ## Generate a new team token
 
 Generates a new team token and overrides existing token if one exists.

--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-teams"
 
 # Teams API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 The Teams API is used to create, edit, and destroy teams as well as manage a team's organization-level permissions. The [Team Membership API](./team-members.html) is used to add or remove users from a team. Use the [Team Access API](./team-access.html) to associate a team with privileges on an individual workspace.
 
 ## List teams

--- a/content/source/docs/enterprise/api/user-tokens.md
+++ b/content/source/docs/enterprise/api/user-tokens.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-user-tokens"
 
 # User Tokens API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 ## List User Tokens
 
 `GET /api/v2/users/:user_id/authentication-tokens`

--- a/content/source/docs/enterprise/api/users.md
+++ b/content/source/docs/enterprise/api/users.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-users"
 
 # Users API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 Terraform Enterprise (TFE)'s user objects do not contain any identifying information about a user, other than their TFE username and avatar image; they are intended for displaying names and avatars in contexts that refer to a user by ID, like lists of team members or the details of a run. Most of these contexts can already include user objects via an `?include` parameter, so you shouldn't usually need to make a separate call to this endpoint.
 
 ## Show a User

--- a/content/source/docs/enterprise/api/variables.html.md
+++ b/content/source/docs/enterprise/api/variables.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-variables"
 
 # Variables API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 This set of APIs covers create, update, list and delete operations on variables.
 
 

--- a/content/source/docs/enterprise/api/workspaces.html.md
+++ b/content/source/docs/enterprise/api/workspaces.html.md
@@ -23,8 +23,6 @@ sidebar_current: "docs-enterprise2-api-workspaces"
 
 # Workspaces API
 
--> **Note**: These API endpoints are in beta and are subject to change.
-
 Workspaces represent running infrastructure managed by Terraform.
 
 ## Create a Workspace

--- a/content/source/layouts/enterprise2.erb
+++ b/content/source/layouts/enterprise2.erb
@@ -300,6 +300,9 @@
               </li>
             </ul>
           </li>
+          <li>
+            <a href="/docs/enterprise/api/stability-policy.html">API Stability Policy</a>
+          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
CHANGELOG: Introduce a public API stability policy for the Terraform Enterprise API

This change removes the beta note from most endpoints in the Terraform Enterprise API and documents a stability policy that guarantees HashiCorp's commitment to the API and what future changes may hold.