### PR TITLE
Fix incorrect HTTP method in API docs

### DIFF
--- a/content/source/docs/enterprise/api/admin/settings.html.md
+++ b/content/source/docs/enterprise/api/admin/settings.html.md
@@ -263,7 +263,7 @@ curl \
 
 ## Revoke previous SAML IdP Certificate
 
-`PUT /api/v2/admin/saml-settings/actions/revoke-old-certificate`
+`POST /api/v2/admin/saml-settings/actions/revoke-old-certificate`
 
 When reconfiguring the IdP certificate, TFE will retain the old IdP certificate to allow for a rotation period. This PUT endpoint will revoke the older IdP certificate when the new IdP certificate is known to be functioning correctly.
 
@@ -275,7 +275,7 @@ See [SAML Configuration](../../saml/configuration.html) for more details.
 curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
-  --request PUT \
+  --request POST \
   https://app.terraform.io/api/v2/admin/saml-settings/actions/revoke-old-certificate
 ```
 


### PR DESCRIPTION
The `revoke-old-certificate` API endpoint for enterprise SAML settings is unfortunately documented wrong… That endpoint responds to `POST`, not `PUT`