### PR TITLE
Doc sentinel module iteration

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -297,7 +297,8 @@ resouce_maps = find_resources_from_config("azurerm_lb")
 ```
 You would then iterate over the `resource_maps` variable to get the maps of the
 specified resource in each module and iterate over the resources in those maps to
-access their attributes.
+access their attributes. Remember that this function will only locate modules (and
+hence resources) in the current configuration.
 
 You could define a similar `find_data_sources_from_config` function to find all data
 sources of a particular type from all modules by simply changing `resources[type]`

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -290,54 +290,10 @@ are maps of all resources of the specified type within the modules. Note the use
 is necessary to avoid the function returning `undefined`.
 
 To invoke this function for a specific resource type, pass it the resource type as a
-string. For example, to get all instances of the `azurerm_lb` resource, you could
-use this:
-```python
-resouce_maps = find_resources_from_config("azurerm_lb")
-```
-You would then iterate over the `resource_maps` variable to get the maps of the
-specified resource in each module and iterate over the resources in those maps to
+string. You would then iterate over the map returned by the function to get the maps
+of the specified resource in each module and iterate over the resources in those maps to
 access their attributes. Remember that this function will only locate modules (and
 hence resources) in the current configuration.
-
-You could define a similar `find_data_sources_from_config` function to find all data
-sources of a particular type from all modules by simply changing `resources[type]`
-to `data[type]` and `resource_maps` to `data_source_maps`.
-
-If you want to determine the [address][resource-addressing] of a resource or data source returned by
-functions like `find_resources_from_confign` using the form `module.A.module.B.<type>.<name>`
-that is used in plan and apply logs, you can use a function like this one:
-
-[resource-addressing]: /docs/internals/resource-addressing.html
-
-```python
-get_address = func(module_path, type, name) {
-  if length(module_path) == 0 {
-    # root module
-    address = type + "." + name
-  } else {
-    # non-root module
-    address = "module." + strings.join(module_path, ".module.") + "." + type + "." + name
-  }
-  return address
-}
-```
-
-This function takes the module path in the list of lists form described above along
-with the type and name of the resource as arguments. To print the complete address of
-a resource in the configuration, you could use the following Sentinel
-code in which `module_path`, `resource_type`, and `name` are pre-existing
-variables in your Sentinel policy that refer to a specific resource
-in a specific module discovered by the above function:
-
-```python
-resource_address = get_address(module_path, resource_type, name)
-print(resource_address, "violated the policy")
-```
-
-This would print out `azurerm_lb.test violated the policy` for an `azurerm_lb` resource named
-`test` in the root module and `module.loadbalancer.azurerm_lb.web violated the policy` for
-an `azurerm_lb` resource named `web` in the `loadbalancer` module.
 
 ## Namespace: Module
 

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -132,8 +132,8 @@ import "tfconfig"
 filename_value = tfconfig.resources.local_file.accounts.config.filename
 
 main = rule {
-	filename_value contains "${var.domain}" and
-	filename_value contains "${var.subdomain}"
+  filename_value contains "${var.domain}" and
+  filename_value contains "${var.subdomain}"
 }
 ```
 
@@ -254,8 +254,8 @@ The value of `module_paths` would be:
 
 ```
 [
-	[],
-	["foo"],
+  [],
+  ["foo"],
 ]
 ```
 
@@ -387,8 +387,8 @@ in your configuration. Consider the following resource block:
 
 ```hcl
 resource "local_file" "foo" {
-    content     = "foo!"
-    filename = "${path.module}/foo.bar"
+  content     = "foo!"
+  filename = "${path.module}/foo.bar"
 }
 ```
 
@@ -436,7 +436,7 @@ file name is used. Given the above example, the following policy would evaluate 
 import "tfconfig"
 
 main = rule {
-	tfconfig.resources.local_file.accounts.config.filename is "accounts.txt"
+  tfconfig.resources.local_file.accounts.config.filename is "accounts.txt"
 }
 ```
 
@@ -507,7 +507,7 @@ The following policy would evaluate to `true`:
 import "tfconfig"
 
 main = rule {
-	tfconfig.resources.null_resource.foo.provisioners[0].config.command is "echo ${self.private_ip} > file.txt"
+  tfconfig.resources.null_resource.foo.provisioners[0].config.command is "echo ${self.private_ip} > file.txt"
 }
 ```
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -217,8 +217,8 @@ resouce_maps = find_resources_from_plan("aws_instance")
 ```
 You would then iterate over the `resource_maps` variable to get the maps of the
 specified resource in each module and iterate over the resources in those maps to
-access their attributes. Remember again that this function will only locate modules
-(and hence resources) that have pending changes.
+access their attributes. Remember that this function will only locate modules
+(and hence resources) that have pending changes in the plan.
 
 You could define a similar `find_data_sources_from_plan` function to find all data
 sources of a particular type from all modules by simply changing `resources[type]`

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -224,7 +224,7 @@ You could define a similar `find_data_sources_from_plan` function to find all da
 sources of a particular type from all modules by simply changing `resources[type]`
 to `data[type]` and `resource_maps` to `data_source_maps`.
 
-If you want to print out the [address](../../../internals/resource-addressing.html)
+If you want to print out the [address](/docs/internals/resource-addressing.html)
 of a resource or data source returned by functions like `find_resources_from_plan`
 using the form `module.A.module.B.<type>.<name>` that is used in plan and apply logs,
 you can use a function like this one: 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -173,8 +173,8 @@ The value of `module_paths` would be:
 
 ```
 [
-	[],
-	["foo"],
+  [],
+  ["foo"],
 ]
 ```
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -191,28 +191,73 @@ main = rule { tfplan.module_paths contains ["foo"] }
 #### Iterating through modules
 
 Iterating through all modules to find particular resources can be useful. This
-example shows how to use `module_paths` with the [`module()`
-function](#function-module-) to retrieve all resources of a particular type from
-all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
-resource). Note the use of `else []` in case some modules don't have any
-resources; this is necessary to avoid the function returning undefined.
-
-[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
-
-Remember again that this will only locate modules (and hence resources) that
-have pending changes.
+example function shows how to use `module_paths` with the [`module()`
+function](#function-module-) to retrieve all resources of a particular type
+from all modules that have pending changes.
 
 ```python
-import "tfplan"
-
-get_vms = func() {
-	vms = []
-	for tfplan.module_paths as path {
-		vms += values(tfplan.module(path).resources.azurerm_virtual_machine) else []
-	}
-	return vms
+find_resources_from_plan = func(type) {
+  resource_maps = {}
+  for tfplan.module_paths as path {
+    resource_maps[path] = tfplan.module(path).resources[type] else {}
+  }
+  return resource_maps
 }
 ```
+
+This function creates a map for which the keys are the module paths and the values
+are maps of all resources of the specified type within the modules. Note the use of
+`else {}` in case some modules don't have any resources of the specified type; this
+is necessary to avoid the function returning undefined.
+
+To invoke this function for a specific resource type, pass it the resource type as a
+string. For example, to get all instances of the `aws_instance` resource, you could
+use this:
+```python
+resouce_maps = find_resources_from_plan("aws_instance")
+```
+You would then iterate over the `resource_maps` variable to get the maps of the
+specified resource in each module and iterate over the resources in those maps to
+access their attributes. Remember again that this function will only locate modules
+(and hence resources) that have pending changes.
+
+You could define a similar `find_data_sources_from_plan` function to find all data
+sources of a particular type from all modules by simply changing `resources[type]`
+to `data[type]` and `resource_maps` to `data_source_maps`.
+
+If you want to print out the [address](../../../internals/resource-addressing.html)
+of a resource or data source returned by functions like `find_resources_from_plan`
+using the form `module.A.module.B.<type>.<name>` that is used in plan and apply logs,
+you can use a function like this one: 
+
+```python
+get_address = func(module_path, type, name) {
+  if length(module_path) == 0 {
+    # root module
+    address = type + "." + name
+  } else {
+    # non-root module
+    address = "module." + strings.join(module_path, ".module.") + "." + type + "." + name
+  }
+  return address
+}
+```
+
+This function takes the module path in the list of lists form described above along
+with the type and name of the resource as arguments. To get the complete address of
+an instance of a resource having multiple instances, you could use the following Sentinel
+code in which `module_path`, `resource_type`, `name`, and `index` are pre-existing
+variables in your Sentinel policy that refer to a specific instance of a specific resource
+in a specific module discovered by the above function:
+
+```python
+resource_address = get_address(module_path, resource_type, name)
+instance_address = resource_address + "[" + string(index) + "]"
+```
+
+This would print out something like `aws_instance.test[1]` for an `aws_instance` resource
+in the root module and something like `module.compute.aws_instance.web[2]` for an
+`aws_instance` resource in the compute module.
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -224,10 +224,11 @@ You could define a similar `find_data_sources_from_plan` function to find all da
 sources of a particular type from all modules by simply changing `resources[type]`
 to `data[type]` and `resource_maps` to `data_source_maps`.
 
-If you want to print out the [address](/docs/internals/resource-addressing.html)
-of a resource or data source returned by functions like `find_resources_from_plan`
-using the form `module.A.module.B.<type>.<name>` that is used in plan and apply logs,
-you can use a function like this one: 
+If you want to print out the [address][resource-addressing] of a resource or data source returned by
+functions like `find_resources_from_plan` using the form `module.A.module.B.<type>.<name>`
+that is used in plan and apply logs, you can use a function like this one:
+
+[resource-addressing]: /docs/internals/resource-addressing.html
 
 ```python
 get_address = func(module_path, type, name) {

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -210,56 +210,10 @@ are maps of all resources of the specified type within the modules. Note the use
 is necessary to avoid the function returning `undefined`.
 
 To invoke this function for a specific resource type, pass it the resource type as a
-string. For example, to get all instances of the `aws_instance` resource, you could
-use this:
-```python
-resouce_maps = find_resources_from_plan("aws_instance")
-```
-You would then iterate over the `resource_maps` variable to get the maps of the
-specified resource in each module and iterate over the resources in those maps to
+string. You would then iterate over the map returned by the function to get the maps
+of the specified resource in each module and iterate over the resources in those maps to
 access their attributes. Remember that this function will only locate modules
 (and hence resources) that have pending changes in the plan.
-
-You could define a similar `find_data_sources_from_plan` function to find all data
-sources of a particular type from all modules by simply changing `resources[type]`
-to `data[type]` and `resource_maps` to `data_source_maps`.
-
-If you want to determine the [address][resource-addressing] of a resource or data source returned by
-functions like `find_resources_from_plan` using the form `module.A.module.B.<type>.<name>`
-that is used in plan and apply logs, you can use a function like this one:
-
-[resource-addressing]: /docs/internals/resource-addressing.html
-
-```python
-get_address = func(module_path, type, name) {
-  if length(module_path) == 0 {
-    # root module
-    address = type + "." + name
-  } else {
-    # non-root module
-    address = "module." + strings.join(module_path, ".module.") + "." + type + "." + name
-  }
-  return address
-}
-```
-
-This function takes the module path in the list of lists form described above along
-with the type and name of the resource as arguments. To print the complete address of
-an instance of a resource having multiple instances, you could use the following Sentinel
-code in which `module_path`, `resource_type`, `name`, and `index` are pre-existing
-variables in your Sentinel policy that refer to a specific instance of a specific resource
-in a specific module discovered by the above function:
-
-```python
-resource_address = get_address(module_path, resource_type, name)
-instance_address = resource_address + "[" + string(index) + "]"
-print(instance_address, "violated the policy")
-```
-
-This would print out `aws_instance.test[0] violated the policy` for the first
-instance of an `aws_instance` resource named `test` in the root module and 
-`module.compute.aws_instance.web[1] violated the policy` for the second instance
-of an `aws_instance` resource named `web` in the `compute` module.
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -190,8 +190,8 @@ main = rule { tfplan.module_paths contains ["foo"] }
 
 #### Iterating through modules
 
-Iterating through all modules to find particular resources can be useful. This
-example function shows how to use `module_paths` with the [`module()`
+Iterating through all modules to find particular resources can be useful. The
+following example function shows how to use `module_paths` with the [`module()`
 function](#function-module-) to retrieve all resources of a particular type
 from all modules that have pending changes.
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -191,9 +191,8 @@ main = rule { tfplan.module_paths contains ["foo"] }
 #### Iterating through modules
 
 Iterating through all modules to find particular resources can be useful. The
-following example function shows how to use `module_paths` with the [`module()`
-function](#function-module-) to retrieve all resources of a particular type
-from all modules that have pending changes.
+following example function shows how to use `module_paths` with the [`module()`](#function-module-)
+function to retrieve all resources of a particular type from all modules that have pending changes.
 
 ```python
 find_resources_from_plan = func(type) {

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -207,7 +207,7 @@ find_resources_from_plan = func(type) {
 This function creates a map for which the keys are the module paths and the values
 are maps of all resources of the specified type within the modules. Note the use of
 `else {}` in case some modules don't have any resources of the specified type; this
-is necessary to avoid the function returning undefined.
+is necessary to avoid the function returning `undefined`.
 
 To invoke this function for a specific resource type, pass it the resource type as a
 string. For example, to get all instances of the `aws_instance` resource, you could

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -257,7 +257,7 @@ print(instance_address, "violated the policy")
 ```
 
 This would print out `aws_instance.test[0] violated the policy` for the first
-instance of an `aws_instance` resource in the root module named `test` and 
+instance of an `aws_instance` resource named `test` in the root module and 
 `module.compute.aws_instance.web[1] violated the policy` for the second instance
 of an `aws_instance` resource named `web` in the `compute` module.
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -224,7 +224,7 @@ You could define a similar `find_data_sources_from_plan` function to find all da
 sources of a particular type from all modules by simply changing `resources[type]`
 to `data[type]` and `resource_maps` to `data_source_maps`.
 
-If you want to print out the [address][resource-addressing] of a resource or data source returned by
+If you want to determine the [address][resource-addressing] of a resource or data source returned by
 functions like `find_resources_from_plan` using the form `module.A.module.B.<type>.<name>`
 that is used in plan and apply logs, you can use a function like this one:
 
@@ -244,7 +244,7 @@ get_address = func(module_path, type, name) {
 ```
 
 This function takes the module path in the list of lists form described above along
-with the type and name of the resource as arguments. To get the complete address of
+with the type and name of the resource as arguments. To print the complete address of
 an instance of a resource having multiple instances, you could use the following Sentinel
 code in which `module_path`, `resource_type`, `name`, and `index` are pre-existing
 variables in your Sentinel policy that refer to a specific instance of a specific resource
@@ -253,11 +253,13 @@ in a specific module discovered by the above function:
 ```python
 resource_address = get_address(module_path, resource_type, name)
 instance_address = resource_address + "[" + string(index) + "]"
+print(instance_address, "violated the policy")
 ```
 
-This would print out something like `aws_instance.test[1]` for an `aws_instance` resource
-in the root module and something like `module.compute.aws_instance.web[2]` for an
-`aws_instance` resource in the compute module.
+This would print out `aws_instance.test[0] violated the policy` for the first
+instance of an `aws_instance` resource in the root module named `test` and 
+`module.compute.aws_instance.web[1] violated the policy` for the second instance
+of an `aws_instance` resource named `web` in the `compute` module.
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -195,56 +195,10 @@ state don't have any resources of the specified type; using the `else` operators
 avoid the function returning `undefined` in these cases.
 
 To invoke this function for a specific resource type, pass it the resource type as a
-string. For example, to get all instances of the `google_sql_database` resource, you could
-use this:
-```python
-resouce_maps = find_resources_from_state("google_sql_database")
-```
-You would then iterate over the `resource_maps` variable to get the maps of the
-specified resource in each module and iterate over the resources in those maps to
+string. You would then iterate over the map returned by this function to get the maps
+of the specified resource in each module and iterate over the resources in those maps to
 access their attributes. Remember that this function will only locate modules (and
 hence resources) that are present in the current state.
-
-You could define a similar `find_data_sources_from_state` function to find all data
-sources of a particular type from all modules by simply changing `resources[type]`
-to `data[type]` and `resource_maps` to `data_source_maps`.
-
-If you want to determine the [address][resource-addressing] of a resource or data source returned by
-functions like `find_resources_from_state` using the form `module.A.module.B.<type>.<name>`
-that is used in plan and apply logs, you can use a function like this one:
-
-[resource-addressing]: /docs/internals/resource-addressing.html
-
-```python
-get_address = func(module_path, type, name) {
-  if length(module_path) == 0 {
-    # root module
-    address = type + "." + name
-  } else {
-    # non-root module
-    address = "module." + strings.join(module_path, ".module.") + "." + type + "." + name
-  }
-  return address
-}
-```
-
-This function takes the module path in the list of lists form described above along
-with the type and name of the resource as arguments. To print the complete address of
-an instance of a resource having multiple instances, you could use the following Sentinel
-code in which `module_path`, `resource_type`, `name`, and `index` are pre-existing
-variables in your Sentinel policy that refer to a specific instance of a specific resource
-in a specific module discovered by the above function:
-
-```python
-resource_address = get_address(module_path, resource_type, name)
-instance_address = resource_address + "[" + string(index) + "]"
-print(instance_address, "violated the policy")
-```
-
-This would print out `google_sql_database.test[0] violated the policy` for the first
-instance of a `google_sql_database` resource named `test` in the root module and 
-`module.compute.google_sql_database.web[1] violated the policy` for the second instance
-of a `google_sql_database` resource named `web` in the `compute` module.
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -203,7 +203,7 @@ resouce_maps = find_resources_from_state("google_sql_database")
 You would then iterate over the `resource_maps` variable to get the maps of the
 specified resource in each module and iterate over the resources in those maps to
 access their attributes. Remember that this function will only locate modules (and
-hence resources) that are present in state.
+hence resources) that are present in the current state.
 
 You could define a similar `find_data_sources_from_state` function to find all data
 sources of a particular type from all modules by simply changing `resources[type]`

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -154,8 +154,8 @@ The value of `module_paths` would be:
 
 ```
 [
-	[],
-	["foo"],
+  [],
+  ["foo"],
 ]
 ```
 
@@ -172,10 +172,9 @@ main = rule { tfstate.module_paths contains ["foo"] }
 #### Iterating through modules
 
 Iterating through all modules to find particular resources can be useful. This
-example shows how to use `module_paths` with the [`module()`
-function](#function-module-) to retrieve all resources of a particular type from
-all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
-resource). Note the use of `else []` in case some modules don't have any
+example shows how to use `module_paths` with the [`module()`](#function-module-)
+function to retrieve all resources of a particular type from all modules in the
+current state of a workspace. Note the use of `else []` in case some modules don't have any
 resources; this is necessary to avoid the function returning undefined.
 
 [ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
@@ -184,16 +183,73 @@ Remember again that this will only locate modules (and hence resources) that are
 present in state.
 
 ```python
-import "tfstate"
-
-get_vms = func() {
-	vms = []
-	for tfstate.module_paths as path {
-		vms += values(tfstate.module(path).resources.azurerm_virtual_machine) else []
-	}
-	return vms
+find_resources_from_state = func(type) {
+  resource_maps = {}
+  for tfstate.module_paths else []  as path {
+    resource_maps[path] = tfstate.module(path).resources[type] else {}
+  }
+  return resource_maps
 }
 ```
+
+This function creates a map for which the keys are the module paths and the values
+are maps of all resources of the specified type within the modules. Note the use of
+`else []` after `tfstate.module_paths` and `else {}` at the end of the next line.
+The first protects against the case that there are currently no resources in
+the state while the second protects against the case that the modules in the
+state don't have any resources of the specified type; using the `else` operators
+avoid the function returning `undefined` in these cases.
+
+To invoke this function for a specific resource type, pass it the resource type as a
+string. For example, to get all instances of the `google_sql_database` resource, you could
+use this:
+```python
+resouce_maps = find_resources_from_state("google_sql_database")
+```
+You would then iterate over the `resource_maps` variable to get the maps of the
+specified resource in each module and iterate over the resources in those maps to
+access their attributes.
+
+You could define a similar `find_data_sources_from_state` function to find all data
+sources of a particular type from all modules by simply changing `resources[type]`
+to `data[type]` and `resource_maps` to `data_source_maps`.
+
+If you want to determine the [address][resource-addressing] of a resource or data source returned by
+functions like `find_resources_from_state` using the form `module.A.module.B.<type>.<name>`
+that is used in plan and apply logs, you can use a function like this one:
+
+[resource-addressing]: /docs/internals/resource-addressing.html
+
+```python
+get_address = func(module_path, type, name) {
+  if length(module_path) == 0 {
+    # root module
+    address = type + "." + name
+  } else {
+    # non-root module
+    address = "module." + strings.join(module_path, ".module.") + "." + type + "." + name
+  }
+  return address
+}
+```
+
+This function takes the module path in the list of lists form described above along
+with the type and name of the resource as arguments. To print the complete address of
+an instance of a resource having multiple instances, you could use the following Sentinel
+code in which `module_path`, `resource_type`, `name`, and `index` are pre-existing
+variables in your Sentinel policy that refer to a specific instance of a specific resource
+in a specific module discovered by the above function:
+
+```python
+resource_address = get_address(module_path, resource_type, name)
+instance_address = resource_address + "[" + string(index) + "]"
+print(instance_address, "violated the policy")
+```
+
+This would print out `google_sql_database.test[0] violated the policy` for the first
+instance of a `google_sql_database` resource named `test` in the root module and 
+`module.compute.google_sql_database.web[1] violated the policy` for the second instance
+of a `google_sql_database` resource named `web` in the `compute` module.
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -174,13 +174,7 @@ main = rule { tfstate.module_paths contains ["foo"] }
 Iterating through all modules to find particular resources can be useful. This
 example shows how to use `module_paths` with the [`module()`](#function-module-)
 function to retrieve all resources of a particular type from all modules in the
-current state of a workspace. Note the use of `else []` in case some modules don't have any
-resources; this is necessary to avoid the function returning undefined.
-
-[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
-
-Remember again that this will only locate modules (and hence resources) that are
-present in state.
+current state of a workspace.
 
 ```python
 find_resources_from_state = func(type) {
@@ -208,7 +202,8 @@ resouce_maps = find_resources_from_state("google_sql_database")
 ```
 You would then iterate over the `resource_maps` variable to get the maps of the
 specified resource in each module and iterate over the resources in those maps to
-access their attributes.
+access their attributes. Remember that this function will only locate modules (and
+hence resources) that are present in state.
 
 You could define a similar `find_data_sources_from_state` function to find all data
 sources of a particular type from all modules by simply changing `resources[type]`


### PR DESCRIPTION
The original example functions that showed how to iterate over modules in the tfplan, tfconfig, and tfstate imports were inadequate in that they did not include the name of the resources or the modules in which they were found in the lists they returned.  I have defined generic, parameterized functions, `find_resources_from_plan`, `find_resources_from_config`, and `find_resources_from_state` that accept the resource type as an argument.

These functions can be used unchanged in all policies that use the respective TFE Sentinel imports. Instead of returning a list of maps, they return a map of maps in which the keys are the module path and the values are maps containing all resources of the specfied type in that module. This allows policies that call the functions to output the module name and full resource path in calls to the Sentinel `print()` function, making the outputs from TFE Sentinel policies much clearer to users when their plans violate Sentinel policies.

Additionally, I've defined an auxillary function, `get_address`, that returns the address of a resource using the form `module.A.module.B.<type>.<name>` that is used in plan and apply logs. I also show how to get the full address of a resource instance by appending something like `"[" + string(index) + "]"`. This function can be used with all 3 of the above functions.

You can see examples of the `find_resources_from_plan`  function being used in this [policy](https://github.com/rberlind/new-policies/blob/master/aws/restrict-ec2-instance-type.sentinel) and others in the same repository. The versions of the functions in that repository have additional comments, but I left them out of the text in the 3 updated pages since the surrounding text explains the functions, making the comments unnecessary in them.  In the near future, I plan to merge the policies in that repository into the official [hashicorp/teraform-guides/governance](https://github.com/hashicorp/terraform-guides/tree/master/governance) repository of official Sentinel examples.