### PR TITLE
Improve the look and design of the newer navigation controls

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -53,19 +53,44 @@ document.addEventListener("turbolinks:load", function() {
         if ($("#sidebar-controls").length === 0) { // then add it!
             var sidebarControlsHTML =
                 '<div id="sidebar-controls">' +
-                    '<span class="glyphicon glyphicon-search"></span>' +
-                    '<input type="search" id="sidebar-filter-field" class="form-control" name="sidebar-filter-field" role="search" placeholder="Filter page titles" />' +
-                    '<a href="#" class="subnav-toggle btn btn-default" role="button">Expand all</a>' +
+                    '<div id="sidebar-filter">' +
+                        '<span class="glyphicon glyphicon-search"></span>' +
+                        '<label for="sidebar-filter-field" class="sr-only sr-only-focusable">Filter page titles in sidebar navigation</label>' +
+                        '<input type="search" id="sidebar-filter-field" class="form-control" name="sidebar-filter-field" role="search" placeholder="Filter page titles" />' +
+                        '<button id="filter-close" class="glyphicon glyphicon-remove-circle" title="Reset filter"><span class="sr-only sr-only-focusable">Reset sidebar filter</span></button>' +
+                    '</div>' +
+                    '<div id="sidebar-buttons">' +
+                        '<button id="toggle-button">Expand all</button>' +
+                        ' | ' +
+                        '<button id="filter-button" title="Shortcut: type the / key">Filter</button>' +
+                    '</div>' +
                 '</div>';
-            if ($("#docs-sidebar a.subnav-toggle").length === 0) { // ...in default location
+            var sidebarHeader = $("#docs-sidebar").children("h1,h2,h3,h4,h5,h6").not("#otherdocs").first();
+            if (sidebarHeader.length === 1) { // under first header
+                sidebarHeader.after(sidebarControlsHTML);
+            } else { // under skip link
                 $("#docs-sidebar #controls-placeholder").replaceWith(sidebarControlsHTML);
-            } else { // ...at a manually chosen location
-                $("#docs-sidebar a.subnav-toggle").replaceWith(sidebarControlsHTML);
             }
         }
 
-        var subnavToggle = $("#sidebar-controls a.subnav-toggle");
+        var filterDiv = $("div#sidebar-filter");
+        var buttonsDiv = $("div#sidebar-buttons");
+        var subnavToggle = $("#sidebar-controls #toggle-button");
         var filterField = $("#sidebar-controls input#sidebar-filter-field");
+        var filterButton = $("#filter-button");
+
+        filterDiv.hide();
+
+        filterButton.on("click", function(e) {
+            buttonsDiv.hide();
+            filterDiv.show();
+            filterField.focus();
+        });
+
+        // Filter field's close button: defer to reset button.
+        $("#filter-close").on("click", function(e) {
+            subnavToggle.trigger("reset");
+        });
 
         // Expand/reset button behavior:
         subnavToggle.on({
@@ -78,6 +103,8 @@ document.addEventListener("turbolinks:load", function() {
                 sidebarLinks.parent("li").show();
                 resetActiveSubnavs();
                 $(this).html("Expand all");
+                buttonsDiv.show();
+                filterDiv.hide();
             },
             "click": function(e) {
                 e.preventDefault();
@@ -121,7 +148,7 @@ document.addEventListener("turbolinks:load", function() {
             var focusedElementType = $(document.activeElement).get(0).tagName.toLowerCase();
             if (focusedElementType !== "textarea" && focusedElementType !== "input") {
                 e.preventDefault();
-                filterField.focus();
+                filterButton.trigger("click");
             }
         });
     }

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -130,14 +130,16 @@ document.addEventListener("turbolinks:load", function() {
     // On docs/content pages, add a hierarchical quick nav menu if there are
     // more than two H2/H3/H4 headers.
     var headers = $('#inner').find('h2, h3, h4');
-    if (headers.length > 2) {
+    if (headers.length > 2 && $("div#inner-quicknav").length === 0) {
         // Build the quick-nav HTML:
-        $("#inner #inner-quicknav").html(
-            '<span id="inner-quicknav-trigger">' +
-                'Page Quick Nav' +
-                '<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg>' +
-            '</span>' +
-            '<ul class="dropdown"></ul>'
+        $("#inner h1").first().after(
+            '<div id="inner-quicknav">' +
+                '<span id="inner-quicknav-trigger">' +
+                    'Jump to Section' +
+                    '<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg>' +
+                '</span>' +
+                '<ul class="dropdown"></ul>' +
+            '</div>'
         );
         var quickNav = $('#inner-quicknav > ul.dropdown');
         headers.each(function(index, element) {

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -2,6 +2,19 @@
   margin-bottom: 30px;
   overflow: hidden;
 
+  // Re-using the .nav class name on lists means we inherit some
+  // unfortunate behavior from Bootstrap, so reset all that.
+  .nav {
+    ul, li, a {
+      float: none;
+      position: static;
+      padding: 0;
+    }
+    ul { display: block; }
+    li { display: list-item; }
+    a { display: inline; }
+  }
+
   // hide an outdated implementation of expand/collapse link
   a.subnav-toggle {
     display: none;
@@ -27,8 +40,6 @@
     color: $sidebar-link-color;
     font-size: $sidebar-font-size;
     overflow-wrap: break-word;
-    margin: 0 0 0 15px;
-    padding: 0 0 11px 0;
 
     &:focus,
     &:hover {
@@ -97,18 +108,25 @@
     padding-top: 10px;
 
     li {
+      padding: 0 0 11px 0;
+
       a {
         @extend %sidebar-link;
+        padding-left: 6px;
+        // Hanging indent for long sidebar links:
+        // * like   (<-yes)   * like
+        //   this   (no ->)   this
+        display: table-cell;
       }
 
       &:before {
         color: $sidebar-link-color-active;
         content: '\2022';
         font-size: 1em;
-        left: -3px;
-        top: -3px;
         opacity: 0.4;
-        position: absolute;
+        position: relative;
+        // Hanging indent for long sidebar links:
+        display: table-cell;
       }
 
       &.has-subnav {
@@ -119,8 +137,7 @@
         }
         &.active:before {
           transform: rotate(90deg);
-          left: -1px;
-          top: -1px;
+          top: 2px;
         }
       }
 
@@ -144,7 +161,8 @@
       display: none;
     }
     ul.nav {
-      padding: 10px;
+      padding-top: 10px;
+      padding-left: 10px;
 
       li {
         margin-left: 10px;

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -1,6 +1,5 @@
 #docs-sidebar {
   margin-bottom: 30px;
-  margin-top: 20px;
   overflow: hidden;
 
   // hide an outdated implementation of expand/collapse link
@@ -12,13 +11,13 @@
     color: $body-link-color;
   }
 
-  h1,
-  h2,
   h3,
-  h4,
-  h5,
-  h6 {
-    margin-top: 10px;
+  h4 {
+    min-height: 35px;
+    margin-top: 30px;
+    display: flex;
+    align-items: center;
+    margin-bottom: 0;
     a {
       color: $body-link-color;
     }
@@ -38,7 +37,12 @@
     }
   }
 
+  h4 + div#sidebar-controls {
+    margin-top: 0;
+  }
+
   div#sidebar-controls {
+    margin-top: 65px; // if no header
     box-sizing: border-box;
     position: relative;
     height: 37px;

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -3,6 +3,15 @@
   margin-top: 20px;
   overflow: hidden;
 
+  // hide an outdated implementation of expand/collapse link
+  a.subnav-toggle {
+    display: none;
+  }
+
+  a#mobile-skip {
+    color: $body-link-color;
+  }
+
   h1,
   h2,
   h3,
@@ -11,7 +20,7 @@
   h6 {
     margin-top: 10px;
     a {
-        color: $body-link-color;
+      color: $body-link-color;
     }
   }
 
@@ -32,6 +41,7 @@
   div#sidebar-controls {
     box-sizing: border-box;
     position: relative;
+    height: 37px;
     .glyphicon-search {
       position: absolute;
       top: 7px;
@@ -39,19 +49,41 @@
       opacity: .7;
       z-index: -1;
     }
+    #filter-close {
+      position: absolute;
+      top: 3px;
+      right: 3px;
+      opacity: .7;
+      z-index: 1;
+      border: none;
+      background: transparent;
+      padding: 4px;
+    }
     input {
       font-size: 1rem;
       height: 100%;
       margin-bottom: 1px;
       padding-left: 28px;
       background: transparent;
-      @media (pointer: coarse) {
+    }
+    @media (pointer: coarse) {
+      input {
         font-size: 16px;
       }
+      #filter-close {
+        top: 7px;
+      }
+      .glyphicon-search {
+        top: 11px;
+      }
     }
-    a.subnav-toggle {
-      font-size: 1rem;
-      padding: .2em 1.4em;
+    #sidebar-buttons button {
+      font-variant-caps: all-small-caps;
+      color: #666;
+      display: inline-block;
+      width: 40%;
+      border: none;
+      background: transparent;
     }
   }
 

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -1,14 +1,15 @@
 #inner {
 
   #inner-quicknav {
-    margin-top: 35px;
-    &+h1 {
-      margin-top: 20px;
-    }
+    margin-top: -15px;
+    margin-bottom: 25px;
+    margin-left: 10px;
 
     span {
       line-height: 20px;
       cursor: pointer;
+      font-variant-caps: all-small-caps;
+      color: #666;
 
       svg {
         fill: $body-font-color;
@@ -37,7 +38,7 @@
         visibility: visible;
         opacity: 1;
         display: block;
-        transition: all 0.5s ease;
+        transition-duration: 0s;
       }
 
       li {

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -131,12 +131,24 @@
   h3,
   h4 {
     color: $body-font-color;
-    margin-top: 54px;
     margin-bottom: $font-size;
     line-height: 1.3;
     overflow-wrap: break-word;
   }
 
+  // Special treatment to align baseline with sidebar header
+  h1 {
+    min-height: 60px;
+    margin-top: 5px;
+    display: flex;
+    align-items: flex-end;
+  }
+
+  h2,
+  h3,
+  h4 {
+    margin-top: 54px;
+  }
   h2 {
     padding-bottom: 3px;
     border-bottom: 1px solid $gray-light;

--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -14,7 +14,7 @@
     "Extending Terraform" => "/docs/extend/index.html"
   }
 -%>
-    <h4><%= header %></h4>
+    <h4 id="otherdocs"><%= header %></h4>
 
     <ul class="nav docs-sidenav">
 <% other_docs.each do |name, path| -%>

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -2,8 +2,9 @@
 <div class="container">
   <div class="row">
     <div id="docs-sidebar" class="col-sm-4 col-md-3 col-xs-12 hidden-print" role="complementary">
-      <a href="#inner" class="visible-xs">(Jump to content ⤵︎)</a>
-      <div id="controls-placeholder"></div>
+      <a href="#inner" id="screenreader-skip" class="sr-only sr-only-focusable">Skip to content</a>
+      <a href="#inner" id="mobile-skip" class="visible-xs">(Skip to content ⤵︎)</a>
+      <div id="controls-placeholder" style="display: none;"></div>
       <% if content_for?(:sidebar) %>
       <%
         sidebar_text = yield_content(:sidebar)

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -15,7 +15,6 @@
     </div>
 
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">
-      <div id="inner-quicknav"></div>
       <%= yield %>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes some of the gnarlier look-and-feel issues with a couple of recently added features on terraform.io: the jump-to-section-of-current-page dropdown, and the sidebar filter/expand controls. 

This redesign is based on a design @glasner whipped up. The new controls take up less space, are positioned in a more intuitive spot, and are less obtrusive and flashy. They work basically the same way as before; the only change is that you click the "filter" button to reveal and focus the text field, instead of the text field being present by default. 

I also went to some pains to get the text in the headers and controls to line up across the sidebar and the main content area.

Here are some screenshots, with some web inspector boxes showing how the stuff lines up a little better:

![filter open](https://user-images.githubusercontent.com/484309/59139074-b8f01000-8945-11e9-83bf-6053bd7998aa.png)

![mismatch controls](https://user-images.githubusercontent.com/484309/59139075-b8f01000-8945-11e9-853f-60b5099788a3.png)

![empty align](https://user-images.githubusercontent.com/484309/59139076-b8f01000-8945-11e9-8e16-4fe1f0520fb1.png)

![headers align](https://user-images.githubusercontent.com/484309/59139077-b8f01000-8945-11e9-9ed6-fdb8da5b573f.png)

![controls align](https://user-images.githubusercontent.com/484309/59139078-b988a680-8945-11e9-93b7-fe7f50681c67.png)

