### PR TITLE
Add HashiCorp forum to community page

### DIFF
--- a/content/source/docs/extend/community/index.html.md
+++ b/content/source/docs/extend/community/index.html.md
@@ -22,19 +22,16 @@ Overflow](https://stackoverflow.com/). Use the tag "terraform" to help your
 question be found by Terraform experts, and please be respectful of the "How to
 Ask" guidelines in each community.
 
-**Mailing list:** [Terraform Google
-Group](https://groups.google.com/group/terraform-tool)
-
-**Gitter:** [Terraform Gitter Room](https://gitter.im/hashicorp-terraform/Lobby)
-
-**IRC:** Use the [Gitter IRC bridge](https://irc.gitter.im)
+**HashiCorp forum:** The [Terraform
+section](https://discuss.hashicorp.com/c/terraform-core) of the community portal
+contains questions, use cases, and useful patterns.
 
 **Bug Trackers:** 
 
 - [Terraform Core Issue tracker on
 GitHub](https://github.com/hashicorp/terraform/issues). Please only use this for
 reporting bugs. Do not ask for general help here; use a Stack Exchange
-community, Gitter chat, or the mailing list for that.
+community or the HashiCorp forum for that.
 
 - Terraform Providers distributed by HashiCorp are part of the
 [`terraform-providers`](https://github.com/terraform-providers) GitHub


### PR DESCRIPTION
The mailing list and chat will be gradually deprecated for the community forum. Updating the community page to direct users to the forum.