### PR TITLE
update remote apply language to use proper it's/its

### DIFF
--- a/content/source/docs/enterprise/run/cli.html.md
+++ b/content/source/docs/enterprise/run/cli.html.md
@@ -126,7 +126,7 @@ Remote applies use the configuration code from the local working directory, but 
 $ terraform apply
 
 Running apply in the remote backend. Output will stream here. Pressing Ctrl-C
-will cancel the remote apply if its still pending. If the apply started it
+will cancel the remote apply if it's still pending. If the apply started it
 will stop streaming the logs, but will not stop the apply running remotely.
 To view this run in a browser, visit:
 https://app.terraform.io/app/my-org/my-app-dev/runs/run-PEekqv44Fs8NkiFx


### PR DESCRIPTION
change its -> it's in the remote apply language (TF Remote Backend). 

old: its still pending
new: it's still pending 

there is also complementing change proposed for the Terraform CLI: [#21735](https://github.com/hashicorp/terraform/pull/21735)