### PR TITLE
update iteration functions

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -24,100 +24,178 @@ see [Mocking Terraform Sentinel Data](../mock.html).
 
 -> **Note:** Terraform Enterprise does not currently support custom imports.
 
-## Useful Idioms for Terraform Sentinel Policies
+## Useful Functions and Idioms for Terraform Sentinel Policies
 
-Terraform's internal data formats are complex, which means basic Sentinel policies for Terraform are more verbose than basic policies that use simpler data sources.
-
-This will improve in future versions of Terraform and Sentinel; in the meantime, be aware of the following idioms as you start writing policies for Terraform.
+The following functions and idioms will be useful as you start writing Sentinel policies for Terraform.
 
 ### To Find Resources, Iterate over Modules
 
-The most basic Sentinel task for Terraform is to enforce a rule on all resources of a given type. Before you can do that, you need to get a collection of all the relevant resources.
-
-The easiest way to do that is to copy a function like the following into any policies that examine every resource in a configuration:
+The most basic Sentinel task for Terraform is to enforce a rule on all resources of a given type. Before you can do that, you need to get a collection of all the relevant resources. The easiest way to do that is to copy a function like the following into your policies:
 
 ```python
 import "tfplan"
+import "strings"
 
-# Get an array of all resources of the given type (or an empty array).
-get_resources = func(type) {
-	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		return get_resources_all_modules(type)
-	} else { # fallback for tests
-		return get_resources_root_only(type)
-	}
-}
-
-get_resources_root_only = func(type) {
-	resources = []
-	named_and_counted_resources = tfplan.resources[type] else {}
-	# Get resource bodies out of nested resource maps, from:
-	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-	# to:
-	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(resources, body)
-		}
-	}
-	return resources
-}
-
-get_resources_all_modules = func(type) {
-	resources = []
-	for tfplan.module_paths as path {
-		named_and_counted_resources = tfplan.module(path).resources[type] else {}
-		# Get resource bodies out of nested resource maps, from:
-		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-		# to:
-		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-		for named_and_counted_resources as _, instances {
-			for instances as _, body {
-				append(resources, body)
-			}
-		}
-	}
-	return resources
+# Find all resources of a specific type from all modules using the tfplan import
+find_resources_from_plan = func(type) {
+        resource_maps = {}
+        for tfplan.module_paths as path {
+                # Compute joined_path from the module path
+                if length(path) == 0 {
+                        joined_path = ""
+                } else {
+                        joined_path = "module." + strings.join(path, ".module.") + "."
+                }
+                # Append all resources of the specified type from the current module
+                resource_maps[joined_path] = tfplan.module(path).resources[type] else {}
+        }
+        return resource_maps
 }
 ```
 
--> **Note:** This example uses the tfplan import. You can easily substitute tfconfig or tfstate, depending on your needs.
+-> **Note:** This example uses the `tfplan` import to find all resources of the specified type that have pending changes. You can easily substitute `tfconfig` or `tfstate` and change the name of the function, depending on your needs.
 
-Later, use the function to get a collection of resources:
+Later, you can call this function to get all resources of a desired type by passing the type as a string in quotes:
 
 ```python
-aws_instances = get_resources("aws_instance")
+aws_instances = find_resources_from_plan("aws_instance")
 ```
 
 This example function handles several things that are tricky about finding resources:
 
 - It checks every module for resources (including the root module) by looping over the `module_paths` namespace. The top-level `resources` namespace is more convenient, but it only reveals resources from the root module.
-- It unwraps the import's nested data structures, leaving only an array of resource bodies. The value of `tfplan.module(path).resources[type]` is a series of nested maps keyed by resource name and by [`count`](/docs/configuration/resources.html#count), but the name and count are almost never relevant to a policy. Removing them early makes the rest of the policy more readable.
-- It uses `else` expressions to recover from `undefined` values, for modules that don't have any resources of that type.
-- It falls back to the `resources` namespace if the real tfplan import isn't available, to support [testing](https://docs.hashicorp.com/sentinel/writing/testing). Since current versions of Sentinel don't allow you to mock tfplan's `module()` function, it isn't possible to test Sentinel code that accesses non-root modules. However, you can still test the rest of the policy by mocking resource data under the `resources` namespace.
+- It computes a `joined_path` variable from Sentinel's module path structure and uses this as the key for the module-specific maps added to the `resource_maps` map.
+- It sets the values of these module-level maps to `tfplan.module(path).resources[type]` which gives a series of nested maps keyed by resource name and instance [`count`](/docs/configuration/resources.html#count-multiple-resource-instances). When combined with the `joined_path` keys, the resource names and instance counts allow writers of Sentinel policies to print the full [addresses](/docs/internals/resource-addressing.html) of resource instances that violate policies. This makes it easier for users who see violation messages to know exactly which resources they need to modify. (See the `validate_instance_types` function below for an example.)
+- It uses the Sentinel `else` operator to recover from `undefined` values which would occur for modules that don't have any resources of the specified type.
 
--> **Note:** This example is checking whether it's in a test by looking for an empty `module_paths` namespace, which assumes that our organization is omitting that key in our mock data for Sentinel tests. For policies that need to test mocked `module_paths` data for other purposes, you might need to use a different method to check for the real Terraform imports.
+### A Function to Give the Full Addresses of Resources
 
-### To Test Resources, Use `all`/`any` Expressions
+Here is a function which can be used to give the full [address](/docs/internals/resource-addressing.html) of a resource instance that violates a policy.
 
-Once you have a collection of resources, you usually want to test some property of each resource in the collection — for example, the planned final value of a particular resource attribute.
+```python
+# Get the full address of a resource instance including modules, type,
+# name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
+get_instance_address = func(joined_path, type, name, index) {
+        address = joined_path + type + "." + name + "[" + string(index) + "]"
+        return address
+}
+```
 
-The most concise tool for this is Sentinel's [`all` and `any` expressions](https://docs.hashicorp.com/sentinel/language/boolexpr#any-all-expressions). For example:
+-> **Note:** This example is intended for use with the tfplan and tfstate imports. For printing resource addresses with the tfconfig import, you could use a function called `get_resource_address` which would leave out the `index` argument and set `address` to `joined_path + type + "." + name`. For all three imports, `joined_path` should be formatted as it is in the `find_resources_from_plan` function above.
+
+We show this function being called in the next section.
+
+### To Validate Resources, Use `for` Loops Inside Functions
+
+Once you have a collection of resources instances of a desired type and know how to give resource instance addresses, you usually want to validate that a particular resource attribute meets some condition.
+
+While you could use Sentinel's [`all` and `any` expressions](https://docs.hashicorp.com/sentinel/language/boolexpr#any-all-expressions) directly inside Sentinel rules, your rules would only report the first violation because Sentinel uses short-circuit logic. It is therefore usually preferred to use [`for` loops](https://docs.hashicorp.com/sentinel/language/loops) inside functions called from your rules so that you can report all violations that occur. Another benefit of calling a function from a rule is that the standard Sentinel output is streamlined allowing users to focus on the warnings your print in your policies.
+
+Here is a function that validates that the instance types of all EC2 instances being provisioned are in a given list:
+
+```python
+# Validate that all EC2 instances have instance_type
+# in the allowed_types list
+validate_instance_types = func(allowed_types) {
+
+        validated = true
+
+        aws_instances = find_resources_from_plan("aws_instance")
+
+        # Loop through the resource maps, resources, and instances
+        for aws_instances as joined_path, resource_map {
+                for resource_map as name, instances {
+                        for instances as index, r {
+
+                                # Get address of the resource instance
+                                address = get_instance_address(joined_path, resource_type, name, index)
+
+                                # Validate that each instance has allowed value
+                                # If not, print violation message
+                                if r.applied.instance_type not in allowed_types {
+                                        print("EC2 instance", address, "has attribute",
+                                                r.applied.instance_type, "that is not in the list", allowed_types)
+                                        validated = false
+                                }
+                        }
+                }
+        }
+
+        return validated
+}
+```
+
+This function calls the `find_resources_from_plan` and `get_instance_address` functions described above.
+
+The boolean variable `validated` is initially set to `true`, but it is set to `false` if any resource instance violates the condition requiring that the `instance_type` attribute be in the `allowed_types` list. Since the function returns `true` or `false`, it can be called inside Sentinel rules.
+
+Note that this function prints a warning message for each resource instance that violates the condition. This allows the writer of a Sentinel rule that calls it to tell a user about **all** resource instances that violate it. This is much better than just reporting the first violation since a user with multiple violations learns about all of them in a single shot.
+
+### Call Functions From Rules
+
+Finally, having re-used the standardized `find_resources_from_plan` and `get_instance_address` functions and having written your own function to validate that resources instances of a specific type satisfy some condition, you can define a list with allowed values and write a rule that calls your function:
 
 ```python
 # Allowed Types
 allowed_types = [
-	"t2.small",
-	"t2.medium",
-	"t2.large",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
 ]
+
+# Call the validation function and assign results
+instance_types_validated = validate_instance_types(allowed_types)
 
 # Rule to restrict instance types
 instance_type_allowed = rule {
-	all get_resources("aws_instance") as r {
-		r.applied.instance_type in allowed_types
-	}
+        instance_types_validated is true
+}
+
+# Main rule
+main = rule {
+        instance_type_allowed is true
+}
+
+```
+
+Note that you could leave out the `instance_type_allowed` rule and place `instance_types_validated is true` directly inside your `main` rule. You could also leave out `is true` in both rules; we included it here to be more explicit.
+
+### Validating Multiple Conditions in a Single Policy
+
+If you want a policy to validate multiple conditions against resources of a specific type, we recommend that you use a single function to iterate over all resource instances of that type and make this function return a list of boolean values, using one for each condition.  You can then use multiple Sentinel rules that evaluate those boolean values or evaluate them all in your `main` rule. Here is a partial example:
+
+```python
+# Function to validate that S3 buckets have private ACL and use KMS encryption
+validate_private_acl_and_kms_encryption = func() {
+
+        # Initialize booleans to true
+        # They will be set to false if any instances violate rules
+        private = true
+        encrypted_by_kms = true
+
+        #s3_buckets = find_resources_from_plan("aws_s3_bucket")
+        # Iterate over resource instances and check that S3 buckets
+        # have private ACL and are encrypted by a KMS key
+        # If an S3 bucket is not private, set private to false
+        # If an S3 bucket is not encrypted by KMS, set encrypted_by_kms to false
+        for s3_buckets as joined_path, resource_map {
+                #...
+        }
+
+        # Return list of booleans
+        return [private, encrypted_by_kms]
+
+}
+
+# Call the validation function and assign results
+validations = validate_private_acl_and_kms_encryption()
+private = validations[0]
+encrypted_by_kms = validations[1]
+
+# Main rule
+main = rule {
+        private and encrypted_by_kms
 }
 ```
 
--> **Note:** This example assumes that you are unwrapping the import's nested maps when finding resources, as described in the previous section. If you leave the nested maps in place, you will have to use nested `all`/`any` expressions to reach the resource attributes.
+Similar functions and policies can be written to restrict Terraform configurations using the tfconfig import and to restrict Terraform state using  the tfstate import.

--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -13,9 +13,15 @@ policy to access reusable libraries, external data and functions. Terraform
 Enterprise provides three imports to define policy rules for the configuration,
 state and plan.
 
-- [tfplan](./tfplan.html) - This provides access to a Terraform plan, the file created as a result of `terraform plan`.	 The plan represents the changes that Terraform needs to make to infrastructure to reach the desired state represented by the configuration.
-- [tfconfig](./tfconfig.html) - This provides access to a Terraform configuration, the set of "tf" files that are used to describe the desired infrastructure state.
-- [tfstate](./tfstate.html) - This provides access to the Terraform state, the file used by Terraform to map real world resources to your configuration.
+- [tfplan](./tfplan.html) - This provides access to a Terraform plan, the file
+  created as a result of `terraform plan`.	 The plan represents the changes
+  that Terraform needs to make to infrastructure to reach the desired state
+  represented by the configuration.
+- [tfconfig](./tfconfig.html) - This provides access to a Terraform
+  configuration, the set of "tf" files that are used to describe the desired
+  infrastructure state.
+- [tfstate](./tfstate.html) - This provides access to the Terraform state, the
+  file used by Terraform to map real world resources to your configuration.
 
 Terraform Enterprise allows you to create mocks of these imports from plans for
 use with the mocking or testing features of the [Sentinel
@@ -26,11 +32,15 @@ see [Mocking Terraform Sentinel Data](../mock.html).
 
 ## Useful Functions and Idioms for Terraform Sentinel Policies
 
-The following functions and idioms will be useful as you start writing Sentinel policies for Terraform.
+The following functions and idioms will be useful as you start writing Sentinel
+policies for Terraform.
 
 ### Iterate over Modules and Find Resources
 
-The most basic Sentinel task for Terraform is to enforce a rule on all resources of a given type. Before you can do that, you need to get a collection of all the relevant resources from all modules. The easiest way to do that is to copy and use a function like the following into your policies:
+The most basic Sentinel task for Terraform is to enforce a rule on all resources
+of a given type. Before you can do that, you need to get a collection of all the
+relevant resources from all modules. The easiest way to do that is to copy and
+use a function like the following into your policies:
 
 ```python
 import "tfplan"
@@ -60,9 +70,12 @@ find_resources_from_plan = func(type) {
 }
 ```
 
--> **Note:** This example uses the `tfplan` import. You can find similar functions that iterate over the `tfconfig` and `tfstate` imports [here](https://github.com/hashicorp/terraform-guides/tree/master/governance/second-generation/common-functions).
+-> **Note:** This example uses the `tfplan` import. You can find similar
+functions that iterate over the `tfconfig` and `tfstate` imports
+[here](https://github.com/hashicorp/terraform-guides/tree/master/governance/second-generation/common-functions).
 
-You can call this function to get all resources of a desired type by passing the type as a string in quotes:
+You can call this function to get all resources of a desired type by passing the
+type as a string in quotes:
 
 ```python
 aws_instances = find_resources_from_plan("aws_instance")
@@ -70,20 +83,49 @@ aws_instances = find_resources_from_plan("aws_instance")
 
 This example function does several useful things while finding resources:
 
-- It checks every module (including the root module) for resources of the specified type by iterating over the `module_paths` namespace. The top-level `resources` namespace is more convenient, but it only reveals resources from the root module.
-- It iterates over the named resources and [resource instances](/docs/configuration/resources.html#count-multiple-resource-instances) found in each module, starting with `tfplan.module(path).resources[type]` which is a series of nested maps keyed by resource names and instance counts.
-- It uses the Sentinel [`else` operator](https://docs.hashicorp.com/sentinel/language/spec#else-operator) to recover from `undefined` values which would occur for modules that don't have any resources of the specified type.
-- It builds a flat `resources` map of all resource instances of the specified type. Using a flat map simplifies the code used by Sentinel policies to evaluate rules.
-- It computes an `address` variable for each resource instance and uses this as the key in the `resources` map. This allows writers of Sentinel policies to print the full [address](/docs/internals/resource-addressing.html) of each resource instance that violate a policy, using the same address format used in plan and apply logs. Doing this tells users who see violation messages exactly which resources they need to modify in their Terraform code to comply with the Sentinel policies.
-- It sets the value of the `resources` map to the data associated with the resource instance (`r`). This is the data that Sentinel policies apply rules against.
+- It checks every module (including the root module) for resources of the
+  specified type by iterating over the `module_paths` namespace. The top-level
+  `resources` namespace is more convenient, but it only reveals resources from
+  the root module.
+- It iterates over the named resources and [resource
+  instances](/docs/configuration/resources.html#count-multiple-resource-instances)
+  found in each module, starting with `tfplan.module(path).resources[type]`
+  which is a series of nested maps keyed by resource names and instance counts.
+- It uses the Sentinel [`else`
+  operator](https://docs.hashicorp.com/sentinel/language/spec#else-operator) to
+  recover from `undefined` values which would occur for modules that don't have
+  any resources of the specified type.
+- It builds a flat `resources` map of all resource instances of the specified
+  type. Using a flat map simplifies the code used by Sentinel policies to
+  evaluate rules.
+- It computes an `address` variable for each resource instance and uses this as
+  the key in the `resources` map. This allows writers of Sentinel policies to
+  print the full [address](/docs/internals/resource-addressing.html) of each
+  resource instance that violate a policy, using the same address format used in
+  plan and apply logs. Doing this tells users who see violation messages exactly
+  which resources they need to modify in their Terraform code to comply with the
+  Sentinel policies.
+- It sets the value of the `resources` map to the data associated with the
+  resource instance (`r`). This is the data that Sentinel policies apply rules
+  against.
 
 ### Validate Resource Attributes
 
-Once you have a collection of resources instances of a desired type indexed by their addresses, you usually want to validate that one or more resource attributes meets some conditions by iterating over the resource instances.
+Once you have a collection of resources instances of a desired type indexed by
+their addresses, you usually want to validate that one or more resource
+attributes meets some conditions by iterating over the resource instances.
 
-While you could use Sentinel's [`all` and `any` expressions](https://docs.hashicorp.com/sentinel/language/boolexpr#any-all-expressions) directly inside Sentinel rules, your rules would only report the first violation because Sentinel uses short-circuit logic. It is therefore usually preferred to use a [`for` loop](https://docs.hashicorp.com/sentinel/language/loops) outside of your rules so that you can report all violations that occur. You can do this inside functions or directly in the policy itself.
+While you could use Sentinel's [`all` and `any`
+expressions](https://docs.hashicorp.com/sentinel/language/boolexpr#any-all-expressions)
+directly inside Sentinel rules, your rules would only report the first violation
+because Sentinel uses short-circuit logic. It is therefore usually preferred to
+use a [`for` loop](https://docs.hashicorp.com/sentinel/language/loops) outside
+of your rules so that you can report all violations that occur. You can do this
+inside functions or directly in the policy itself.
 
-Here is a function that calls the `find_resources_from_plan` function and validates that the instance types of all EC2 instances being provisioned are in a given list:
+Here is a function that calls the `find_resources_from_plan` function and
+validates that the instance types of all EC2 instances being provisioned are in
+a given list:
 
 ```python
 # Validate that all EC2 instances have instance_type in the allowed_types list
@@ -109,15 +151,32 @@ validate_ec2_instance_types = func(allowed_types) {
 }
 ```
 
-The boolean variable `validated` is initially set to `true`, but it is set to `false` if any resource instance violates the condition requiring that the `instance_type` attribute be in the `allowed_types` list. Since the function returns `true` or `false`, it can be called inside Sentinel rules.
+The boolean variable `validated` is initially set to `true`, but it is set to
+`false` if any resource instance violates the condition requiring that the
+`instance_type` attribute be in the `allowed_types` list. Since the function
+returns `true` or `false`, it can be called inside Sentinel rules.
 
-Note that this function prints a warning message for **every** resource instance that violates the condition. This allows writers of Terraform code to fix all violations after just one policy check. It also prints warnings when the attribute being evaluated is [computed](/docs/enterprise/sentinel/import/tfplan.html#value-computed) and does not evaluate the condition in this case since the applied value will not be known.
+Note that this function prints a warning message for **every** resource instance
+that violates the condition. This allows writers of Terraform code to fix all
+violations after just one policy check. It also prints warnings when the
+attribute being evaluated is
+[computed](/docs/enterprise/sentinel/import/tfplan.html#value-computed) and does
+not evaluate the condition in this case since the applied value will not be
+known.
 
-While this function allows a rule to validate an attribute against a list, some rules will only need to validate an attribute against a single value; in those cases, you could either use a list with a single value or embed that value inside the function itself, drop the `allowed_types` parameter from the function definition, and use the `is` operator instead of the `in` operator to compare the resource attribute against the embedded value.
+While this function allows a rule to validate an attribute against a list, some
+rules will only need to validate an attribute against a single value; in those
+cases, you could either use a list with a single value or embed that value
+inside the function itself, drop the `allowed_types` parameter from the function
+definition, and use the `is` operator instead of the `in` operator to compare
+the resource attribute against the embedded value.
 
 ### Write Rules
 
-Having used the standardized `find_resources_from_plan` function and having written your own function to validate that resources instances of a specific type satisfy some condition, you can define a list with allowed values and write a rule that evaluates the value returned by your validation function.
+Having used the standardized `find_resources_from_plan` function and having
+written your own function to validate that resources instances of a specific
+type satisfy some condition, you can define a list with allowed values and write
+a rule that evaluates the value returned by your validation function.
 
 ```python
 # Allowed Types
@@ -136,7 +195,13 @@ main = rule {
 
 ### Validate Multiple Conditions in a Single Policy
 
-If you want a policy to validate multiple conditions against resources of a specific type, you could define a separate validation function for each condition or use a single function to evaluate all the conditions. In the latter case, you would make this function return a list of boolean values, using one for each condition.  You can then use multiple Sentinel rules that evaluate those boolean values or evaluate all of them in your `main` rule. Here is a partial example:
+If you want a policy to validate multiple conditions against resources of a
+specific type, you could define a separate validation function for each
+condition or use a single function to evaluate all the conditions. In the latter
+case, you would make this function return a list of boolean values, using one
+for each condition.  You can then use multiple Sentinel rules that evaluate
+those boolean values or evaluate all of them in your `main` rule. Here is a
+partial example:
 
 ```python
 # Function to validate that S3 buckets have private ACL and use KMS encryption
@@ -175,4 +240,6 @@ main = rule {
 }
 ```
 
-Similar functions and policies can be written to restrict Terraform configurations using the tfconfig import and to restrict Terraform state using  the tfstate import.
+Similar functions and policies can be written to restrict Terraform
+configurations using the tfconfig import and to restrict Terraform state using
+the tfstate import.

--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -97,19 +97,14 @@ Here is a function that validates that the instance types of all EC2 instances b
 # Validate that all EC2 instances have instance_type
 # in the allowed_types list
 validate_instance_types = func(allowed_types) {
-
         validated = true
-
         aws_instances = find_resources_from_plan("aws_instance")
-
         # Loop through the resource maps, resources, and instances
         for aws_instances as joined_path, resource_map {
                 for resource_map as name, instances {
                         for instances as index, r {
-
                                 # Get address of the resource instance
                                 address = get_instance_address(joined_path, resource_type, name, index)
-
                                 # Validate that each instance has allowed value
                                 # If not, print violation message
                                 if r.applied.instance_type not in allowed_types {
@@ -120,7 +115,6 @@ validate_instance_types = func(allowed_types) {
                         }
                 }
         }
-
         return validated
 }
 ```
@@ -146,19 +140,12 @@ allowed_types = [
 # Call the validation function and assign results
 instance_types_validated = validate_instance_types(allowed_types)
 
-# Rule to restrict instance types
-instance_type_allowed = rule {
-        instance_types_validated is true
-}
-
 # Main rule
 main = rule {
-        instance_type_allowed is true
+        instance_types_validated
 }
 
 ```
-
-Note that you could leave out the `instance_type_allowed` rule and place `instance_types_validated is true` directly inside your `main` rule. You could also leave out `is true` in both rules; we included it here to be more explicit.
 
 ### Validating Multiple Conditions in a Single Policy
 
@@ -167,22 +154,18 @@ If you want a policy to validate multiple conditions against resources of a spec
 ```python
 # Function to validate that S3 buckets have private ACL and use KMS encryption
 validate_private_acl_and_kms_encryption = func() {
-
-        # Initialize booleans to true
-        # They will be set to false if any instances violate rules
         private = true
         encrypted_by_kms = true
 
-        #s3_buckets = find_resources_from_plan("aws_s3_bucket")
+        s3_buckets = find_resources_from_plan("aws_s3_bucket")
         # Iterate over resource instances and check that S3 buckets
         # have private ACL and are encrypted by a KMS key
         # If an S3 bucket is not private, set private to false
-        # If an S3 bucket is not encrypted by KMS, set encrypted_by_kms to false
+        # If an S3 bucket is not encrypted, set encrypted_by_kms to false
         for s3_buckets as joined_path, resource_map {
                 #...
         }
 
-        # Return list of booleans
         return [private, encrypted_by_kms]
 
 }

--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -141,17 +141,17 @@ If you want a policy to validate multiple conditions against resources of a spec
 ```python
 # Function to validate that S3 buckets have private ACL and use KMS encryption
 validate_private_acl_and_kms_encryption = func() {
-        private = true
-        encrypted_by_kms = true
-        s3_buckets = find_resources_from_plan("aws_s3_bucket")
-        # Iterate over resource instances and check that S3 buckets
-        # have private ACL and are encrypted by a KMS key
-        # If an S3 bucket is not private, set private to false
-        # If an S3 bucket is not encrypted, set encrypted_by_kms to false
-        for s3_buckets as joined_path, resource_map {
-                #...
-        }
-        return [private, encrypted_by_kms]
+    private = true
+    encrypted_by_kms = true
+    s3_buckets = find_resources_from_plan("aws_s3_bucket")
+    # Iterate over resource instances and check that S3 buckets
+    # have private ACL and are encrypted by a KMS key
+    # If an S3 bucket is not private, set private to false
+    # If an S3 bucket is not encrypted, set encrypted_by_kms to false
+    for s3_buckets as joined_path, resource_map {
+        #...
+    }
+    return [private, encrypted_by_kms]
 }
 
 # Call the validation function and assign results

--- a/content/source/docs/enterprise/sentinel/import/index.html.md
+++ b/content/source/docs/enterprise/sentinel/import/index.html.md
@@ -141,32 +141,32 @@ If you want a policy to validate multiple conditions against resources of a spec
 ```python
 # Function to validate that S3 buckets have private ACL and use KMS encryption
 validate_private_acl_and_kms_encryption = func() {
-    private = true
-    encrypted_by_kms = true
+    result = {
+        "private":          true,   
+        "encrypted_by_kms": true,
+    }
     s3_buckets = find_resources_from_plan("aws_s3_bucket")
     # Iterate over resource instances and check that S3 buckets
     # have private ACL and are encrypted by a KMS key
-    # If an S3 bucket is not private, set private to false
-    # If an S3 bucket is not encrypted, set encrypted_by_kms to false
+    # If an S3 bucket is not private, set result["private"] to false
+    # If an S3 bucket is not encrypted, set result["encrypted_by_kms"] to false
     for s3_buckets as joined_path, resource_map {
-        #...
-    }
-    return [private, encrypted_by_kms]
+        #...    
+    }   
+    return result
 }
 
-# Call the validation function and assign results
+# Call the validation function
 validations = validate_private_acl_and_kms_encryption()
-private = validations[0]
-encrypted_by_kms = validations[1]
 
 # ACL rule
 is_private = rule {
-    private
+    validations["private"]
 }
 
 # KMS Encryption Rule
 is_encrypted_by_kms = rule {
-    encrypted_by_kms
+    validations["encrypted_by_kms"]
 }
 
 # Main rule

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -272,7 +272,9 @@ main = rule { tfconfig.module_paths contains ["foo"] }
 Iterating through all modules to find particular resources can be useful. This
 [example](iterate-over-modules) shows how to use `module_paths` with the
 [`module()` function](#function-module-) to find all resources of a
-particular type from all modules using the `tfplan` import. By changing `tfplan` in this function to `tfconfig`, you could make a similar function find all resources of a specific type in the Terraform configuration.
+particular type from all modules using the `tfplan` import. By changing `tfplan`
+in this function to `tfconfig`, you could make a similar function find all
+resources of a specific type in the Terraform configuration.
 
 [iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
 

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -267,28 +267,14 @@ import "tfconfig"
 main = rule { tfconfig.module_paths contains ["foo"] }
 ```
 
-#### Iterating through modules
+#### Iterating Through Modules
 
 Iterating through all modules to find particular resources can be useful. This
-example shows how to use `module_paths` with the [`module()`
-function](#root-function-module) to retrieve all resources of a particular type from
-all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
-resource). Note the use of `else []` in case some modules don't have any
-resources; this is necessary to avoid the function returning undefined.
+[example](iterate-over-modules) shows how to use `module_paths` with the
+[`module()` function](#function-module-) to find all resources of a
+particular type from all modules using the `tfplan` import. By changing `tfplan` in this function to `tfconfig`, you could make a similar function find all resources of a specific type in the Terraform configuration.
 
-[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
-
-```python
-import "tfconfig"
-
-get_vms = func() {
-	vms = []
-	for tfconfig.module_paths as path {
-		vms += values(tfconfig.module(path).resources.azurerm_virtual_machine) else []
-	}
-	return vms
-}
-```
+[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
 
 ## Namespace: Module
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -188,31 +188,15 @@ main = rule { tfplan.module_paths contains ["foo"] }
 
 -> Note the above example only applies if the module is present in the diff.
 
-#### Iterating through modules
+#### Iterating Through Modules
 
 Iterating through all modules to find particular resources can be useful. This
-example shows how to use `module_paths` with the [`module()`
-function](#function-module-) to retrieve all resources of a particular type from
-all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
-resource). Note the use of `else []` in case some modules don't have any
-resources; this is necessary to avoid the function returning undefined.
+[example](iterate-over-modules) shows how to use `module_paths` with the
+[`module()` function](#function-module-) to find all resources of a
+particular type from all modules that have pending changes using the `tfplan`
+import.
 
-[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
-
-Remember again that this will only locate modules (and hence resources) that
-have pending changes.
-
-```python
-import "tfplan"
-
-get_vms = func() {
-	vms = []
-	for tfplan.module_paths as path {
-		vms += values(tfplan.module(path).resources.azurerm_virtual_machine) else []
-	}
-	return vms
-}
-```
+[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -174,7 +174,9 @@ main = rule { tfstate.module_paths contains ["foo"] }
 Iterating through all modules to find particular resources can be useful. This
 [example](iterate-over-modules) shows how to use `module_paths` with the
 [`module()` function](#function-module-) to find all resources of a
-particular type from all modules using the `tfplan` import. By changing `tfplan` in this function to `tfstate`, you could make a similar function find all resources of a specific type in the current state.
+particular type from all modules using the `tfplan` import. By changing `tfplan`
+in this function to `tfstate`, you could make a similar function find all
+resources of a specific type in the current state.
 
 [iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -169,31 +169,14 @@ main = rule { tfstate.module_paths contains ["foo"] }
 
 -> Note the above example only applies if the module is present in the state.
 
-#### Iterating through modules
+#### Iterating Through Modules
 
 Iterating through all modules to find particular resources can be useful. This
-example shows how to use `module_paths` with the [`module()`
-function](#function-module-) to retrieve all resources of a particular type from
-all modules (in this case, the [`azurerm_virtual_machine`][ref-tf-azurerm-vm]
-resource). Note the use of `else []` in case some modules don't have any
-resources; this is necessary to avoid the function returning undefined.
+[example](iterate-over-modules) shows how to use `module_paths` with the
+[`module()` function](#function-module-) to find all resources of a
+particular type from all modules using the `tfplan` import. By changing `tfplan` in this function to `tfstate`, you could make a similar function find all resources of a specific type in the current state.
 
-[ref-tf-azurerm-vm]: /docs/providers/azurerm/r/virtual_machine.html
-
-Remember again that this will only locate modules (and hence resources) that are
-present in state.
-
-```python
-import "tfstate"
-
-get_vms = func() {
-	vms = []
-	for tfstate.module_paths as path {
-		vms += values(tfstate.module(path).resources.azurerm_virtual_machine) else []
-	}
-	return vms
-}
-```
+[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
 
 ### Value: `terraform_version`
 


### PR DESCRIPTION
Here is my new PR that updates functions used to iterate over modules.  In fact, I essentially rewrote much of the TFE Sentinel import/index.html page: (Defining Policies) at https://www.terraform.io/docs/enterprise/sentinel/import/index.html

This page now gives what I consider to be much better functions for iterating over modules when looking for resource instances of a specific type and for giving the complete addresses of the resource instances that violate policies.  It also adopts the approach I have recently adopted of doing most of the work of validating conditions in Sentinel functions intead of directly in rules since this allows the policies to report all violations of the policy.

While Sentinel's short-circuit logic is efficient at evaluating boolean expressions, it is not really useful for the consumer of a Sentinel policy violation, meaning the person who is informed while doing a run in TFE that their Terraform code violated a policy.  Sentinel's short-circuit logic causes rules to only report the first violation.  The person receiving the violation then has to fix the violation and try again.  If they have multiple resources that violate the policy, they have to go through this cycle multiple times.

It is much better to tell the user up front in a single shot about all their violations so they can fix them and then just try their plan once more.  That is what doing the work in functions accomplishes.

I look forward to feedback from the reviewers.