### PR TITLE
Update links to terraform-guides/governance

### DIFF
--- a/content/source/docs/enterprise/sentinel/examples.html.md
+++ b/content/source/docs/enterprise/sentinel/examples.html.md
@@ -12,30 +12,29 @@ This page lists some example Sentinel policies. These examples are not exhaustiv
 
 ### Amazon Web Services
 
-* [Enforce owner allow list on `aws_ami` data source](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/enforce-ami-owners.sentinel)
-* [Enforce mandatory tags on instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/enforce-mandatory-tags.sentinel)
-* [Restrict availability zones](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/restrict-aws-availability-zones.sentinel)
-* [Disallow CIDR blocks](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/restrict-aws-cidr-blocks.sentinel)
-* [Restrict the type of instance to be provisioned](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/restrict-aws-instance-type.sentinel)
-* [Require VPCs to be tagged and have DNS hostnames enabled](https://github.com/hashicorp/terraform-guides/blob/master/governance/aws/aws-vpcs-must-have-tags-and-enable-dns-hostnames.sentinel)
+* [Enforce owner allow list on `aws_ami` data source](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/enforce-ami-owners.sentinel)
+* [Enforce mandatory tags on instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/enforce-mandatory-tags.sentinel)
+* [Restrict availability zones](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/restrict-aws-availability-zones.sentinel)
+* [Disallow 0.0.0.0/0 CIDR blocks](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel)
+* [Restrict instance types of EC2 instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/aws/restrict-ec2-instance-type.sentinel)
+* [Require VPCs to be tagged and have DNS hostnames enabled](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/aws-vpcs-must-have-tags-and-enable-dns-hostnames.sentinel)
 
 
 ### Microsoft Azure
 
-* [Restrict VM images](https://github.com/hashicorp/terraform-guides/blob/master/governance/azure/restrict-vm-image-id.sentinel)
-* [Restrict the type of VM to be provisioned](https://github.com/hashicorp/terraform-guides/blob/master/governance/azure/restrict-vm-size.sentinel)
-* [Enforce limits on an ACS cluster](https://github.com/hashicorp/terraform-guides/blob/master/governance/azure/acs-cluster-policy.sentinel)
-* [Enforce limits on an AKS cluster](https://github.com/hashicorp/terraform-guides/blob/master/governance/azure/aks-cluster-policy.sentinel)
+* [Restrict VM images](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/azure/restrict-vm-image-id.sentinel)
+* [Restrict the size of Azure VMs](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/azure/restrict-vm-size.sentinel)
+* [Enforce limits on AKS clusters](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/azure/aks-cluster-policy.sentinel)
 
 ### Google Cloud Platform
 
-* [Disallow CIDR blocks](https://github.com/hashicorp/terraform-guides/blob/master/governance/gcp/block-allow-all-cidr.sentinel)
-* [Enforce limits on a GKE cluster](https://github.com/hashicorp/terraform-guides/blob/master/governance/gcp/gke-cluster-policy.sentinel)
-* [Restrict the type of machine to be provisioned](https://github.com/hashicorp/terraform-guides/blob/master/governance/gcp/restrict-machine-type.sentinel)
+* [Disallow 0.0.0.0/0 CIDR blocks](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/gcp/block-allow-all-cidr.sentinel)
+* [Enforce limits on a GKE cluster](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/gcp/gke-cluster-policy.sentinel)
+* [Restrict machine type of Virtual Machine instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/gcp/restrict-gce-machine-type.sentinel)
 
 ### VMware
 
-* [Require Storage DRS to be enabled](https://github.com/hashicorp/terraform-guides/blob/master/governance/vmware/require-storage-drs.sentinel)
-* [Restrict virtual disk size and type](https://github.com/hashicorp/terraform-guides/blob/master/governance/vmware/restrict-virtual-disk-size-and-type.sentinel)
-* [Restrict VM CPU count and memory](https://github.com/hashicorp/terraform-guides/blob/master/governance/vmware/restrict-vm-cpu-and-memory.sentinel)
-* [Enforce NFS 4.1 and Kerberos](https://github.com/hashicorp/terraform-guides/blob/master/governance/vmware/require_nfs41_and_kerberos.sentinel)
+* [Require Storage DRS to be enabled](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/vmware/require-storage-drs.sentinel)
+* [Restrict virtual disk size](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/vmware/restrict-vm-disk-size.sentinel)
+* [Restrict VM CPU count and memory](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel)
+* [Enforce NFS 4.1 and Kerberos](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/vmware/require_nfs41_and_kerberos.sentinel)


### PR DESCRIPTION
The governance section of the terraform-guides repository was reorganized into first-generation and second-generation policies.  All of the links on this page had to be updated.  Some point to older first-generation policies while others point to new secong-generation policies.