### PR TITLE
Two small CSS tweaks

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -100,9 +100,12 @@
       font-variant-caps: all-small-caps;
       color: #666;
       display: inline-block;
-      width: 40%;
       border: none;
       background: transparent;
+
+      &:first-child {
+        min-width: 6em;
+      }
     }
   }
 

--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -69,6 +69,7 @@
         display: block;
         padding: 15px;
         line-height: 20px;
+        cursor: pointer;
 
         svg {
           fill: $header-link-color;
@@ -89,15 +90,11 @@
         margin-right: 3px;
       }
 
-      &:hover {
-        cursor: pointer;
-
-        & > ul {
-          visibility: visible;
-          opacity: 1;
-          display: block;
-          transition: all 0.5s ease;
-        }
+      &:hover > ul {
+        visibility: visible;
+        opacity: 1;
+        display: block;
+        transition: all 0.5s ease;
       }
 
       ul {


### PR DESCRIPTION
- Keep the dropdown menus from lying to people.
- Keep the "Expand all" button from wrapping to two lines (while still keeping it from jumping around when it transforms). 