### PR TITLE
Add 0.12 upgrade callout to downloads page

### DIFF
--- a/content/source/downloads.html.erb
+++ b/content/source/downloads.html.erb
@@ -39,6 +39,10 @@ show_notification: true
       <p>
       Check out the <a href="https://github.com/hashicorp/terraform/blob/v<%= latest_version %>/CHANGELOG.md">v<%= latest_version %> CHANGELOG</a> for information on the latest release.
       </p>
+
+      <div class="alert alert-info" role="alert">
+        <p><strong>Note:</strong> When you upgrade to Terraform 0.12, your existing Terraform configurations might need syntax updates. You can make most of these updates automatically with the <code>terraform 0.12upgrade</code> command; for more information, see <a href="/upgrade-guides/0-12.html">Upgrading to Terraform 0.12</a>.</p>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
During the education/guides sync, someone mentioned that we had a trend of people opening tickets for 0.12 upgrade problems that could have been solved by following the upgrade guide (or even just ignoring the guide and running the `0.12upgrade` command sight unseen). 

We already link to the upgrade guides in the sidebar of the downloads page, but that's easy to ignore if you're not looking for it. We can probably save ourselves and our users some time by putting a blue callout box about the automatic syntax fixes here for, idk, the rest of the year or so. 

![Screenshot_2019-06-19 Download Terraform - Terraform by HashiCorp](https://user-images.githubusercontent.com/484309/59799974-5fb7a300-929a-11e9-9d1d-f1126d9d38da.png)