### PR TITLE
fixed iterate-over-modules links

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -270,7 +270,7 @@ main = rule { tfconfig.module_paths contains ["foo"] }
 #### Iterating Through Modules
 
 Iterating through all modules to find particular resources can be useful. This
-[example](iterate-over-modules) shows how to use `module_paths` with the
+[example][iterate-over-modules] shows how to use `module_paths` with the
 [`module()` function](#function-module-) to find all resources of a
 particular type from all modules using the `tfplan` import. By changing `tfplan`
 in this function to `tfconfig`, you could make a similar function find all

--- a/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfconfig.html.md
@@ -276,7 +276,7 @@ particular type from all modules using the `tfplan` import. By changing `tfplan`
 in this function to `tfconfig`, you could make a similar function find all
 resources of a specific type in the Terraform configuration.
 
-[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
+[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#iterate-over-modules-and-find-resources
 
 ## Namespace: Module
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -196,7 +196,7 @@ Iterating through all modules to find particular resources can be useful. This
 particular type from all modules that have pending changes using the `tfplan`
 import.
 
-[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
+[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#iterate-over-modules-and-find-resources
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -191,7 +191,7 @@ main = rule { tfplan.module_paths contains ["foo"] }
 #### Iterating Through Modules
 
 Iterating through all modules to find particular resources can be useful. This
-[example](iterate-over-modules) shows how to use `module_paths` with the
+[example][iterate-over-modules] shows how to use `module_paths` with the
 [`module()` function](#function-module-) to find all resources of a
 particular type from all modules that have pending changes using the `tfplan`
 import.

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -178,7 +178,7 @@ particular type from all modules using the `tfplan` import. By changing `tfplan`
 in this function to `tfstate`, you could make a similar function find all
 resources of a specific type in the current state.
 
-[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#to-find-resources-iterate-over-modules
+[iterate-over-modules]: /docs/enterprise/sentinel/import/index.html#iterate-over-modules-and-find-resources
 
 ### Value: `terraform_version`
 

--- a/content/source/docs/enterprise/sentinel/import/tfstate.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfstate.html.md
@@ -172,7 +172,7 @@ main = rule { tfstate.module_paths contains ["foo"] }
 #### Iterating Through Modules
 
 Iterating through all modules to find particular resources can be useful. This
-[example](iterate-over-modules) shows how to use `module_paths` with the
+[example][iterate-over-modules] shows how to use `module_paths` with the
 [`module()` function](#function-module-) to find all resources of a
 particular type from all modules using the `tfplan` import. By changing `tfplan`
 in this function to `tfstate`, you could make a similar function find all


### PR DESCRIPTION
When I changed a section header in index.html.md under sentine/import, I broke the iterate-over-modules links in the tfconfig.html.md, tfstate.html.md, and tfplan.html.md files.  This PR fixes those links.