### PR TITLE
Update and clarify usage of team tokens

### DIFF
--- a/content/source/docs/enterprise/users-teams-organizations/service-accounts.html.md
+++ b/content/source/docs/enterprise/users-teams-organizations/service-accounts.html.md
@@ -20,23 +20,25 @@ Like with [user tokens](./users.html#api-tokens), service account tokens are dis
 
 -> **API:** See the [Team Token API](../api/team-tokens.html).
 
+Team service accounts are designed to let automated systems (like CI/CD tools) perform Terraform runs and API operations with a specific set of workspace permissions.
+
+Team tokens have the same access level as their team. For example, if a team has write access to a given workspace, the team's token can be used to update that workspace's variables, run `terraform apply` in that workspace with the `remote` backend, and create and apply runs in that workspace via the API. If a team has plan access to a workspace, the team's token can run `terraform plan` or create speculative plans via the API, but cannot update variables or make changes to real infrastructure.
+
 To manage the API token for a team service account, go to **Organization settings > Teams > (desired team)** and use the controls under the "Team API Token" header.
 
 Each team can have **one** valid API token at a time, and any member of a team can generate or revoke that team's token. When a token is regenerated, the previous token immediately becomes invalid.
 
-Team service accounts are designed for performing API operations on workspaces. They have access to the same workspaces as their team, at the same access level; for example, if a team has write access to a workspace, the team's token can create runs and configuration versions via the API.
-
-Note that the individual members of a team can usually perform actions the team itself cannot, since users can belong to multiple teams, can belong to multiple organizations, and can authenticate with Terraform's `atlas` backend for running Terraform locally.
+Note that the individual members of a team can usually perform actions the team itself cannot, since users can belong to multiple teams in multiple organizations.
 
 ## Organization Service Accounts
 
 -> **API:** See the [Organization Token API](../api/organization-tokens.html).
 
+Organization service accounts are designed for creating and configuring workspaces and teams. We don't recommend using them as an all-purpose interface to TFE; their purpose is to do some initial setup before delegating a workspace to a team. For more routine interactions with workspaces, use team service accounts.
+
 To manage the API token for an organization service account, go to **Organization settings > API Token** and use the controls under the "Organization Tokens" header.
 
 Each organization can have **one** valid API token at a time. Only [organization owners](./teams.html#the-owners-team) can generate or revoke an organization's token.
-
-Organization service accounts are designed for creating and configuring workspaces and teams. We don't recommend using them as an all-purpose interface to TFE; their purpose is to do some initial setup before delegating a workspace to a team. For more routine interactions with workspaces, use team service accounts.
 
 Organization service accounts have permissions across the entire organization. They can perform all CRUD operations on most resources, but have some limitations; most importantly, they cannot start runs or create configuration versions. Any API endpoints that can't be used with an organization account include a note like the following:
 


### PR DESCRIPTION
Team tokens are the recommended way to do remote runs from CI/CD scripts.
In cases where SAML is enabled, they're the only viable option, since user
tokens go inactive if the user doesn't log in on schedule.