### PR TITLE
Tweak span.circle cursor behaviour

### DIFF
--- a/content/source/assets/stylesheets/_home.scss
+++ b/content/source/assets/stylesheets/_home.scss
@@ -308,6 +308,7 @@
     border: 1px solid $white;
     background-color: $black;
     box-sizing: border-box;
+    cursor: default;
     color: $white;
     font-family: $font-family-monospace;
     font-size: 16px;
@@ -316,6 +317,7 @@
     padding: 10px 20px 20px 20px;
 
     .terminal-content {
+      cursor: text;
       margin-top: 15px;
       overflow-x: scroll;
       width: 100%;


### PR DESCRIPTION
Before this PR, in the `terminal` sections, if you hover your cursor over the circles (mimicking a GUI window) then the cursor is textual and encourages the user highlight the circles, breaking the illusion of a terminal window.

Now it shows the default cursor, better befitting a window — unless you've hovering over the terminal content, where it is a textual cursor, as expected.