### PR TITLE
API: Terraform Enterprise Policy description attribute

### DIFF
--- a/content/source/docs/enterprise/api/policies.html.md
+++ b/content/source/docs/enterprise/api/policies.html.md
@@ -56,6 +56,7 @@ Key path                                | Type            | Default          | D
 ----------------------------------------|-----------------|------------------|------------
 `data.type`                             | string          |                  | Must be `"policies"`.
 `data.attributes.name`                  | string          |                  | The name of the policy, which cannot be modified after creation. Can include letters, numbers, `-`, and `_`.
+`data.attributes.description`           | string          | `null`           | A description of the policy's purpose. This field supports Markdown and will be rendered in the Terraform Enterprise UI.
 `data.attributes.enforce`               | array\[object\] |                  | An array of enforcement configurations which map Sentinel file paths to their enforcement modes. Currently policies only support a single file, so this array will consist of a single element. If the path in the enforcement map does not match the Sentinel policy (`<NAME>.sentinel`), then the default `hard-mandatory` will be used.
 `data.attributes.enforce[].path`        | string          |                  | Must be `<NAME>.sentinel`, where `<NAME>` has the same value as `data.attributes.name`.
 `data.attributes.enforce[].mode`        | string          | `hard-mandatory` | The enforcement level of the policy. Valid values are `"hard-mandatory"`, `"soft-mandatory"`, and `"advisory"`. For more details, see [Managing Policies](../sentinel/manage-policies.html).
@@ -73,7 +74,8 @@ Key path                                | Type            | Default          | D
           "mode": "hard-mandatory"
         }
       ],
-      "name": "my-example-policy"
+      "name": "my-example-policy",
+      "description": "An example policy."
     },
     "relationships": {
       "policy-sets": {
@@ -107,6 +109,7 @@ curl \
     "type":"policies",
     "attributes": {
       "name":"my-example-policy",
+      "description":"An example policy.",
       "enforce": [
         {
           "path":"my-example-policy.sentinel",
@@ -166,6 +169,7 @@ curl --request GET \
     "type": "policies",
     "attributes": {
       "name": "my-example-policy",
+      "description":"An example policy.",
       "enforce": [
         {
           "path": "my-example-policy.sentinel",
@@ -257,6 +261,7 @@ Key path                         | Type            | Default          | Descript
 ---------------------------------|-----------------|------------------|------------
 `data.type`                      | string          |                  | Must be `"policies"`.
 `data.attributes.name`           | string          | (Current name)   | Ignored if present.
+`data.attributes.description`    | string          | `null`           | A description of the policy's purpose. This field supports Markdown and will be rendered in the Terraform Enterprise UI.
 `data.attributes.enforce`        | array\[object\] |                  | An array of enforcement configurations which map Sentinel file paths to their enforcement modes. Currently policies only support a single file, so this array will consist of a single element. The value provided **replaces** the enforcement map. To make an incremental update, you can first fetch the current value of this map from the [show endpoint](#show-a-policy) and modify it. If the path in the enforcement map does not match the Sentinel policy (`<NAME>.sentinel`), then the default `hard-mandatory` will be used.
 `data.attributes.enforce[].path` | string          |                  | Must be `<NAME>.sentinel`, where `<NAME>` matches the original value of `data.attributes.name`.
 `data.attributes.enforce[].mode` | string          | `hard-mandatory` | The enforcement level of the policy. Valid values are `"hard-mandatory"`, `"soft-mandatory"`, and `"advisory"`. For more details, see [Managing Policies](../sentinel/manage-policies.html).
@@ -299,6 +304,7 @@ curl \
     "type":"policies",
     "attributes": {
       "name":"my-example-policy",
+      "description":"An example policy.",
       "enforce": [
         {
           "path":"my-example-policy.sentinel",
@@ -367,6 +373,7 @@ curl \
           }
         ],
         "name": "my-example-policy",
+        "description": "An example policy.",
         "policy-set-count": 0,
         "updated-at": "2017-10-10T20:52:13.898Z"
       },


### PR DESCRIPTION
CHANGELOG: Document the description attribute for Terraform Enterprise policies.

A small change to the API documentation to state that there is a `description` attribute for policies. This field is rendered in the Terraform Enterprise UI and returned in API calls for a policy.