### PR TITLE
API updates for Team

### DIFF
--- a/content/source/docs/enterprise/api/teams.html.md
+++ b/content/source/docs/enterprise/api/teams.html.md
@@ -107,6 +107,7 @@ Key path                              | Type   | Default   | Description
 -----------------------               |--------|-----------|------------
 `data.type`                           | string |           | Must be `"teams"`.
 `data.attributes.name`                | string |           | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.
+`data.attributes.visible` **(beta)**  | boolean | `false` | The visibility of the team within its organization. When `true`, the team can be seen by every user within that organization.
 `data.attributes.organization-access` | object | (nothing) | Settings for the team's organization access. This object can include `manage-policies`, `manage-workspaces`, and `manage-vcs-settings` properties with boolean values. All properties default to `false`.
 
 ### Sample Payload
@@ -144,6 +145,7 @@ $ curl \
   "data": {
     "attributes": {
       "name": "team-creation-test",
+      "visible": false,
       "organization-access": {
         "manage-policies": false,
         "manage-vcs-settings": false,
@@ -172,7 +174,7 @@ $ curl \
 }
 ```
 
-## Show Team Information
+## Show a Team
 
 `GET /teams/:team_id`
 
@@ -191,6 +193,7 @@ $ curl \
 ```
 
 ### Sample Response
+
 ```json
 {
   "data": {
@@ -198,6 +201,7 @@ $ curl \
     "type": "teams",
     "attributes": {
       "name": "team-creation-test",
+      "visible": false,
       "users-count": 0,
       "permissions": {
         "can-update-membership": true,
@@ -220,6 +224,100 @@ $ curl \
     "links": {
       "self": "/api/v2/teams/team-6p5jTwJQXwqZBncC"
     }
+  }
+}
+```
+
+## Update a Team
+
+`PATCH /teams/:team_id`
+
+Parameter   | Description
+------------|------------
+`:team_id`  | The team ID to be updated.
+
+Status  | Response                                | Reason
+--------|-----------------------------------------|----------
+[200][] | [JSON API document][] (`type: "teams"`) | Successfully created a team
+[400][] | [JSON API error object][]               | Invalid `include` parameter
+[404][] | [JSON API error object][]               | Team not found, or user unauthorized to perform action
+[422][] | [JSON API error object][]               | Malformed request body (missing attributes, wrong types, etc.)
+[500][] | [JSON API error object][]               | Failure during team creation
+
+
+### Request Body
+
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+Key path                              | Type   | Default   | Description
+-----------------------               |--------|-----------|------------
+`data.type`                           | string |           | Must be `"teams"`.
+`data.attributes.name`                | string |           | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.
+`data.attributes.visible` **(beta)**  | boolean | (previous value) | The visibility of the team within its organization. When `true`, the team can be seen by every user within that organization.
+`data.attributes.organization-access` | object | (nothing) | Settings for the team's organization access. This object can include `manage-policies`, `manage-workspaces`, and `manage-vcs-settings` properties with boolean values. All properties default to `false`.
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type": "teams",
+    "attributes": {
+      "visible": true,
+      "organization-access": {
+        "manage-vcs-settings": true
+      }
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PATCH \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/teams/team-6p5jTwJQXwqZBncC
+```
+
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "attributes": {
+      "name": "team-creation-test",
+      "visible": true,
+      "organization-access": {
+        "manage-policies": false,
+        "manage-vcs-settings": true,
+        "manage-workspaces": true
+      },
+      "permissions": {
+        "can-destroy": true,
+        "can-update-membership": true
+      },
+      "users-count": 0
+    },
+    "id": "team-6p5jTwJQXwqZBncC",
+    "links": {
+      "self": "/api/v2/teams/team-6p5jTwJQXwqZBncC"
+    },
+    "relationships": {
+      "authentication-token": {
+        "meta": {}
+      },
+      "users": {
+        "data": []
+      }
+    },
+    "type": "teams"
   }
 }
 ```


### PR DESCRIPTION
I intended to add the attribute `visible` to the Team API documentation, but noticed that the endpoint for updating a Team was missing itself. This PR includes that, as well as the aforementioned attribute, which is marked as **(beta)**.