### PR TITLE
Add Alert Banner click track event w/ necessary features to test variant text

### DIFF
--- a/content/source/assets/javascripts/analytics.js
+++ b/content/source/assets/javascripts/analytics.js
@@ -13,4 +13,15 @@ document.addEventListener('turbolinks:load', function() {
       product: 'terraform'
     }
   })
+
+  track('a.notification', function(el) {
+    var params = {
+      name: 'Alert Banner',
+      variant: el.innerText.replace(/\s+/g, ' ').trim()
+    }
+    // Create a stringified `label` prop of the event for GA tracking purposes
+    params.label = JSON.stringify(params)
+    params.event = 'CTA Clicked'
+    return params
+  })
 })


### PR DESCRIPTION
This PR adds an additional track event to the `.notification` Alert Banner-style elements