### PR TITLE
sentinel: tfplan, note that applied is omitted on destroyed resources

### DIFF
--- a/content/source/docs/enterprise/sentinel/import/tfplan.html.md
+++ b/content/source/docs/enterprise/sentinel/import/tfplan.html.md
@@ -394,6 +394,9 @@ are `undefined`. **In either case**, you should instead use the
 namespace](#namespace-resource-diff) to determine that a computed value will
 exist.
 
+-> If a resource is being destroyed, its `applied` value is omitted from the
+namespace and trying to fetch it will return undefined.
+
 ### Value: `diff`
 
 * **Value Type:** A map of [diff namespaces](#namespace-resource-diff).


### PR DESCRIPTION
This will be coming in an upcoming version of Terraform Cloud, which
is a correction to an issue of a destroyed resource's proposed state
still existing in various ways when it should be missing completely
from tfplan.