### PR TITLE
Adjusted the header level of 'Disk Resizing'

### DIFF
--- a/content/source/docs/enterprise/private/preflight-installer.html.md
+++ b/content/source/docs/enterprise/private/preflight-installer.html.md
@@ -162,7 +162,7 @@ The following are **supported** mounted disk types:
 * SAN
 * Physically connected disks as in non-cloud hardware
 
-##### Disk Resizing
+#### Disk Resizing
 
 Depending on your cloud or storage application, you may need to confirm the disk has been resized to above Private Terraform Enterprise's minimum disk size of 40GB.
 


### PR DESCRIPTION
It may have been a conscious decision, but the header level of "Disk Resizing" looked a bit goofy to me, so I made it a tad bigger to match "Supported Mounted Disk Types" and "Unsupported Mounted Disk Types".

[Relevant spot on the live site](https://www.terraform.io/docs/enterprise/private/preflight-installer.html#disk-resizing)