### PR TITLE
Deploy script: Treat .jpg files as images

### DIFF
--- a/content/scripts/deploy.sh
+++ b/content/scripts/deploy.sh
@@ -102,6 +102,8 @@ if [ -z "$NO_UPLOAD" ]; then
     --exclude "*" \
     --include "*.png" \
     --include "*.gif" \
+    --include "*.jpg" \
+    --include "*.jpeg" \
     --acl-public \
     --recursive \
     setacl "s3://hc-sites/$PROJECT/latest/"


### PR DESCRIPTION
There are only two JPEGs in the entire site, in the vmware reference
architecture for TFE. We could just convert them to PNGs, but also it seems
bizarre to not treat JPEGs as images, and I don't know for sure that this won't
happen again with another author.