### PR TITLE
Fix show state version code block

### DIFF
--- a/content/source/docs/cloud/api/state-versions.html.md
+++ b/content/source/docs/cloud/api/state-versions.html.md
@@ -323,7 +323,7 @@ curl \
 
 ## Show a State Version
 
-`GET /state-versions/:state_version_id
+`GET /state-versions/:state_version_id`
 
 Parameter | Description
 ----------|---------


### PR DESCRIPTION
This pr fixes the code block in the show state version section, it was missing the backtick at the end of the line.