### PR TITLE
Update middleman-hashicorp container and Gemfile.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.39"
+VERSION?="0.3.41"
 MKFILE_PATH=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DEPLOY_ENV?="development"
 

--- a/content/Gemfile
+++ b/content/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.39"
+gem "middleman-hashicorp", "0.3.41"

--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.6.1)
       execjs
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
@@ -41,8 +41,8 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    ffi (1.10.0)
-    haml (5.0.4)
+    ffi (1.11.1)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     hike (1.2.3)
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.39)
+    middleman-hashicorp (0.3.41)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -95,16 +95,16 @@ GEM
       sprockets (~> 2.12.1)
       sprockets-helpers (~> 1.1.0)
       sprockets-sass (~> 1.3.0)
-    middleman-syntax (3.0.0)
+    middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
-      rouge (~> 2.0)
+      rouge (~> 3.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     padrino-helpers (0.12.9)
       i18n (~> 0.6, >= 0.6.7)
@@ -117,16 +117,14 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    redcarpet (3.4.0)
-    rouge (2.2.1)
+    redcarpet (3.5.0)
+    rouge (3.9.0)
     sass (3.4.25)
-    sassc (2.0.1)
+    sassc (2.1.0-x86_64-linux)
       ffi (~> 1.9)
-      rake
     sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -157,7 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.39)
+  middleman-hashicorp (= 0.3.41)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Time marches on, and so do security vulnerabilities in Nokogiri. So it's time
for a new container.

As with last time, here's a reminder for the next person who needs to update
this:

- You shouldn't just update the dependency in Gemfile.lock, because your build
  times will go to heck as you compile Nokogiri from source on every run. So you
  need an updated container with all the dependencies.
- To update the container, you need to push a new tag to the middleman-hashicorp
  repo. Teamcity does the rest, and will ship a new container to Docker Hub
  (unless its credentials are out of date, in which case go ask team-eng-serv.)
- Once that's pushed:
    - Update Makefile
    - Update the Gemfile
    - Delete Gemfile.lock
    - `make website` until it comes up, then ctrl-C
    - Commit the changes