### PR TITLE
Update links and Terraform Enterprise references in GitHub Actions docs

### DIFF
--- a/content/source/docs/github-actions/actions/apply.html.md
+++ b/content/source/docs/github-actions/actions/apply.html.md
@@ -61,7 +61,7 @@ action "terraform init" {
 | `TF_ACTION_WORKING_DIR`  | `"."`                | Which directory `plan` runs in. Relative to the root of the repo.   |
 | `TF_ACTION_COMMENT`      | `"true"`             | Set to `"false"` to disable commenting back on pull request.        |
 | `TF_ACTION_WORKSPACE`    | `"default"`          | Which [Terraform workspace](/docs/state/workspaces.html) to run in. |
-| `TF_ACTION_TFE_HOSTNAME` | `"app.terraform.io"` | If using Private Terraform Enterprise set this to its hostname.     |
+| `TF_ACTION_TFE_HOSTNAME` | `"app.terraform.io"` | If using Terraform Enterprise, set this to its hostname.            |
 
 ## Workspaces
 
@@ -74,7 +74,7 @@ If you need to run `plan` in multiple workspaces, see [Workspaces](../workspaces
 | Name                  | Description                                                                                                                                                                                                                                   |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `GITHUB_TOKEN`        | Required for posting comments to the pull request unless `TF_ACTION_COMMENT = "false"`.                                                                                                                                                       |
-| `TF_ACTION_TFE_TOKEN` | If using the Terraform Enterprise [remote backend](/docs/backends/types/remote.html) set this secret to a [user API token](/docs/enterprise/users-teams-organizations/users.html#api-tokens). |
+| `TF_ACTION_TFE_TOKEN` | If using the Terraform Cloud [remote backend](/docs/backends/types/remote.html) set this secret to a [user API token](/docs/cloud/users-teams-organizations/users.html#api-tokens). |
 
 You'll also likely need to add secrets for your providers, like `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` or `GOOGLE_CREDENTIALS`.
 

--- a/content/source/docs/github-actions/actions/init.html.md
+++ b/content/source/docs/github-actions/actions/init.html.md
@@ -40,14 +40,14 @@ action "terraform init" {
 |--------------------------|----------------------|-------------------------------------------------------------------|
 | `TF_ACTION_WORKING_DIR`  | `"."`                | Which directory `init` runs in. Relative to the root of the repo. |
 | `TF_ACTION_COMMENT`      | `"true"`             | Set to `"false"` to disable commenting back on pull on error.     |
-| `TF_ACTION_TFE_HOSTNAME` | `"app.terraform.io"` | If using Private Terraform Enterprise set this to its hostname.   |
+| `TF_ACTION_TFE_HOSTNAME` | `"app.terraform.io"` | If using Terraform Enterprise, set this to its hostname.          |
 
 
 ## Secrets
 | Name                  | Description                                                                                                                                                                                                                                   |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `GITHUB_TOKEN`        | Required for posting comments to the pull request unless `TF_ACTION_COMMENT = "false"`.                                                                                                                                                       |
-| `TF_ACTION_TFE_TOKEN` | If using the Terraform Enterprise [remote backend](/docs/backends/types/remote.html) set this secret to a [user API token](/docs/enterprise/users-teams-organizations/users.html#api-tokens). |
+| `TF_ACTION_TFE_TOKEN` | If using the Terraform Cloud [remote backend](/docs/backends/types/remote.html) set this secret to a [user API token](/docs/cloud/users-teams-organizations/users.html#api-tokens). |
 
 **NOTE:** You may also need to add secrets for your providers, like `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` or `GOOGLE_CREDENTIALS`,
 if you're using a Terraform feature that uses them during `init` (such as Remote State).

--- a/content/source/docs/github-actions/actions/plan.html.md
+++ b/content/source/docs/github-actions/actions/plan.html.md
@@ -51,7 +51,7 @@ action "terraform init" {
 | `TF_ACTION_WORKING_DIR`  | `"."`                | Which directory `plan` runs in. Relative to the root of the repo.   |
 | `TF_ACTION_COMMENT`      | `"true"`             | Set to `"false"` to disable commenting back on pull request.        |
 | `TF_ACTION_WORKSPACE`    | `"default"`          | Which [Terraform workspace](/docs/state/workspaces.html) to run in. |
-| `TF_ACTION_TFE_HOSTNAME` | `"app.terraform.io"` | If using Private Terraform Enterprise set this to its hostname.     |
+| `TF_ACTION_TFE_HOSTNAME` | `"app.terraform.io"` | If using Terraform Enterprise, set this to its hostname.            |
 
 ## Workspaces
 
@@ -64,7 +64,7 @@ If you need to run `plan` in multiple workspaces, see [Workspaces](../workspaces
 | Name                  | Description                                                                                                                                                                                                                                   |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `GITHUB_TOKEN`        | Required for posting comments to the pull request unless `TF_ACTION_COMMENT = "false"`.                                                                                                                                                       |
-| `TF_ACTION_TFE_TOKEN` | If using the Terraform Enterprise [remote backend](/docs/backends/types/remote.html) set this secret to a [user API token](/docs/enterprise/users-teams-organizations/users.html#api-tokens). |
+| `TF_ACTION_TFE_TOKEN` | If using the Terraform Cloud [remote backend](/docs/backends/types/remote.html) set this secret to a [user API token](/docs/cloud/users-teams-organizations/users.html#api-tokens). |
 
 You'll also likely need to add secrets for your providers, like `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` or `GOOGLE_CREDENTIALS`.
 

--- a/content/source/docs/github-actions/remote-backend.html.md
+++ b/content/source/docs/github-actions/remote-backend.html.md
@@ -1,25 +1,25 @@
 ---
 layout: "github-actions"
-page_title: "Terraform Enterprise Remote Backend - Terraform GitHub Actions"
+page_title: "Terraform Cloud Remote Backend - Terraform GitHub Actions"
 sidebar_current: "docs-github-actions-remote-backend"
 ---
 
-# Terraform Enterprise Remote Backend
+# Terraform Cloud Remote Backend
 
-Terraform GitHub Actions supports Terraform Enterprise's [remote backend](/docs/backends/types/remote.html).
+Terraform GitHub Actions supports Terraform Cloud's [remote backend](/docs/backends/types/remote.html).
 
 To enable:
 
-1. Create a new secret `TF_ACTION_TFE_TOKEN` set to a Terraform Enterprise
- [user API token](/docs/enterprise/users-teams-organizations/users.html#api-tokens).
+1. Create a new secret `TF_ACTION_TFE_TOKEN` set to a Terraform Cloud
+ [user API token](/docs/cloud/users-teams-organizations/users.html#api-tokens).
 1. Add the secret to the `terraform-init` and `terraform-plan` actions.
-1. If you're using Private Terraform Enterprise, set the `TF_ACTION_TFE_HOSTNAME`
-   environment variable to your Private Terraform Enterprise's hostname.
+1. If you're using Terraform Enterprise, set the `TF_ACTION_TFE_HOSTNAME`
+   environment variable to your Terraform Enterprise instance's hostname.
 
 Example:
 
 ```hcl
-workflow "Terraform Enterprise" {
+workflow "Terraform Cloud" {
   resolves = "terraform-plan"
   on = "pull_request"
 }


### PR DESCRIPTION
I THINK these are the last remaining broken links that've been bedeviling our Travis runs. (They're not broken in prod, they're redirected. But they should be updated anyway.)