### PR TITLE
Redirect Google provider moved pages

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -146,8 +146,9 @@
 /docs/providers/azurerm/authenticating_via_azure_cli.html         /docs/providers/azurerm/auth/azure_cli.html
 /docs/providers/azurerm/authenticating_via_msi.html               /docs/providers/azurerm/auth/managed_service_identity.html
 
-# Fixing terraform-provider-google#2197
+# Google Provider
 /docs/provider/google/provider_versions.html          /docs/providers/google/provider_versions.html
+/docs/providers/google/r/bigquery_dataset.html        /docs/providers/google/r/big_query_dataset.html
 
 # Move content to learn.hashicorp.com:
 # These redirects are inert in this file, because they need a "real" Varnish

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -147,11 +147,11 @@
 /docs/providers/azurerm/authenticating_via_msi.html               /docs/providers/azurerm/auth/managed_service_identity.html
 
 # Google Provider
-/docs/provider/google/provider_versions.html          /docs/providers/google/provider_versions.html
-/docs/providers/google/r/big_query_dataset.html        /docs/providers/google/r/bigquery_dataset.html
-/docs/providers/google/r/cloud_build_trigger.html        /docs/providers/google/r/cloudbuild_trigger.html
-/docs/providers/google/r/security_center_source.html        /docs/providers/google/r/scc_source.html
-/docs/providers/google/r/source_repo_repository.html        /docs/providers/google/r/sourcerepo_repository.html
+/docs/provider/google/provider_versions.html                    /docs/providers/google/provider_versions.html
+/docs/providers/google/r/big_query_dataset.html                 /docs/providers/google/r/bigquery_dataset.html
+/docs/providers/google/r/cloud_build_trigger.html               /docs/providers/google/r/cloudbuild_trigger.html
+/docs/providers/google/r/security_center_source.html            /docs/providers/google/r/scc_source.html
+/docs/providers/google/r/source_repo_repository.html            /docs/providers/google/r/sourcerepo_repository.html
 /docs/providers/google/r/source_repo_repository_iam.html        /docs/providers/google/r/sourcerepo_repository_iam.html
 
 # Move content to learn.hashicorp.com:

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -148,7 +148,11 @@
 
 # Google Provider
 /docs/provider/google/provider_versions.html          /docs/providers/google/provider_versions.html
-/docs/providers/google/r/bigquery_dataset.html        /docs/providers/google/r/big_query_dataset.html
+/docs/providers/google/r/big_query_dataset.html        /docs/providers/google/r/bigquery_dataset.html
+/docs/providers/google/r/cloud_build_trigger.html        /docs/providers/google/r/cloudbuild_trigger.html
+/docs/providers/google/r/security_center_source.html        /docs/providers/google/r/scc_source.html
+/docs/providers/google/r/source_repo_repository.html        /docs/providers/google/r/sourcerepo_repository.html
+/docs/providers/google/r/source_repo_repository_iam.html        /docs/providers/google/r/sourcerepo_repository_iam.html
 
 # Move content to learn.hashicorp.com:
 # These redirects are inert in this file, because they need a "real" Varnish


### PR DESCRIPTION
Context: https://github.com/terraform-providers/terraform-provider-google-beta/pull/1028/files#diff-65a56644793884c92585c3275b38b6b8L222

Redirects for pages that were moved in https://github.com/GoogleCloudPlatform/magic-modules/pull/2257

/cc @paddycarver