### PR TITLE
Add rel="canonical" links to every page, pointing to terraform.io

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="<%= description_for(current_page) %>">
 
+    <link rel="canonical" href="<%= File.join(base_url, current_page.url) %>" />
     <link rel="apple-touch-icon" sizes="180x180" href="<%= image_path("favicons/apple-touch-icon.png") %>">
     <link rel="icon" type="image/png" href="<%= image_path("favicons/favicon-32x32.png") %>" sizes="32x32">
     <link rel="icon" type="image/png" href="<%= image_path("favicons/favicon-16x16.png") %>" sizes="16x16">


### PR DESCRIPTION
We discovered that a random copy of the website on the public internet (at an IP
address we didn't recognize) was being indexed by Google and rated more highly
than the terraform.io copy for a particular search.

We can make future accidental copies harmless by marking the real version as
canonical; that should tell search engines to ignore your random test build and
point people to us.

Of course, malicious copies can just remove the canonical link, but we can issue
takedowns or something for those because they're probably also doing something
legitimately bad.