### PR TITLE
Fix syntax on test case example

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -74,9 +74,9 @@ a new testcase object:
 package example
 
 func TestAccExampleWidget_basic(t *testing.T) {
-  resource.Test(t, resource.TestCase){
+  resource.Test(t, resource.TestCase{
   	// ...
-  }
+  })
 }
 ```
 

--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -125,7 +125,7 @@ func TestAccExampleWidget_basic(t *testing.T) {
   resource.Test(t, resource.TestCase{
     PreCheck:     func() { testAccPreCheck(t) },
   	// ...
-  }
+  })
 }
 
 
@@ -166,7 +166,7 @@ func TestAccExampleWidget_basic(t *testing.T) {
     PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
   	// ...
-  }
+  })
 }
 
 // File: example/provider_test.go
@@ -209,7 +209,7 @@ func TestAccExampleWidget_basic(t *testing.T) {
     Providers:    testAccProviders,
     CheckDestroy: testAccCheckExampleResourceDestroy,
     // ...
-  }
+  })
 }
 
 // testAccCheckExampleResourceDestroy verifies the Widget 


### PR DESCRIPTION
`resource.TestCase` is a `struct` that is passed as a parameter to the `resource.Test` function, so the parentheses should be placed at the end of the function call.