### PR TITLE
Fix indentation in code sample for resource.TestCase Providers

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -164,7 +164,7 @@ package example
 func TestAccExampleWidget_basic(t *testing.T) {
   resource.Test(t, resource.TestCase{
     PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+    Providers:    testAccProviders,
   	// ...
   }
 }


### PR DESCRIPTION
Seems like there was a tab char instead of spaces that was being rendered as 8 spaces causing the `struct` fields to look misaligned.