### PR TITLE
Fix the navigation sidebar title for migrating from Local Terraform

### DIFF
--- a/content/source/layouts/cloud.erb
+++ b/content/source/layouts/cloud.erb
@@ -34,7 +34,7 @@
       </li>
 
       <li>
-        <a href="/docs/cloud/migrate/index.html">Migrating from Open Source</a>
+        <a href="/docs/cloud/migrate/index.html">Migrating from Local Terraform</a>
         <ul class="nav">
           <li>
             <a href="/docs/cloud/migrate/workspaces.html">Migrating Multiple Workspaces</a>


### PR DESCRIPTION
In https://github.com/hashicorp/terraform-website/pull/865, the migration document has changed to mention Terraform Cloud, but it seems like the navigation sidebar title hasn't been updated