### PR TITLE
WIP: Update Sentinel tag enforcement for AWS to point at second generation

### DIFF
--- a/content/source/docs/cloud/sentinel/examples.html.md
+++ b/content/source/docs/cloud/sentinel/examples.html.md
@@ -12,7 +12,7 @@ This page lists some example Sentinel policies. These examples are not exhaustiv
 ### Amazon Web Services
 
 * [Enforce owner allow list on `aws_ami` data source](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/enforce-ami-owners.sentinel)
-* [Enforce mandatory tags on instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/enforce-mandatory-tags.sentinel)
+* [Enforce mandatory tags on instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/aws/enforce-mandatory-tags.sentinel)
 * [Restrict availability zones](https://github.com/hashicorp/terraform-guides/blob/master/governance/first-generation/aws/restrict-aws-availability-zones.sentinel)
 * [Disallow 0.0.0.0/0 CIDR blocks](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel)
 * [Restrict instance types of EC2 instances](https://github.com/hashicorp/terraform-guides/blob/master/governance/second-generation/aws/restrict-ec2-instance-type.sentinel)


### PR DESCRIPTION
We've seen a few situations lately where people have referred to the first generation of the AWS tag enforcement Sentinel policy and have ran into issues due to not compensating for destroyed resources.

Initially I'd considered updating all of the links within the example pages to point at the second generation, however, there are some that show up on both generations and some that don't. I'm more than happy to add the others/change things around more, but wanted to focus on getting this one corrected as a starting point.