### PR TITLE
Doc additional tf 012 sentinel diffs

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -118,7 +118,7 @@ vcs_repo (map of keys)
 ## Namespace: cost_estimate
 
 The **cost_estimation namespace** contains data associated with the current run's cost estimate. This
-namespace is only present if a cost estimate is available. Note that cost estimates are never
+namespace is only present if a cost estimate is available. Note that cost estimates are not
 available for Terraform 0.11.
 
 ### Value: `prior_monthly_cost`

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -118,7 +118,8 @@ vcs_repo (map of keys)
 ## Namespace: cost_estimate
 
 The **cost_estimation namespace** contains data associated with the current run's cost estimate. This
-namespace is only present if cost a estimate is available.
+namespace is only present if a cost estimate is available. Note that cost estimates are never
+available for Terraform 0.11.
 
 ### Value: `prior_monthly_cost`
 

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -210,7 +210,7 @@ the `tfplan` import.  Since these values are available with both Terraform
 see if a resource is being destroyed and not re-created with both versions of
 Terraform.
 
-Please note that if you are using a private instance of Terraform Enterprise,
+Please note that if you are using Terraform Enterprise,
 you must use version v201909-1 or higher in order to use the `destroy` and
 `requires_new` values.
 

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -188,7 +188,7 @@ to validate whether or not a value is unknown before looking for it in
 
 In Terraform 0.11, when a resource is being destroyed but not re-created, it's
 [`diff`](./import/tfplan.html#value-diff) value in the `tfplan` import is empty.
-In Terraform 0.12, however, the `diff` value does has data. For both versions of
+In Terraform 0.12, however, the `diff` value does have data. For both versions of
 Terraform, the [`applied`](./import/tfplan.html#value-applied) value will be
 absent.
 

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -29,7 +29,7 @@ checks and comparisons done against numeric attributes.
 
 There are no explicit changes in the [`tfrun`](./import/tfrun.html) import for
 Terrraform 0.12, but the
-[`cost_estimate namespace`](./import/tfrun.html#namespace-cost_estimate)
+[`cost_estimate` namespace](./import/tfrun.html#namespace-cost_estimate)
 does not appear in it for Terraform 0.11 since cost estimates are not available
 in workspaces that use Terraform 0.11.
 

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -188,26 +188,24 @@ to validate whether or not a value is unknown before looking for it in
 
 In Terraform 0.11, when a resource is being destroyed but not re-created, it's
 [`diff`](./import/tfplan.html#value-diff) value in the `tfplan` import is empty.
-In Terraform 0.12, however, the `diff` value does have data. For both versions of
-Terraform, the [`applied`](./import/tfplan.html#value-applied) value will be
-absent.
+In Terraform 0.12, however, the `diff` value does have data. Existing policies
+that test the condition `length(r.diff) == 0` to determine whether a resource
+is being destroyed but not re-created need to be updated for use with Terraform
+0.12.
 
-It is therefore recommended to check whether resources are being destroyed and
-not re-created in all Sentinel policies that use the `tfplan` import and the
-`applied` value in order to avoid `undefined` values in your functions and
-rules.
+Additionally, a change made in the `tfplan` import means that the
+[`applied`](./import/tfplan.html#value-applied) value is absent when a
+resource is being destroyed but not re-created for both versions of Terraform.
+It is therefore very important to check whether this is the case in all Sentinel
+policies that use the `tfplan` import and the `applied` value to avoid
+`undefined` values in functions and rules.
 
-Before Terraform 0.12 was released, some Sentinel policies tested whether
-a resource was being destroyed and not re-created by testing the condition
-`length(r.diff) == 0`. However, that cannot be used with Terraform 0.12.
-
-Fortunately, after Terraform 0.12 was released, new
-[`destroy`](./import/tfplan.html#value-destroy) and
-[`requires_new`](./import/tfplan.html#value-requires_new) values were added to
-the `tfplan` import. Since these values are available both for Terraform
-0.11 and 0.12, you can now simply test `r.destroy and not r.requires_new` to
-see if a resource is being destroyed and not re-created with both versions of
-Terraform.
+New [`destroy`](./import/tfplan.html#value-destroy) and
+[`requires_new`](./import/tfplan.html#value-requires_new) values have been added
+to the `tfplan` import to enable this check. Since these values are available
+both for Terraform 0.11 and 0.12, you can now test
+`r.destroy and not r.requires_new` to determine if a resource is being destroyed
+but not re-created with both versions of Terraform.
 
 Please note that if you are using Terraform Enterprise,
 you must use version v201909-1 or higher in order to use the `destroy` and

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -27,14 +27,15 @@ that numeric attributes of resources are now treated as floats in Terraform
 these attributes as strings. In particular, you might have to modify existence
 checks and comparisons done against numeric attributes.
 
-There are no explicit changes in the `tfrun` import for Terrraform 0.12, but
-the [`cost_estimate namespace`](./import/tfrun.html#namespace-cost_estimate)
-does not appear in the `tfrun` import for Terraform 0.11 since cost estimates
-are not available in workspaces that use Terraform 0.11.
+There are no explicit changes in the [`tfrun`](./import/tfrun.html) import for
+Terrraform 0.12, but the
+[`cost_estimate namespace`](./import/tfrun.html#namespace-cost_estimate)
+does not appear in it for Terraform 0.11 since cost estimates are not available
+in workspaces that use Terraform 0.11.
 
 ## Changes to `tfconfig`
 
-Terraform 0.12 no longer exports raw configuration to Sentinel and as such the
+Terraform 0.12 no longer exports raw configuration to Sentinel, so the
 [`tfconfig`](./import/tfconfig.html) import has seen the
 most profound changes, with the introduction of the `references` key in several
 of the namespaces within the import. Certain block values (such as maps) are
@@ -45,7 +46,7 @@ correctness in their definition in Terraform 0.12.
 
 In Terraform 0.12, configuration values that do not contain static, constant
 values can no longer be referenced directly within their respective `config` or
-`value` keys. Attempting to do so will yield an undefined value.
+`value` keys. Attempting to do so will yield an `undefined` value.
 
 Instead, any identifiers referenced directly in an expression or via
 interpolation are now added to a `references` value, mirroring the structure of
@@ -167,13 +168,11 @@ following exceptions:
 
 ### Changes to Unknown Values in `applied`
 
-Unknown values within
-[`applied`](./import/tfplan.html#value-applied) in the
-[resource
-namespace](./import/tfplan.html#namespace-resources-data-sources)
+Unknown values within `applied` in the
+[resource namespace](./import/tfplan.html#namespace-resources-data-sources)
 no longer return the magic UUID value (defined as
 `74D93920-ED26-11E3-AC10-0800200C9A66` in Terraform 0.11 or earlier). Instead,
-unknown values are now returned as undefined.
+unknown values are now returned as `undefined`.
 
 As mentioned within the documentation for `tfplan`, relying on specific behavior
 of unknown data within `applied` is not supported. Instead, it is recommended to
@@ -194,11 +193,10 @@ is being destroyed but not re-created need to be updated for use with Terraform
 0.12.
 
 Additionally, a change made in the `tfplan` import means that the
-[`applied`](./import/tfplan.html#value-applied) value is absent when a
-resource is being destroyed but not re-created for both versions of Terraform.
-It is therefore very important to check whether this is the case in all Sentinel
-policies that use the `tfplan` import and the `applied` value to avoid
-`undefined` values in functions and rules.
+`applied` value is absent when a resource is being destroyed but not re-created
+for both versions of Terraform. It is therefore very important to check whether
+this is the case in all Sentinel policies that use the `tfplan` import and the
+`applied` value to avoid `undefined` values in functions and rules.
 
 New [`destroy`](./import/tfplan.html#value-destroy) and
 [`requires_new`](./import/tfplan.html#value-requires_new) values have been added

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -205,7 +205,7 @@ the `diff` will not be empty for such a resource.
 Fortunately, after Terraform 0.12 was released, new
 [`destroy`](./import/tfplan.html#value-destroy) and
 [`requires_new`](./import/tfplan.html#value-requires_new) values were added to
-the `tfplan` import.  Since these values are available with both Terraform
+the `tfplan` import. Since these values are available with both Terraform
 0.11 and 0.12, you can now simply test `r.destroy and not r.requires_new` to
 see if a resource is being destroyed and not re-created with both versions of
 Terraform.

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -28,7 +28,7 @@ these attributes as strings. In particular, you might have to modify existence
 checks and comparisons done against numeric attributes.
 
 There are no explicit changes in the `tfrun` import for Terrraform 0.12, but
-the [`cost_estimate` namespace](./import/tfrun.html#namespace-cost_estimate)
+the [`cost_estimate namespace`](./import/tfrun.html#namespace-cost_estimate)
 does not appear in the `tfrun` import for Terraform 0.11 since cost estimates
 are not available in workspaces that use Terraform 0.11.
 

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -187,25 +187,24 @@ to validate whether or not a value is unknown before looking for it in
 ### Changes Affecting Resources Being Destroyed but not Re-created
 
 In Terraform 0.11, when a resource is being destroyed but not re-created, it's
-[`diff`](./import/tfplan.html#value-diff) value in the `tfplan` import is empty
-while its [`applied`](./import/tfplan.html#value-applied) value has data. In
-Terraform 0.12, the situation is reversed; the `diff` value has data while the
-`applied` value is empty.
+[`diff`](./import/tfplan.html#value-diff) value in the `tfplan` import is empty.
+In Terraform 0.12, however, the `diff` value does has data. For both versions of
+Terraform, the [`applied`](./import/tfplan.html#value-applied) value will be
+absent.
 
-It is therefore recommended to check whether Terraform 0.12 resources are being
-destroyed and not re-created in all Sentinel policies that use the `tfplan`
-import and the `applied` value in order to avoid `undefined` values in your
-functions and rules.
+It is therefore recommended to check whether resources are being destroyed and
+not re-created in all Sentinel policies that use the `tfplan` import and the
+`applied` value in order to avoid `undefined` values in your functions and
+rules.
 
 Before Terraform 0.12 was released, some Sentinel policies tested whether
 a resource was being destroyed and not re-created by testing the condition
-`length(r.diff) == 0`. However, that cannot be used with Terraform 0.12 since
-the `diff` will not be empty for such a resource.
+`length(r.diff) == 0`. However, that cannot be used with Terraform 0.12.
 
 Fortunately, after Terraform 0.12 was released, new
 [`destroy`](./import/tfplan.html#value-destroy) and
 [`requires_new`](./import/tfplan.html#value-requires_new) values were added to
-the `tfplan` import. Since these values are available with both Terraform
+the `tfplan` import. Since these values are available both for Terraform
 0.11 and 0.12, you can now simply test `r.destroy and not r.requires_new` to
 see if a resource is being destroyed and not re-created with both versions of
 Terraform.


### PR DESCRIPTION
This PR points out some additional important differences in Sentinel between Terraform 0.11 and 0.12.

I added additional differences between how Sentinel behaves in Terraform 0.11 and 0.12
Near the beginning of this document, I mention that numeric attributes are now treated as floats.
Also, since we now have the tfrun import (which did not exist when this document was first written), I added a paragraph about that, saying that there are no cost_estimate data in Terraform 0.11.
I also described the diffences when resources are destroyed but not re-created, referring to the new destroy and requires_new attributes.

I also corrected a typo "cost a estimate" to "a cost estimate" in the tfrun doc and mentioned that cost estimates are never available in Terraform 0.11

