### PR TITLE
Change tfe description

### DIFF
--- a/content/source/docs/cloud/index.html.md
+++ b/content/source/docs/cloud/index.html.md
@@ -15,7 +15,7 @@ This is the documentation for Terraform Cloud.
 
 Terraform Cloud is available as a hosted service at [https://app.terraform.io](https://app.terraform.io). We offer free accounts for small teams, and paid plans with additional feature sets for medium-sized businesses.
 
-Large enterprises can purchase [Terraform Enterprise](/docs/enterprise/index.html), our on-premise distribution of Terraform Cloud. It offers enterprises a private instance of the Terraform Cloud application, with no resource limits and with additional enterprise-grade architectural features like audit logging and SAML single sign-on.
+Large enterprises can purchase [Terraform Enterprise](/docs/enterprise/index.html), our self-hosted distribution of Terraform Cloud. It offers enterprises a private instance of the Terraform Cloud application, with no resource limits and with additional enterprise-grade architectural features like audit logging and SAML single sign-on.
 
 ### Note About Product Names
 

--- a/content/source/docs/enterprise/index.html.md
+++ b/content/source/docs/enterprise/index.html.md
@@ -9,7 +9,7 @@ This is the documentation for Terraform Enterprise.
 
 ## About Terraform Cloud and Terraform Enterprise
 
-Terraform Enterprise is our on-premise distribution of Terraform Cloud. It offers enterprises a private instance of the Terraform Cloud application, with no resource limits and with additional enterprise-grade architectural features like audit logging and SAML single sign-on.
+Terraform Enterprise is our self-hosted distribution of Terraform Cloud. It offers enterprises a private instance of the Terraform Cloud application, with no resource limits and with additional enterprise-grade architectural features like audit logging and SAML single sign-on.
 
 [Terraform Cloud](https://www.hashicorp.com/products/terraform/) is an application that helps teams use Terraform together. It manages Terraform runs in a consistent and reliable environment, and includes easy access to shared state and secret data, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more.
 


### PR DESCRIPTION
It is incorrect to describe TFE as "on-premise".  While it is on-premise when installed on VMware, it is often installed in virtual private networks (VPCs) in AWS, Azure, and Google Compute Cloud.  So, it is better to use the term "self-hosted" which is also what we use on https://www.hashicorp.com/products/terraform/pricing