### PR TITLE
Tidy up header layout, and enable registry links

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -22,6 +22,11 @@ document.addEventListener("turbolinks:load", function() {
     // - Subnavs are collapsed (<ul> hidden) or expanded (<ul> visible).
     // - Collapse/expand is managed by the "active" class on the <li>.
 
+    // Move the header (if any) into the grid container so we can make things line up nicely.
+    var sidebarHeaderGrid = $("#sidebar-header-grid");
+    var sidebarHeader = $("#docs-sidebar").children("h1,h2,h3,h4,h5,h6").not("#otherdocs").first();
+    sidebarHeaderGrid.append(sidebarHeader);
+
     // Collapse most subnavs, but reveal any that contain the
     // current page. The a.current-page class is added during build by
     // layouts/inner.erb.
@@ -74,12 +79,7 @@ document.addEventListener("turbolinks:load", function() {
                         '<button id="filter-button" title="Shortcut: type the / key">Filter</button>' +
                     '</div>' +
                 '</div>';
-            var sidebarHeader = $("#docs-sidebar").children("h1,h2,h3,h4,h5,h6").not("#otherdocs").first();
-            if (sidebarHeader.length === 1) { // under first header
-                sidebarHeader.after(sidebarControlsHTML);
-            } else { // under skip link
-                $("#docs-sidebar #controls-placeholder").replaceWith(sidebarControlsHTML);
-            }
+            sidebarHeaderGrid.append(sidebarControlsHTML);
         }
 
         var filterDiv = $("div#sidebar-filter");
@@ -163,12 +163,16 @@ document.addEventListener("turbolinks:load", function() {
     }
 
 
+    // Move the main title into the grid container, so we can make things line up nicely.
+    var innerHeaderGrid = $('#inner-header-grid');
+    innerHeaderGrid.append( $("#inner h1").first() );
+
     // On docs/content pages, add a hierarchical quick nav menu if there are
     // more than two H2/H3/H4 headers.
     var headers = $('#inner').find('h2, h3, h4');
     if (headers.length > 2 && $("div#inner-quicknav").length === 0) {
         // Build the quick-nav HTML:
-        $("#inner h1").first().after(
+        innerHeaderGrid.append(
             '<div id="inner-quicknav">' +
                 '<span id="inner-quicknav-trigger">' +
                     'Jump to Section' +

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -35,6 +35,11 @@
     grid-template-rows: minmax(90px, auto) 32px; // match #inner-header-grid
     margin-bottom: 16px;
 
+    margin-top: 20px; // fallback for non-grid browsers
+    @supports (display: grid) {
+      margin-top: 0;
+    }
+
     h3, h4 {
       grid-column: 1/2;
       grid-row: 1/2;

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -39,7 +39,7 @@
       grid-column: 1/2;
       grid-row: 1/2;
       align-self: self-end;
-      line-height: 36px; // align baseline w/ H1 in inner
+      line-height: 26px; // align baseline w/ H1 in inner
     }
 
     #sidebar-controls {

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -29,16 +29,29 @@
     color: $body-link-color;
   }
 
+  #sidebar-header-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(90px, auto) 32px; // match #inner-header-grid
+    margin-bottom: 16px;
+
+    h3, h4 {
+      grid-column: 1/2;
+      grid-row: 1/2;
+      align-self: self-end;
+      line-height: 36px; // align baseline w/ H1 in inner
+    }
+
+    #sidebar-controls {
+      grid-column: 1/2;
+      grid-row: 2/3;
+      align-self: self-start;
+    }
+  }
+
   h3,
   h4 {
-    min-height: 35px;
-    margin-top: 32px;
-    // This is just for vertical alignment. We don't need "real" flex behavior,
-    // we just need to align the text to the middle of the box instead of the
-    // top.
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap; // in case of inner inline elements
+    margin-top: 0;
     margin-bottom: 0;
     a {
       color: $body-link-color;
@@ -57,15 +70,9 @@
     }
   }
 
-  h4 + div#sidebar-controls {
-    margin-top: 0;
-  }
-
   div#sidebar-controls {
-    margin-top: 65px; // if no header
     box-sizing: border-box;
     position: relative;
-    height: 37px;
     .glyphicon-search {
       position: absolute;
       top: 7px;
@@ -117,7 +124,7 @@
   ul.nav.docs-sidenav {
     display: block;
     padding-bottom: 15px;
-    padding-top: 10px;
+    margin-top: 10px;
 
     li {
       padding: 0 0 11px 0;

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -1,11 +1,36 @@
 #inner {
+
+  #inner-header-grid {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: minmax(90px, auto) 32px; // match #sidebar-header-grid
+    margin-bottom: 16px;
+
+    h1 {
+      grid-column: 1/2;
+      grid-row: 1/2;
+      align-self: self-end;
+      line-height: 44px; // align baseline w/ H4 in sidebar
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  #external-docs-link {
+    grid-column: 2/3;
+    grid-row: 1/2;
+    align-self: self-end;
+    line-height: 36px;
+    margin-left: 12px;
+  }
+
   #inner-quicknav {
-    margin-top: -15px;
-    margin-bottom: 25px;
     margin-left: 10px;
+    grid-column: 1/3;
+    grid-row: 2/3;
+    align-self: self-start;
 
     span {
-      line-height: 20px;
       cursor: pointer;
       font-variant-caps: all-small-caps;
       color: #666;
@@ -153,18 +178,7 @@
     overflow-wrap: break-word;
   }
 
-  // Special treatment to align baseline with sidebar header
-  h1 {
-    min-height: 60px;
-    margin-top: 5px;
-    // This is just for vertical alignment. We don't need "real" flex behavior,
-    // we just need to align the text on the bottom of the box instead of the
-    // top.
-    display: flex;
-    align-items: flex-end;
-    flex-wrap: wrap; // in case of inner inline elements
-  }
-
+  h1,
   h2,
   h3,
   h4 {

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -20,7 +20,7 @@
     grid-column: 2/3;
     grid-row: 1/2;
     align-self: self-end;
-    line-height: 36px;
+    line-height: 26px;
     margin-left: 12px;
   }
 

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -6,6 +6,11 @@
     grid-template-rows: minmax(90px, auto) 32px; // match #sidebar-header-grid
     margin-bottom: 16px;
 
+    margin-top: 20px; // fallback for non-grid browsers
+    @supports (display: grid) {
+      margin-top: 0;
+    }
+
     h1 {
       grid-column: 1/2;
       grid-row: 1/2;

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -5,6 +5,7 @@
       <a href="#inner" id="screenreader-skip" class="sr-only sr-only-focusable">Skip to content</a>
       <a href="#inner" id="mobile-skip" class="visible-xs">(Skip to content ⤵︎)</a>
       <div id="controls-placeholder" style="display: none;"></div>
+      <div id="sidebar-header-grid"></div>
       <% if content_for?(:sidebar) %>
       <%
         sidebar_text = yield_content(:sidebar)
@@ -16,6 +17,10 @@
     </div>
 
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">
+      <div id="inner-header-grid">
+        <div id="external-docs-link">
+        </div>
+      </div>
       <%= yield %>
     </div>
   </div>

--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -16,9 +16,17 @@
       <% end %>
     </div>
 
+    <%
+      external_docs_links = {
+        # '/docs/providers/aws/index.html' => 'https://registry.terraform.io/path/to/provider',
+      }
+    %>
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">
       <div id="inner-header-grid">
         <div id="external-docs-link">
+          <% if external_docs_links[current_page.url] %>
+            <a href="<%= external_docs_links[current_page.url] %>">View on Terraform Registry <span class="glyphicon glyphicon-new-window" aria-hidden="true" /></a>
+          <% end %>
         </div>
       </div>
       <%= yield %>


### PR DESCRIPTION
This CSS was a mess (full disclosure: _my_ mess), so here's a better approach using only grid, align-self, and line-height.

The goal here:

- The baselines of the main page title and the sidebar title (if present) need to more or less line up. 
- The dynamic navigation controls (expand/filter and "jump to section") need to line up. 
- Two-line page titles happen fairly frequently, so they should look reasonable and not misalign things. (Three-line titles are rare, so they can go ahead and misalign things.)

### Screenshots

#### Looks about the same, which was the hope. 

![Screenshot_2019-11-07 Pre-Install Checklist - Before Installing - Terraform Enterprise - Terraform by HashiCorp](https://user-images.githubusercontent.com/484309/68439414-56ad6c80-017c-11ea-99d8-b17bcdfb7939.png)

#### With gridlines turned on: 

![Screenshot_2019-11-07 Pre-Install Checklist - Before Installing - Terraform Enterprise - Terraform by HashiCorp(1)](https://user-images.githubusercontent.com/484309/68439423-6036d480-017c-11ea-91da-2b5bf03f7ddd.png)

#### Baselines don't look too far off. Pardon my improvised ruler. 

![Screen Shot 2019-11-07 at 4 17 05 PM](https://user-images.githubusercontent.com/484309/68439435-6c229680-017c-11ea-91c1-5cf9ea2ccf25.png)

![Screen Shot 2019-11-07 at 4 17 24 PM](https://user-images.githubusercontent.com/484309/68439436-6cbb2d00-017c-11ea-9563-f49b16c5aceb.png)

### Also

The reason I'm doing this now is because the registry team needs to be able to link to registry pages from the front page of a given provider's documentation, without having to edit that provider's actual docs text. The second commit shows how we can do that (without turning it on for any pages yet), and the CSS follows the design I was given for those links. 

![Screen Shot 2019-11-07 at 4 27 32 PM](https://user-images.githubusercontent.com/484309/68439437-6cbb2d00-017c-11ea-87e6-cf8a54c97605.png)

Baselines line up for that link, too. The square-with-arrow icon is just pulled out of the Bootstrap stuff that's already available, but I can swap in a tidier-looking SVG if you've got one for me. 

If there's no link enabled for a page, that grid column just squishes down and stays out of the way. 

-----

Notable drawback: Since this uses javascript to arrange things up top, it can look a little goofy if you have javascript disabled.

![image](https://user-images.githubusercontent.com/484309/69467084-66f84680-0d3b-11ea-8ce9-9b57d24e0815.png)

I have some ideas for how to mitigate that, but our sites are gonna do a lot of other other goofy stuff with JS disabled, so a little extra whitespace might be the least of it. 