### PR TITLE
Fixing typo in `tar` command.

### DIFF
--- a/content/source/docs/cloud/run/api.html.md
+++ b/content/source/docs/cloud/run/api.html.md
@@ -59,7 +59,7 @@ The [configuration version API](../api/configuration-versions.html) requires a `
 
 ```bash
 UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
-tar -zcvf "$UPLOAD_FILE_NAME" "$CONTENT_DIRECTORY" .
+tar -zcvf "$UPLOAD_FILE_NAME" -C "$CONTENT_DIRECTORY" .
 ```
 
 ### 3. Look Up the Workspace ID
@@ -147,7 +147,7 @@ WORKSPACE_NAME="$(cut -d'/' -f2 <<<"$2")"
 # 2. Create the File for Upload
 
 UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
-tar -zcvf "$UPLOAD_FILE_NAME" "$CONTENT_DIRECTORY"
+tar -zcvf "$UPLOAD_FILE_NAME" -C "$CONTENT_DIRECTORY"
 
 # 3. Look Up the Workspace ID
 


### PR DESCRIPTION
Adding `-C` back to `tar` command to ensure the proper directory gets archived. It was incorrectly removed in https://github.com/hashicorp/terraform-website/pull/774.