### PR TITLE
Deduplicate metadata in Community pages

### DIFF
--- a/content/source/docs/extend/community/code-of-conduct.html.md
+++ b/content/source/docs/extend/community/code-of-conduct.html.md
@@ -1,10 +1,10 @@
 ---
 layout: "extend"
-page_title: "Community"
+page_title: "Terraform Developers Code of Conduct"
 sidebar_current: "docs-extend-community-code-of-conduct"
 description: |-
-  Terraform is a mature project with a growing community. There are
-  active, dedicated people willing to help you through various mediums.
+  Code of Conduct applicable to Terraform developers
+  when interacting with the community
 ---
 
 # Terraform Developers Code of Conduct

--- a/content/source/docs/extend/community/contributing.html.md
+++ b/content/source/docs/extend/community/contributing.html.md
@@ -1,10 +1,9 @@
 ---
 layout: "extend"
-page_title: "Community"
+page_title: "Contributing"
 sidebar_current: "docs-extend-community-contributing"
 description: |-
-  Terraform is a mature project with a growing community. There are
-  active, dedicated people willing to help you through various mediums.
+  How to contribute to Terraform providers and differences between HashiCorp and community providers.
 
 ---
 

--- a/content/source/docs/extend/community/maintainers.html.md
+++ b/content/source/docs/extend/community/maintainers.html.md
@@ -1,10 +1,9 @@
 ---
 layout: "extend"
-page_title: "Community"
+page_title: "Maintainers"
 sidebar_current: "docs-extend-community-maintainers"
 description: |-
-  Terraform is a mature project with a growing community. There are
-  active, dedicated people willing to help you through various mediums.
+  Members of the community who are responsible for maintaining providers
 
 ---
 


### PR DESCRIPTION
One remaining question is what do we do about the Community page, currently represented in the following (pretty much duplicate) files:
```
./content/source/docs/extend/community/index.html.md
./content/source/community.html.erb
```

There is currently 301 redirection from `/community.html` to `/docs/extend/community/index.html`, so it's not really duplicate content from the perspective of SEO, but it's confusing nonetheless:

 - users and developers are (IMO) two different audiences which may deserve each their own Community page
 - we should remove a page that is being shadowed by the redirect and never rendered, to avoid confusion of maintainers
