### PR TITLE
Create dedicated SDK Community page

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -119,7 +119,6 @@
 
 # Extending Terraform section
 /guides/writing-custom-terraform-providers.html          /docs/extend/writing-custom-providers.html
-/community.html                                          /docs/extend/community/index.html
 /docs/extend/resources.html                              /docs/extend/resources/index.html
 
 # Move the docs about TFE runs

--- a/content/source/community.html.erb
+++ b/content/source/community.html.erb
@@ -12,26 +12,40 @@ description: |-
   Terraform is a mature project with a growing community. There are
   active, dedicated people willing to help you through various mediums.
 </p>
-<p>
-  <strong>Stack Exchange:</strong> Terraform questions often get asked and
-  answered on
-  <a href="https://serverfault.com/">Server Fault</a> and
-  <a href="https://stackoverflow.com/">Stack Overflow</a>. Use the tag
-  "terraform" to help your question be found by Terraform experts, and please
-  be respectful of the "How to Ask" guidelines in each community.
-</p>
-<p>
-  <strong>Gitter:</strong> <a href="https://gitter.im/hashicorp-terraform/Lobby">Terraform Gitter Room</a>
-</p>
-<p>
-  <strong>IRC:</strong> Use the <a href="https://irc.gitter.im">Gitter IRC bridge</a>
-</p>
-<p>
-  <strong>Mailing list:</strong> <a href="https://groups.google.com/group/terraform-tool">Terraform Google Group</a>
-</p>
-<p>
-  <strong>Bug Tracker:</strong> <a href="https://github.com/hashicorp/terraform/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use a Stack Exchange community, Gitter chat, or the mailing list for that.
-</p>
-<p>
-  <strong>Training:</strong> Paid <a href="https://www.hashicorp.com/training.html">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.
-</p>
+
+<p><strong>Events:</strong> HashiCorp sponsors various community events to bring together
+Terraform ecosystem developers. See the <a href="/docs/extend/community/events/index.html">events</a> page for more information.</p>
+
+<p><strong>Stack Exchange:</strong> Terraform questions often get asked and answered on <a href="https://serverfault.com/">Server
+Fault</a> and <a href="https://stackoverflow.com/">Stack
+Overflow</a>. Use the tag "terraform" to help your
+question be found by Terraform experts, and please be respectful of the "How to
+Ask" guidelines in each community.</p>
+
+<p><strong>HashiCorp forum:</strong></p>
+<ul>
+  <li>The <a href="https://discuss.hashicorp.com/c/terraform-core">Terraform section</a>
+of the community portal contains questions, use cases, and useful patterns.</li>
+  <li>For provider related questions please visit the <a href="https://discuss.hashicorp.com/c/terraform-providers">Terraform Providers section</a>
+of the community portal.</li>
+</ul>
+
+<p><strong>Bug Trackers:</strong></p>
+<ul>
+  <li><a href="https://github.com/hashicorp/terraform/issues">Terraform Core Issue tracker on
+GitHub</a>. Please only use this for
+reporting bugs. Do not ask for general help here; use a Stack Exchange
+community or the HashiCorp forum for that.</li>
+  <li>Terraform Providers distributed by HashiCorp are part of the
+<a href="https://github.com/terraform-providers"><code>terraform-providers</code></a> GitHub
+Organization. Each Provider is a separate GitHub project with their own issue
+trackers.</li>
+</ul>
+
+<p><strong>Training:</strong> <a href="https://www.hashicorp.com/training.html">Paid HashiCorp training
+courses</a> are also available in a city
+near you. Private training courses are also available.</p>
+
+<hr>
+
+Mediums for <em>developers</em> of Terraform providers are listed under <a href="/docs/extend/community/index.html">Terraform SDK Community</a>.

--- a/content/source/docs/extend/community/index.html.md
+++ b/content/source/docs/extend/community/index.html.md
@@ -1,49 +1,22 @@
 ---
 layout: "extend"
-page_title: "Community"
+page_title: "Plugin SDK Community"
 sidebar_current: "docs-extend-community"
 description: |-
-  Terraform is a mature project with a growing community. There are
-  active, dedicated people willing to help you through various mediums.
+  Terraform has an active and growing community of plugin developers
+  willing to help you through various mediums.
 ---
 
-# Terraform Community
+# Plugin SDK Community
 
-Terraform is a mature project with a growing community. There are active,
-dedicated people willing to help you through various mediums.
+Terraform has an active and growing community of plugin developers
+willing to help you through various mediums.
 
-**Events:** HashiCorp sponsors various community events to bring together
-Terraform ecosystem developers. See the
-[events](/docs/extend/community/events/index.html) page for more information.
+-> Mediums for **users of Terraform** are listed under the main [Community page](/community.html)
 
-**Stack Exchange:** Terraform questions often get asked and answered on [Server
-Fault](https://serverfault.com/) and [Stack
-Overflow](https://stackoverflow.com/). Use the tag "terraform" to help your
-question be found by Terraform experts, and please be respectful of the "How to
-Ask" guidelines in each community.
-
-**HashiCorp forum:**
-
-- The [Terraform section](https://discuss.hashicorp.com/c/terraform-core)
+- The [Terraform Plugin SDK section](https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk)
 of the community portal contains questions, use cases, and useful patterns.
 
-- For SDK related questions please visit the
-[Terraform Providers section](https://discuss.hashicorp.com/c/terraform-providers)
-of the community portal.
-
-**Bug Trackers:** 
-
-- [Terraform Core Issue tracker on
-GitHub](https://github.com/hashicorp/terraform/issues). Please only use this for
-reporting bugs. Do not ask for general help here; use a Stack Exchange
-community or the HashiCorp forum for that.
-
-- Terraform Providers distributed by HashiCorp are part of the
-[`terraform-providers`](https://github.com/terraform-providers) GitHub
-Organization. Each Provider is a separate GitHub project with their own issue
-trackers.
-
-
-**Training:** [Paid HashiCorp training
-courses](https://www.hashicorp.com/training.html) are also available in a city
-near you. Private training courses are also available.
+- [Terraform Plugin SDK Issue tracker on
+GitHub](https://github.com/hashicorp/terraform-plugin-sdk/issues). Please only use this for
+reporting bugs. Do not ask for general help here; use the HashiCorp forum for that.


### PR DESCRIPTION
Both pages link to each other, but I decided to make the link from SDK Community page more visible, because there is higher chance that people will keep landing there for some time, until the removal of the redirect is fully propagated, and/or they may just come through an outdated link.