### PR TITLE
Update mediums on main community page

### DIFF
--- a/content/source/community.html.erb
+++ b/content/source/community.html.erb
@@ -13,20 +13,11 @@ description: |-
   active, dedicated people willing to help you through various mediums.
 </p>
 
-<p><strong>Events:</strong> HashiCorp sponsors various community events to bring together
-Terraform ecosystem developers. See the <a href="/docs/extend/community/events/index.html">events</a> page for more information.</p>
-
-<p><strong>Stack Exchange:</strong> Terraform questions often get asked and answered on <a href="https://serverfault.com/">Server
-Fault</a> and <a href="https://stackoverflow.com/">Stack
-Overflow</a>. Use the tag "terraform" to help your
-question be found by Terraform experts, and please be respectful of the "How to
-Ask" guidelines in each community.</p>
-
-<p><strong>HashiCorp forum:</strong></p>
+<p><strong>Community forum:</strong></p>
 <ul>
   <li>The <a href="https://discuss.hashicorp.com/c/terraform-core">Terraform section</a>
 of the community portal contains questions, use cases, and useful patterns.</li>
-  <li>For provider related questions please visit the <a href="https://discuss.hashicorp.com/c/terraform-providers">Terraform Providers section</a>
+  <li>For provider-related questions please visit the <a href="https://discuss.hashicorp.com/c/terraform-providers">Terraform Providers section</a>
 of the community portal.</li>
 </ul>
 
@@ -34,8 +25,7 @@ of the community portal.</li>
 <ul>
   <li><a href="https://github.com/hashicorp/terraform/issues">Terraform Core Issue tracker on
 GitHub</a>. Please only use this for
-reporting bugs. Do not ask for general help here; use a Stack Exchange
-community or the HashiCorp forum for that.</li>
+reporting bugs. Do not ask for general help here; use the HashiCorp forum for that.</li>
   <li>Terraform Providers distributed by HashiCorp are part of the
 <a href="https://github.com/terraform-providers"><code>terraform-providers</code></a> GitHub
 Organization. Each Provider is a separate GitHub project with their own issue


### PR DESCRIPTION
Update the main community page with the community forum as top
active medium for questions. Remove the "community events" link since
currently no updates. Remove Stack Exchange link since we are not actively
monitoring that for questions.