### PR TITLE
Remove linebreak to fix formatting issue

### DIFF
--- a/content/source/docs/cloud/vcs/azure-devops-services.html.md
+++ b/content/source/docs/cloud/vcs/azure-devops-services.html.md
@@ -43,10 +43,11 @@ The rest of the page explains these steps in more detail.
 1. Open Terraform Cloud in your browser and navigate to the “Settings > VCS Providers” page for your organization. Click the “Add VCS Provider” button.
 
     If you just created your organization, you might already be on this page. Otherwise:
-    - Click the upper-left organization menu, making sure it currently shows your organization
-    - Click the “Settings” link at the top of the page (or within the &#9776; menu)
-    - On the next page, click “VCS Providers” in the left sidebar
-    - Click the “Add a VCS Provider” button
+
+    1. Click the upper-left organization menu, making sure it currently shows your organization
+    1. Click the “Settings” link at the top of the page (or within the &#9776; menu)
+    1. On the next page, click “VCS Providers” in the left sidebar
+    1. Click the “Add a VCS Provider” button
 
     ![Azure DevOps Services Screenshot: Adding a new VCS Provider in Terraform Cloud](./images/azure-devops-services-add-vcs-provider.png)
 

--- a/content/source/docs/cloud/vcs/azure-devops-services.html.md
+++ b/content/source/docs/cloud/vcs/azure-devops-services.html.md
@@ -43,7 +43,6 @@ The rest of the page explains these steps in more detail.
 1. Open Terraform Cloud in your browser and navigate to the “Settings > VCS Providers” page for your organization. Click the “Add VCS Provider” button.
 
     If you just created your organization, you might already be on this page. Otherwise:
-    
     - Click the upper-left organization menu, making sure it currently shows your organization
     - Click the “Settings” link at the top of the page (or within the &#9776; menu)
     - On the next page, click “VCS Providers” in the left sidebar


### PR DESCRIPTION
An extra linebreak was throwing off the formatting under Step 2. If the nested unordered list has a empty line above it, it'll be formatted as a code block. If it does not have a empty line above it, it renders as an unordered list. If the list is changed to an ordered (numbered) list, it renders correctly with the empty line above it. Both are used in other VCS documentation pages, so I'm choosing to simply change the list to an ordered list. 

<img width="945" alt="Screen Shot 2019-10-25 at 3 25 24 PM" src="https://user-images.githubusercontent.com/11901347/67598506-af701480-f73b-11e9-8629-ca15ce3cd790.png">
