### PR TITLE
Added proper link to intro blog post

### DIFF
--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -17,7 +17,7 @@ description: |-
             <div>
                 <div>
                     <div>
-                        <a class="notification no-bg" href="https://app.terraform.io/signup/account?utm_source=iopage&utm_campaign=tf_cloud_ga">
+                        <a class="notification no-bg" href="https://www.hashicorp.com/blog/announcing-terraform-cloud/">
                             <span>New</span> Introducing Terraform Cloud <span><svg width="14" height="8"
                                     viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <path


### PR DESCRIPTION
Not sure why this was a sign up link. Should've directed to the announcement blog.