### PR TITLE
Add docs for importing providers.

### DIFF
--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -41,6 +41,10 @@ If not, please reach out and [open an issue](https://github.com/hashicorp/terraf
 outlining your use case, and we'll work with you to find an appropriate way
 to interface with Terraform to meet your use case.
 
+~> **Note**: a notable exception to this is providers importing other providers
+in their test files. A better solution for that use case is in the works, but
+at the moment importing the providers is the best available solution.
+
 ## Exporting the Schema
 
 Some projects just care about the schema and resources a provider presents. As

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -1,0 +1,55 @@
+---
+layout: "extend"
+page_title: "Extending Terraform: Depending on Providers"
+sidebar_current: "docs-extend-best-practices-depending-on-providers"
+description: |-
+  How to safely depend on providers and understand their interfaces.
+---
+
+## Depending on Providers
+
+Terraform's providers are a substantial amount of code, and occasionally it
+makes sense to depend on their functionality. The most straightforward and
+obvious way to depend on a provider is to depend on the Terraform CLI, but
+occasionally it makes sense to rely on a provider in a different context.
+
+This guide lays out the supported ways to interface with and depend on
+Terraform's providers. Unless the provider explicitly states otherwise, no
+other compatibility guarantees are provided.
+
+### Importing Providers as Go Modules
+
+Terraform's providers are written as Go packages, and they mostly use Go
+modules as their dependency management solution. This makes it tempting to
+import the provider as a dependency of your Go code, and to call its exposed
+interface. This is explicitly an **unsupported** way to interact with providers
+and provider maintainers make no guarantees around backwards compatibility or
+the continued functioning of code that does this.
+
+Providers are unable to be imported as Go modules reliably because their
+versioning scheme is intended to convey information about the Terraform config
+interface the provider presents. It's unable to capture both the configuration
+interface _and_ the Go API interface in a useful way, as what is compatible in
+one may not be compatible in the other. Rather than give the impression that
+the package should be imported by using the `/vX` suffix now mandated for
+versions after 2.0.0, providers have chosen to make their incompatibility with
+being imported into Go code explicit.
+
+If you find yourself needing to do this, perhaps one of the methods below will
+work for you, and is explicitly supported and covered under versioning policies.
+If not, please reach out and [open an issue](https://github.com/hashicorp/terraform/issues/new)
+and we'll try to come to an appropriate solution.
+
+### Exporting the Schema
+
+Some projects just care about the schema and resouces a provider presents. As
+of Terraform 0.12, the `terraform providers schema -json` command can be used
+to export a JSON representation of the schemas for the providers used in a
+workspace.
+
+### Using the RPC Protocol
+
+For projects that actually want to drive the provider, using the [gRPC protocol](https://github.com/hashicorp/terraform/tree/master/docs/plugin-protocol)
+and using the RPC calls the protocol supplies is a supported option. This
+protocol is the same protocol that drives Terraform's CLI interface, and
+it is versioned using a protocol version. It changes relatively infrequently.

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -6,7 +6,7 @@ description: |-
   How to safely depend on providers and understand their interfaces.
 ---
 
-## Depending on Providers
+# Depending on Providers
 
 Terraform's providers are a substantial amount of code, and occasionally it
 makes sense to depend on their functionality. The most straightforward and

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -50,7 +50,7 @@ workspace.
 
 ### Using the RPC Protocol
 
-For projects that actually want to drive the provider, using the [gRPC protocol](https://github.com/hashicorp/terraform/tree/master/docs/plugin-protocol)
+For projects that actually want to drive the provider, the supported option is to use the [gRPC protocol](https://github.com/hashicorp/terraform/tree/master/docs/plugin-protocol)
 and using the RPC calls the protocol supplies is a supported option. This
 protocol is the same protocol that drives Terraform's CLI interface, and
 it is versioned using a protocol version. It changes relatively infrequently.

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -17,7 +17,7 @@ This guide lays out the supported ways to interface with and depend on
 Terraform's providers. Unless the provider explicitly states otherwise, no
 other compatibility guarantees are provided.
 
-### Importing Providers as Go Modules
+## Do Not Import Providers as Go Modules
 
 Terraform's providers are written as Go packages, and they mostly use Go
 modules as their dependency management solution. This makes it tempting to

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -43,7 +43,7 @@ to interface with Terraform to meet your use case.
 
 ### Exporting the Schema
 
-Some projects just care about the schema and resouces a provider presents. As
+Some projects just care about the schema and resources a provider presents. As
 of Terraform 0.12, the `terraform providers schema -json` command can be used
 to export a JSON representation of the schemas for the providers used in a
 workspace.

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -38,7 +38,8 @@ being imported into Go code explicit.
 If you find yourself needing to do this, perhaps one of the methods below will
 work for you, and is explicitly supported and covered under versioning policies.
 If not, please reach out and [open an issue](https://github.com/hashicorp/terraform/issues/new)
-and we'll try to come to an appropriate solution.
+outlining your use case, and we'll work with you to find an appropriate way
+to interface with Terraform to meet your use case.
 
 ### Exporting the Schema
 

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -51,6 +51,6 @@ workspace.
 ### Using the RPC Protocol
 
 For projects that actually want to drive the provider, the supported option is to use the [gRPC protocol](https://github.com/hashicorp/terraform/tree/master/docs/plugin-protocol)
-and using the RPC calls the protocol supplies is a supported option. This
+and the RPC calls the protocol supplies. This
 protocol is the same protocol that drives Terraform's CLI interface, and
 it is versioned using a protocol version. It changes relatively infrequently.

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -41,7 +41,7 @@ If not, please reach out and [open an issue](https://github.com/hashicorp/terraf
 outlining your use case, and we'll work with you to find an appropriate way
 to interface with Terraform to meet your use case.
 
-### Exporting the Schema
+## Exporting the Schema
 
 Some projects just care about the schema and resources a provider presents. As
 of Terraform 0.12, the `terraform providers schema -json` command can be used

--- a/content/source/docs/extend/best-practices/depending-on-providers.html.md
+++ b/content/source/docs/extend/best-practices/depending-on-providers.html.md
@@ -48,7 +48,7 @@ of Terraform 0.12, the `terraform providers schema -json` command can be used
 to export a JSON representation of the schemas for the providers used in a
 workspace.
 
-### Using the RPC Protocol
+## Using the RPC Protocol
 
 For projects that actually want to drive the provider, the supported option is to use the [gRPC protocol](https://github.com/hashicorp/terraform/tree/master/docs/plugin-protocol)
 and the RPC calls the protocol supplies. This

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -59,6 +59,10 @@
             <a href="/docs/extend/best-practices/naming.html">Naming</a>
           </li>
 
+	  <li<%= sidebar_current("docs-extend-best-practices-depending-on-providers") %>>
+            <a href="/docs/extend/best-practices/depending-on-providers.html">Depending on Providers</a>
+	  </li>
+
           <li<%= sidebar_current("docs-extend-best-practices-deprecations") %>>
             <a href="/docs/extend/best-practices/deprecations.html">Deprecations, Removals, and Renames</a>
           </li>


### PR DESCRIPTION
Add a guide to cover the ways you can depend on providers (gRPC, schema
export) and explicitly call out that importing providers as a Go module
is not supported.