### PR TITLE
Add note about admin permissions to avoid confusion

### DIFF
--- a/content/source/docs/cloud/vcs/azure-devops-services.html.md
+++ b/content/source/docs/cloud/vcs/azure-devops-services.html.md
@@ -22,7 +22,7 @@ The rest of the page explains these steps in more detail.
 
 1. Open your [Azure DevOps Services Profile](https://aex.dev.azure.com) in a browser tab; log in to your Azure DevOps Services account if necessary.
 
-    ~> **Important:** The Azure DevOps Services account you use for connecting Terraform Cloud must have admin access since creating webhooks requires admin permissions.
+    ~> **Important:** The Azure DevOps Services account you use for connecting Terraform Cloud must have admin access since creating webhooks requires admin permissions. If you're unable to load the link above, you can create a new application for the next step at one of the following links: `https://aex.dev.azure.com/app/register?mkt=en-US` or `https://app.vsaex.visualstudio.com/app/register?mkt=en-US`.
 
 2. Click the “Create new application” link at the bottom of the left column under the “Applications and services” header. The next page is a form asking for your company and application information. At the minimum, you’ll need to provide your company name, application name (Terraform Cloud), application website (`https://app.terraform.io` or the URL of your Terraform Enterprise instance), and authorization callback URL.
     

--- a/content/source/docs/cloud/vcs/azure-devops-services.html.md
+++ b/content/source/docs/cloud/vcs/azure-devops-services.html.md
@@ -22,6 +22,8 @@ The rest of the page explains these steps in more detail.
 
 1. Open your [Azure DevOps Services Profile](https://aex.dev.azure.com) in a browser tab; log in to your Azure DevOps Services account if necessary.
 
+    ~> **Important:** The Azure DevOps Services account you use for connecting Terraform Cloud must have admin access since creating webhooks requires admin permissions.
+
 2. Click the “Create new application” link at the bottom of the left column under the “Applications and services” header. The next page is a form asking for your company and application information. At the minimum, you’ll need to provide your company name, application name (Terraform Cloud), application website (`https://app.terraform.io` or the URL of your Terraform Enterprise instance), and authorization callback URL.
     
     The authorization callback URL can be a placeholder, as you’ll update it with the actual callback value in Step 2.


### PR DESCRIPTION
To avoid confusion in case the Azure DevOps Services Profile link doesn't work, I propose we add an Important box like we do for other VCS pages.