### PR TITLE
Sensitive variables can also end up in state files

### DIFF
--- a/content/source/docs/cloud/workspaces/variables.html.md
+++ b/content/source/docs/cloud/workspaces/variables.html.md
@@ -70,7 +70,7 @@ Marking a variable as sensitive prevents anybody (including you) from viewing it
 
 Users with edit permissions can set new values for sensitive variables. No other attribute of a sensitive variable can be modified. To update other attributes, delete the variable and create a new variable to replace it.
 
-~> **Important:** Terraform runs will receive the full text of sensitive variables, and might print the value in logs if the configuration pipes the value through to an output or a resource parameter. Take care when writing your configurations to avoid unnecessary credential disclosure.
+~> **Important:** Terraform runs will receive the full text of sensitive variables, and might print the value in logs and state files if the configuration pipes the value through to an output or a resource parameter. Take care when writing your configurations to avoid unnecessary credential disclosure. Whenever possible, use environment variables since these cannot end up in state files. (Environment variables can end up in log files if TF_LOG is set to TRACE.)
 
 ### Looking Up Variable Names
 


### PR DESCRIPTION
Document that sensitive variables can end up in both logs and state files.
Also, point out that environment variables cannot end up in state files so are preferred when using them is possible.
My parenthetical statement that an environment variable can show up in a log file if TF_LOG is set to TRACE is based on personal experience.  It is possible that this could also happen with TF_LOG set to DEBUG, but I have not tested for that.