### PR TITLE
Clarify that certificates will be looked up or provided via ARN

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -77,13 +77,13 @@ To deploy Terraform Enterprise, you must obtain a license file from HashiCorp.
 
 ### TLS Certificate and Private Key
 
-Terraform Enterprise requires a TLS certificate and private key in order to operate. This certificate must match Terraform Enterprise's hostname (or the hostname of the load balancer for clusters), and ideally it should be a wildcard certificate.
+Terraform Enterprise requires a TLS certificate and private key in order to operate. This certificate must match Terraform Enterprise's hostname (or the hostname of the load balancer for clusters), either by being issued for the FQDN or ideally being a wildcard certificate.
 
 The certificate can be signed by a public or private CA, but it _must_ be trusted by all of the services that Terraform Enterprise is expected to interface with; this includes your VCS provider, any CI systems or other tools that call Terraform Enterprise's API, and any services that Terraform Enterprise workspaces might send notifications to (for example: Slack). Due to these wide-ranging interactions, we recommend using a certificate signed by a public CA.
 
 If you are using clustered deployment, you might need to ensure the certificate is available in your cloud provider's certificate management service:
 
-- For AWS clusters, the certificate must be available in ACM.
+- For AWS clusters, the certificate must be available in ACM matching the domain provided or via ARN.
 - For Azure clusters, the certificate can be provided as a file but must be in PFX format.
 - For GCP clusters, the certificate can be provided as a file or as a GCP certificate link.
 

--- a/content/source/docs/enterprise/install/cluster-aws.html.md
+++ b/content/source/docs/enterprise/install/cluster-aws.html.md
@@ -36,7 +36,7 @@ This page should be used in conjunction with the module's documentation on the T
 
 Before you begin, follow the [Pre-Install Checklist](../before-installing/index.html) and ensure you have all of the prerequisites. This checklist includes several important decisions, some supporting infrastructure, and necessary credentials.
 
-In particular, note that Terraform Enterprise's certificate must be available in ACM.
+In particular, note that Terraform Enterprise's certificate must be available in ACM matching the domain provided or via ARN.
 
 ## Prepare a Machine for Terraform
 


### PR DESCRIPTION
In the Terraform Enterprise documentation we call out that AWS certificates must be in the ACM but also make particular note of wildcard certificates. This can cause some confusion of how certificates are looked up which is by the domain name provided. As such I've attempted to clarify that we will look up things by domain so wildcard or FQDN is good. 

Additionally with https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/33, certificates can be passed in via ARN (once we cut a new version of the module) so this PR also calls out that fact. 