### PR TITLE
Add note about instance profiles and build workers for TFE

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -168,6 +168,14 @@ For other Linux distributions, check Docker compatibility:
 
 ~> **Important:** We do not recommend running Docker under a 2.x kernel.
 
+### AWS-Specific Configuration
+
+Terraform Enterprise's instance profile serves as default credentials for Terraform's AWS provider. Workspaces without environment variables for credentials will attempt to use the instance profile to provision AWS resources.
+
+By default, clustered deployments use an instance profile with very minimal permissions; for individual deployments, the instance profile is the operator's responsibility.
+
+If you plan to specify any non-default permissions for Terraform Enterprise's instance profile, be aware that Terraform runs might use those permissions and plan accordingly.
+
 ### SELinux
 
 SELinux is supported when Terraform Enterprise runs in `External Services` mode and only the default SELinux policies provided by RedHat are used. Terraform Enterprise v201812-1 or later is required for this support.

--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -132,6 +132,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo unzip daemontools git-core ssh wget curl psmisc iproute2 openssh-client redis-tools netcat-openbsd
 ```
 
+If an Instance Profile is used in AWS the worker image will use those permissions for Terraform operations unless other credentials are passed via environment variables.
+
 ### Image initialization
 To run initialization commands in your image during runtime, create a script at `/usr/local/bin/init_custom_worker.sh` and make it executable. This script, and all commands it invokes, will be executed before TFE runs `terraform init`.
 

--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -132,7 +132,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo unzip daemontools git-core ssh wget curl psmisc iproute2 openssh-client redis-tools netcat-openbsd
 ```
 
-If an Instance Profile is used in AWS the worker image will use those permissions for Terraform operations unless other credentials are passed via environment variables.
+-> **Note:** If Terraform Enterprise is running in AWS with an instance profile, the worker containers will use that profile's permissions for Terraform operations unless other credentials are passed via environment variables.
 
 ### Image initialization
 To run initialization commands in your image during runtime, create a script at `/usr/local/bin/init_custom_worker.sh` and make it executable. This script, and all commands it invokes, will be executed before TFE runs `terraform init`.

--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -132,8 +132,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo unzip daemontools git-core ssh wget curl psmisc iproute2 openssh-client redis-tools netcat-openbsd
 ```
 
--> **Note:** If Terraform Enterprise is running in AWS with an instance profile, the worker containers will use that profile's permissions for Terraform operations unless other credentials are passed via environment variables.
-
 ### Image initialization
 To run initialization commands in your image during runtime, create a script at `/usr/local/bin/init_custom_worker.sh` and make it executable. This script, and all commands it invokes, will be executed before TFE runs `terraform init`.
 


### PR DESCRIPTION
In Terraform Enterprise customers can use alternative Terraform worker images to do their Terraform runs. These short lived docker containers will pick up the instance profile of the machine they're running on unless env vars are passed in overriding them. 

Currently this isn't documented anywhere, and can be a bit confusing if you're not expecting it. This PR attempts to fix that fact. 