### PR TITLE
Add docs deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+---
+version: 2
+
+references:
+  images:
+    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.41
+
+  cache:
+    rubygem: &RUBYGEM_CACHE_KEY static-site-gems-v1-{{ checksum "content/Gemfile.lock" }}
+
+jobs:
+  deploy-website:
+    docker:
+      - image: *MIDDLEMAN_IMAGE
+    steps:
+      - checkout
+
+      # pull and update git submodules
+      - run: make sync
+
+      # restores gem cache
+      - restore_cache:
+          key: *RUBYGEM_CACHE_KEY
+
+      - run:
+          name: install gems
+          working_directory: content
+          command: bundle check || bundle install --path vendor/bundle --retry=3
+
+      # saves gem cache if we have changed the Gemfile
+      - save_cache:
+          key: *RUBYGEM_CACHE_KEY
+          paths:
+            - content/vendor/bundle
+
+      - run:
+          name: middleman build
+          working_directory: content
+          command: bundle exec middleman build
+
+      - run:
+          working_directory: content
+          command: ./scripts/deploy.sh
+
+workflows:
+  version: 2
+  website:
+    jobs:
+      - deploy-website:
+          context: static-sites
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This PR migrates our old website deployment to CircleCI. 

It encompasses a few things:
- will build ONLY the `master` branch automatically on commit
- caching of git submodules based on `git submodule status` so subsequent website builds are faster
- caching of ruby gems so the website build is faster
- parallelization of warming the cache across the `aws provider`, `non-aws providers` and `other`. If there is more parallelization needed or if there are suggestions for how to better split this out, let me know. The high water mark here is the `non-aws providers` taking ~8-10 mins. 

A sample of the whole workflow can be found here: https://circleci.com/workflow-run/e3ff65d4-13c4-4bfd-b582-b5215ff651df. Total time is about 20 mins but is still faster than the old build. We can worry about optimizing if this becomes too long in the future.

This job can be triggered manually by rerunning the workflow on the master branch in the UI here: https://circleci.com/gh/hashicorp/workflows/terraform-website

Alternatively, it can also be triggered via the API with something like:
curl -X POST "https://circleci.com/api/v1.1/project/gh/hashicorp/terraform-website/build?circle-token=$CIRCLE_TOKEN"