### PR TITLE
website - add -moz-osx-font-smoothing for smooth firefox osx fonts

### DIFF
--- a/content/source/assets/stylesheets/_global.scss
+++ b/content/source/assets/stylesheets/_global.scss
@@ -7,6 +7,7 @@ html {
 }
 
 body {
+  -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   color: $body-font-color;
   background-color: $white;


### PR DESCRIPTION
Adding `-moz-osx-font-smoothing: grayscale;` to `<body>`  in `global-styles` to smooth out fonts in Firefox on OSX.

Note that we are already using `-webkit-font-smoothing: antialiased;`.

#### Before

![Screen Shot 2019-11-07 at 12 12 10 PM](https://user-images.githubusercontent.com/5368111/68420406-85661b80-0159-11ea-982d-424654df8f57.png)

---

### After

![Screen Shot 2019-11-07 at 12 12 04 PM](https://user-images.githubusercontent.com/5368111/68420424-8d25c000-0159-11ea-882c-26d03a6e2bfb.png)

