### PR TITLE
Fix un-minifiable javascript on terraform.io

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -9,7 +9,7 @@
 
 
 //= require terraform-overview/vendor-scripts/object-fit-images.min.js
-//= require terraform-overview/home-hero
+// DON'T require terraform-overview/home-hero, because the compressor is old.
 //= require terraform-overview/hashi-tabbed-content
 
 // Set up terraform.io UI helpers

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -39,6 +39,7 @@
     <!-- Site scripts -->
     <!--[if lt IE 9]><%= javascript_include_tag "ie-compat", defer: true %><![endif]-->
     <%= javascript_include_tag "application", defer: true %>
+    <%= javascript_include_tag "terraform-overview/home-hero", defer: true %>
 
     <!-- Analytics scrpts -->
     <script defer>


### PR DESCRIPTION
Our semi-abandoned Middleman-based site builder uses Uglifier 2.x to minify
JavaScript, and it barfs on any es2015 syntax. Uglifier runs on JS files after
Sprockets processes them. If a Sprockets directive pulls an es2015 file into
application.js, it can't be compressed and will be served raw.

I could solve this by rewriting the lambdas and string templates in home-hero
into es5, but instead let's do a two-line fix that doesn't impact the
maintainability of that JS.

This still emits an error during builds, but the result is fine. 