### PR TITLE
Adjust position of sidebar chevrons to fit new font styles

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -143,7 +143,6 @@
         }
         &.active:before {
           transform: rotate(90deg);
-          top: 2px;
         }
       }
 


### PR DESCRIPTION
We used to need this top: 2 property to keep the chevron from looking misaligned,
but now it looks better without.

### Before

![Screenshot_2019-11-07 Provider AWS - Terraform by HashiCorp(1)](https://user-images.githubusercontent.com/484309/68439310-ff0f0100-017b-11ea-9543-2302787bb1d4.png)

### After

![Screenshot_2019-11-07 Provider AWS - Terraform by HashiCorp](https://user-images.githubusercontent.com/484309/68439323-07673c00-017c-11ea-99d8-19c3427a7ce2.png)

Eh, it's subtle. LMK if you need me to GIF it or something. 