### PR TITLE
Revert "adding note about requiring 3-character usernames (#986)"

### DIFF
--- a/content/source/docs/enterprise/saml/identity-provider-configuration-okta.html.md
+++ b/content/source/docs/enterprise/saml/identity-provider-configuration-okta.html.md
@@ -24,9 +24,9 @@ Follow these steps to configure Okta as the identity provider (IdP) for Terrafor
     - **Name ID format** (drop-down): EmailAddress (the full name for this format in the SAML specification is `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`).
     - **Application username** (drop-down): Email
 
-    ~> **Important:** TFE usernames must be at least 3 characters. If Email is not used as the application username, ensure that your Okta username or other method selected contains only usernames having at least 3 characters. For example, if Email Prefix is selected and the email is Jo@domain.com, the user will not be able to log in and will receive the message "ERROR: Validation failed: Username must have at least 3 characters".
+        -> **Note:** If you are using Terraform Enterprise version v201912-1 or later, you can also choose Email Prefix for the application username. (This was unreliable in older versions due to a bug that required usernames to be at least 3 characters.)
 
-      ![Screenshot: The "Configure SAML" page of Okta's new app workflow, with the specified settings entered.](./images/sso-okta-new-application-saml.png)
+    ![Screenshot: The "Configure SAML" page of Okta's new app workflow, with the specified settings entered.](./images/sso-okta-new-application-saml.png)
 
 5. Still in the "Configure SAML" page, configure a group attribute statement to report which teams a user belongs to. Under the "Group Attribute Statements (Optional)" header, configure the statement as follows:
     - **Name:** `MemberOf` (This is the default name for TFE's group [attribute][]; the name of this attribute can be changed in [TFE's SAML settings](./configuration.html) if necessary.)


### PR DESCRIPTION
This reverts commit da7d25d7b56820531ddfe87052192d76550809fc, because that
username restriction has been removed, per @dylanegan in #986. 

Filing this as a draft, because I still have questions! 

- What version of TFE is it fixed in? Is it out yet? 
- Instead of just removing, should we change it to a note about the required TFE version for using Okta with non-email names? 