### PR TITLE
Update links to google provider_reference.html

### DIFF
--- a/content/scripts/testdata/incoming-links.txt
+++ b/content/scripts/testdata/incoming-links.txt
@@ -683,7 +683,7 @@
 /docs/providers/google/d/google_organization.html
 /docs/providers/google/getting_started.html
 /docs/providers/google/index.html
-/docs/providers/google/provider_reference.html
+/docs/providers/google/guides/provider_reference.html
 /docs/providers/google/provider_versions.html
 /docs/providers/google/r/bigquery_dataset.html
 /docs/providers/google/r/bigtable_instance.html

--- a/content/source/docs/enterprise/install/cluster-gcp.html.md
+++ b/content/source/docs/enterprise/install/cluster-gcp.html.md
@@ -46,7 +46,7 @@ Decide where you'll be running Terraform, and ensure:
 
 - [The latest Terraform 0.11 release][tf11] is installed and available in the PATH.
 - The system running Terraform has access to the target subnet.
-- The system running Terraform can authenticate to GCP. For more details, see [Google Provider Configuration Reference: Credentials](/docs/providers/google/provider_reference.html#credentials-1).
+- The system running Terraform can authenticate to GCP. For more details, see [Google Provider Configuration Reference: Credentials](/docs/providers/google/guides/provider_reference.html#credentials-1).
 - You're familiar enough with Terraform to write simple configurations that call [modules ](/docs/configuration-0-11/modules.html) and specify [output values](/docs/configuration-0-11/outputs.html).
 
 ## Prepare Infrastructure


### PR DESCRIPTION
This got moved to the provider's /guides directory, to match what the Registry expects.

cf. https://github.com/terraform-providers/terraform-provider-google-beta/pull/1333