### PR TITLE
cloud/sentinel: Simulator -> CLI

### DIFF
--- a/content/source/docs/cloud/sentinel/import/index.html.md
+++ b/content/source/docs/cloud/sentinel/import/index.html.md
@@ -24,10 +24,10 @@ state, and run associated with a policy check.
 - [tfrun](./tfrun.html) - This provides access to data associated with a run
   in Terraform Cloud, such as the run's workspace.
 
-Terraform Cloud allows you to create mocks of these imports from plans for
-use with the mocking or testing features of the [Sentinel
-Simulator](https://docs.hashicorp.com/sentinel/commands/). For more information,
-see [Mocking Terraform Sentinel Data](../mock.html).
+Terraform Cloud allows you to create mocks of these imports from plans for use
+with the mocking or testing features of the [Sentinel
+CLI](https://docs.hashicorp.com/sentinel/commands/). For more information, see
+[Mocking Terraform Sentinel Data](../mock.html).
 
 -> **Note:** Terraform Cloud does not currently support custom imports.
 

--- a/content/source/docs/cloud/sentinel/index.html.md
+++ b/content/source/docs/cloud/sentinel/index.html.md
@@ -37,8 +37,7 @@ Using Sentinel with Terraform Cloud involves:
 - [Enforcing policy checks on runs](./enforce.html) - Policies are checked when
   a run is performed, after the `terraform plan` but before it can be confirmed
   or the `terraform apply` is executed.
-- [Mocking Sentinel Terraform data](./mock.html) - Terraform Cloud provides
-  the ability to generate mock data for any run within a workspace. This data
-  can be used with the [Sentinel
-  Simulator](https://docs.hashicorp.com/sentinel/commands/) to test policies
-  before deployment.
+- [Mocking Sentinel Terraform data](./mock.html) - Terraform Cloud provides the
+  ability to generate mock data for any run within a workspace. This data can be
+  used with the [Sentinel CLI](https://docs.hashicorp.com/sentinel/commands/) to
+  test policies before deployment.

--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -15,8 +15,8 @@ generate mock data from existing configurations. This can be used to create
 sample data for a new policy, or data to reproduce issues in an existing one.
 
 Testing policies is done using the [Sentinel
-Simulator](https://docs.hashicorp.com/sentinel/commands/). More general
-information on testing Sentinel policies can be found in the [Testing
+CLI](https://docs.hashicorp.com/sentinel/commands/). More general information on
+testing Sentinel policies can be found in the [Testing
 section](https://docs.hashicorp.com/sentinel/writing/testing) of the [Sentinel
 runtime documentation](https://docs.hashicorp.com/sentinel).
 


### PR DESCRIPTION
This changes a few mentions to the "Sentinel Simulator" to "Sentinel
CLI" to reflect upcoming changes in naming in the Sentinel core runtime.