### PR TITLE
Fix sidebar jank: wandering chevrons and cut-off titles

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -1,6 +1,11 @@
 #docs-sidebar {
   margin-bottom: 30px;
-  overflow: hidden;
+
+  // fallback styles for gridless browsers
+  overflow-x: hidden;
+  @supports (display: grid) {
+    overflow-x: visible;
+  }
 
   // Re-using the .nav class name on lists means we inherit some
   // unfortunate behavior from Bootstrap, so reset all that.
@@ -42,6 +47,7 @@
 
   %sidebar-link {
     color: $sidebar-link-color;
+    word-wrap: break-word;
     overflow-wrap: break-word;
 
     &:focus,
@@ -112,27 +118,46 @@
     display: block;
     padding-bottom: 15px;
     padding-top: 10px;
-    
+
     li {
       padding: 0 0 11px 0;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      grid-template-rows: auto auto;
+      grid-template-areas: "marker name"
+                           "subnav subnav";
+      align-items: start;
+      grid-column-gap: .4em;
 
       a {
         @extend %sidebar-link;
-        padding-left: 6px;
-        // Hanging indent for long sidebar links:
-        // * like   (<-yes)   * like
-        //   this   (no ->)   this
+        grid-area: name;
+        max-width: 100%;
+        min-width: 0; // grid parent can shrink it
+
+        // fallback styles for gridless browsers
+        padding-left: .4em;
         display: table-cell;
+        @supports (display: grid) {
+          padding-left: 0;
+          display: inline;
+        }
       }
 
       &:before {
+        grid-area: marker;
+        text-align: center;
+
         color: $sidebar-link-color-active;
         content: '\2022';
         font-size: 0.938rem;
         opacity: 0.4;
-        position: relative;
-        // Hanging indent for long sidebar links:
+
+        // fallback styles for gridless browsers
         display: table-cell;
+        @supports (display: grid) {
+          display: inline;
+        }
       }
 
       &.has-subnav {
@@ -167,6 +192,7 @@
       display: none;
     }
     ul.nav {
+      grid-area: subnav;
       padding-top: 10px;
       padding-left: 10px;
 

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -143,6 +143,7 @@
         }
         &.active:before {
           transform: rotate(90deg);
+          transform-origin: 50% .83em;
         }
       }
 


### PR DESCRIPTION
The commit messages have explanations for the fixes. Here's some screenshots: 

### Before:

This shows both the weird wandering chevron, and some cut-off titles. 

![Screen Shot 2019-11-14 at 4 34 02 PM](https://user-images.githubusercontent.com/484309/68907873-2296f600-06fe-11ea-8180-54e28eb43b2a.png)

This adds 

### After:

Safari: 

![Screen Shot 2019-11-14 at 4 30 42 PM](https://user-images.githubusercontent.com/484309/68907826-06935480-06fe-11ea-8325-a232dccc22bf.png)

Firefox (with slightly wider window breakpoint):

![Screen Shot 2019-11-14 at 4 30 50 PM](https://user-images.githubusercontent.com/484309/68907853-1743ca80-06fe-11ea-8474-6e9471253f5f.png)

### Misc:

Here's a before and after that adds a background color, to make it more obvious what's going on with those chevrons: 

![Screenshot_2019-11-14 Google google_composer_image_versions - Terraform by HashiCorp(1)](https://user-images.githubusercontent.com/484309/68908011-ae108700-06fe-11ea-97be-648badb7d6d7.png)

![Screenshot_2019-11-14 Google google_composer_image_versions - Terraform by HashiCorp(2)](https://user-images.githubusercontent.com/484309/68908044-d304fa00-06fe-11ea-832a-d32eba2c9323.png)

Here's a shot with grid layout indicators turned on, so you can see how it gets laid out both with and without a subnav. (Although, one thing I really like about the `grid-template-areas` property is that you can "see" the grid right there in the CSS, so maybe this shot wasn't quite necessary.)

![image](https://user-images.githubusercontent.com/484309/68974173-ed91ae80-07a4-11ea-8781-f6a3741bc587.png)