### PR TITLE
fix(doc): example indentation

### DIFF
--- a/content/source/docs/github-actions/common-tasks/variables.html.md
+++ b/content/source/docs/github-actions/common-tasks/variables.html.md
@@ -29,7 +29,7 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
-        args: '-var="env=dev"'
+          args: '-var="env=dev"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -54,7 +54,7 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
-        args: '-var-file="dev.tfvars"'
+          args: '-var-file="dev.tfvars"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
The indentation for the examples when using `hashicorp/terraform-github-actions` was incorrect. Followed exactly, users would see an error like so:

```bash
- Your workflow file was invalid: The pipeline is not valid. .github/workflows/workflow.yml (Line: xx, Col: x): Unexpected value 'args'
```

This PR fixes this inaccuracy