### PR TITLE
Fix syntax for GitHub actions args nesting

### DIFF
--- a/content/source/docs/github-actions/common-tasks/arguments.html.md
+++ b/content/source/docs/github-actions/common-tasks/arguments.html.md
@@ -29,7 +29,7 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
-        args: '-var="env=dev"'
+          args: '-var="env=dev"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/source/docs/github-actions/common-tasks/backends.html.md
+++ b/content/source/docs/github-actions/common-tasks/backends.html.md
@@ -27,7 +27,7 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
-        args: '-backend-config="token=${{ secrets.TF_API_TOKEN }}" -backend-config="organization=CHANGE_ME"'
+          args: '-backend-config="token=${{ secrets.TF_API_TOKEN }}" -backend-config="organization=CHANGE_ME"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/source/docs/github-actions/common-tasks/variables.html.md
+++ b/content/source/docs/github-actions/common-tasks/variables.html.md
@@ -29,7 +29,7 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
-        args: '-var="env=dev"'
+          args: '-var="env=dev"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -54,7 +54,7 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
-        args: '-var-file="dev.tfvars"'
+          args: '-var-file="dev.tfvars"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
This is just a replacement for #1017 that catches the other couple instances of that bug. I'm going to self-merge this, because the change itself was already reviewed by @sudomateo. 