### PR TITLE
Redirect deleted google provider page to the upgrade guide that explains the deletion

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -396,3 +396,6 @@
 /docs/providers/google/getting_started.html                         /docs/providers/google/guides/getting_started.html
 /docs/providers/google/version_2_upgrade.html                       /docs/providers/google/guides/version_2_upgrade.html
 /docs/providers/google/version_3_upgrade.html                       /docs/providers/google/guides/version_3_upgrade.html
+
+# Deleted resource type
+/docs/providers/google/r/google_project_services.html               /docs/providers/google/guides/version_3_upgrade.html

--- a/content/scripts/testdata/incoming-links.txt
+++ b/content/scripts/testdata/incoming-links.txt
@@ -734,7 +734,6 @@
 /docs/providers/google/r/google_project.html
 /docs/providers/google/r/google_project_iam.html
 /docs/providers/google/r/google_project_service.html
-/docs/providers/google/r/google_project_services.html
 /docs/providers/google/r/google_service_account.html
 /docs/providers/google/r/google_service_account_iam.html
 /docs/providers/google/r/google_service_account_key.html


### PR DESCRIPTION
The commit that did this over in google-beta was attributed to that "magician" robot, so I'm not 100% sure who to go to for reviews, but anyway: this seems to be the occasional example of that "incoming links" checker working the way it was intended. We've got a Travis failure because this page was deleted without any mitigation. 

I'm going with redirecting it to [the 3.0 upgrade guide](https://www.terraform.io/docs/providers/google/guides/version_3_upgrade.html), since that includes an explanation of what happened. It's kind of a disorienting jump, but at least it's something. 