### PR TITLE
website: Invert check for Segment ID

### DIFF
--- a/content/middleman_helpers.rb
+++ b/content/middleman_helpers.rb
@@ -2,10 +2,10 @@ module Helpers
   # Returns a segment tracking ID such that local development is not
   # tracked to production systems.
   def segmentId()
-    if (ENV['DEPLOY_ENV'] == 'production')
-      'EnEETDWhfxp1rp09jVvJr66LdvwI6KVP'
-    else
+    if (ENV['DEPLOY_ENV'] == 'development')
       '0EXTgkNx0Ydje2PGXVbRhpKKoe5wtzcE'
+    else
+      'EnEETDWhfxp1rp09jVvJr66LdvwI6KVP'
     end
   end
 


### PR DESCRIPTION
With the switch from TeamCity to CircleCI, it looks like we're missing the `DEPLOY_ENV` environmental variable - I can't verify as I'm unable to access the CircleCI config for the project. We've been pushing production analytics to our staging destination in Segment since ~Nov 6 😢 

This inverts the check so that we default to production. The `make` file sets `DEPLOY_ENV` to `development`, so we should be covered when running this locally.

Ultimately it's better to leak a bit of dev activity analytics into production, then have no production analytics at all.