### PR TITLE
improve formatting of code block inside headers

### DIFF
--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -181,7 +181,8 @@
   h4 > code,
   h5 > code h6 > code {
     color: inherit;
-    font-size: 90%;
+    font-size: 50%;
+    margin: 0 5px;
   }
 
   table {


### PR DESCRIPTION
- reduces font-size of code block for better readability
- adds some additional left/right margin which comes in handy when inside parenthesis

reference page: https://www.terraform.io/docs/commands/cli-config.html

**Before:**
<img width="904" alt="image" src="https://user-images.githubusercontent.com/49507/69658935-2a825e80-104b-11ea-8115-3d1edb15d82c.png">


**After:**
<img width="912" alt="image" src="https://user-images.githubusercontent.com/49507/69658969-3d952e80-104b-11ea-8d56-f7b7067e542b.png">


⚠️ I did some searching and wasn't able to find another example of a code block inside a header so I'm not 100% sure this doesn't cause any regression else where but I expect these changes are suitable for all usage and this poor formatting was caused by the recent font updates.