### PR TITLE
Adding content type in curl example for adding ssh key

### DIFF
--- a/content/source/docs/cloud/api/ssh-keys.html.md
+++ b/content/source/docs/cloud/api/ssh-keys.html.md
@@ -166,6 +166,7 @@ Key path                    | Type   | Default | Description
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
   https://app.terraform.io/api/v2/organizations/my-organization/ssh-keys


### PR DESCRIPTION
Adding missing `--header "Content-Type: application/vnd.api+json" \` in creating ssh key  curl request

without this, the api call gives the following error:

```
{"errors":[{"status":"415","title":"invalid content type","detail":"content-type must be application/vnd.api+json"}]}
```
