### PR TITLE
[DOC] Workspace naming

### DIFF
--- a/content/source/docs/cloud/workspaces/naming.html.md
+++ b/content/source/docs/cloud/workspaces/naming.html.md
@@ -7,7 +7,7 @@ page_title: "Naming - Workspaces - Terraform Cloud"
 
 Terraform Cloud organizes workspaces by name, so it's important to use a consistent and informative naming strategy. And although future releases of Terraform Cloud will add more organizational tools, the name will always be the most important piece of information about a workspace.
 
-Note that workspace names need to be 90 characters or less and can only include letters, numbers, -, and _.
+Note that workspace names need to be 90 characters or less and can only include letters, numbers, - (dash), _ (underscore), and . (dot).
 
 The best way to make names that are both unique and useful is to combine the workspace's most distinguishing _attributes_ in a consistent order. Attributes can be any defining
 characteristic of a workspace — such as the component being managed, the


### PR DESCRIPTION
As it turns out, workspace names can contain . (dot) as well.

I think documentation should be complete regarding workspace naming. Currently, dot symbol is not mentioned in docs as allowed, whereas Terraform allows workspace names to contain dot symbol. This is important for teams that use workspace names in other parts of their projects.

Tested with v0.11.13 and v0.12.17.
