### PR TITLE
Make note of standard Sentinel imports

### DIFF
--- a/content/source/docs/cloud/sentinel/index.html.md
+++ b/content/source/docs/cloud/sentinel/index.html.md
@@ -41,3 +41,8 @@ Using Sentinel with Terraform Cloud involves:
   ability to generate mock data for any run within a workspace. This data can be
   used with the [Sentinel CLI](https://docs.hashicorp.com/sentinel/commands/) to
   test policies before deployment.
+
+### Standard Imports
+
+The Terraform integration for HashiCorp Sentinel implements all of the
+available [standard imports](https://docs.hashicorp.com/sentinel/imports/).


### PR DESCRIPTION
> Sentinel-embedded applications can choose to whitelist or blacklist
certain standard imports. Please reference the documentation for the
Sentinel-enabled application you're using to determine if all standard
imports are available.