### PR TITLE
adding in private key doc

### DIFF
--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -190,6 +190,7 @@ Key path                             | Type   | Default | Description
 `data.attributes.http-url`           | string |         | The homepage of your VCS provider (e.g. `"https://github.com"` or `"https://ghe.example.com"`)
 `data.attributes.api-url`            | string |         | The base URL of your VCS provider's API (e.g. `"https://api.github.com"` or `"https://ghe.example.com/api/v3"`)
 `data.attributes.oauth-token-string` | string |         | The token string you were given by your VCS provider
+`data.attributes.private-key`        | string |         | **Required for Azure DevOps Server** The text of the SSH private key associated with your Azure DevOps Server account.
 
 ### Sample Payload
 
@@ -201,7 +202,8 @@ Key path                             | Type   | Default | Description
       "service-provider": "github",
       "http-url": "https://github.com",
       "api-url": "https://api.github.com",
-      "oauth-token-string": "4306823352f0009d0ed81f1b654ac17a"
+      "oauth-token-string": "4306823352f0009d0ed81f1b654ac17a",
+      "private-key": "-----BEGIN RSA PRIVATE KEY-----\ncontent\n-----END RSA PRIVATE KEY-----"
     }
   }
 }
@@ -377,4 +379,3 @@ curl \
   --request DELETE \
   https://app.terraform.io/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K
 ```
-


### PR DESCRIPTION
This adds in documentation about the `private-key` parameter which is REQUIRED for Azure DevOps Server