### PR TITLE
TFC API: ensure Content-Type is included for POST, PATCH, DELETE examples

### DIFF
--- a/content/source/docs/cloud/api/policies.html.md
+++ b/content/source/docs/cloud/api/policies.html.md
@@ -414,6 +414,7 @@ Status  | Response                  | Reason
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
   https://app.terraform.io/api/v2/policies/pl-u3S5p2Uwk21keu1s
 ```

--- a/content/source/docs/cloud/api/policy-sets.html.md
+++ b/content/source/docs/cloud/api/policy-sets.html.md
@@ -778,6 +778,7 @@ Status  | Response                  | Reason
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
   https://app.terraform.io/api/v2/policy-sets/polset-3yVQZvHzf5j3WRJ1
 ```
@@ -803,6 +804,7 @@ Status  | Response                                              | Reason
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
   --request POST \
   https://app.terraform.io/api/v2/policy-sets/polset-3yVQZvHzf5j3WRJ1/versions
 ```

--- a/content/source/docs/cloud/api/ssh-keys.html.md
+++ b/content/source/docs/cloud/api/ssh-keys.html.md
@@ -238,6 +238,7 @@ Key path                    | Type   | Default   | Description
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
   https://app.terraform.io/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM
@@ -285,6 +286,7 @@ Status  | Response                                             | Reason
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
   https://app.terraform.io/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM
 ```


### PR DESCRIPTION
Actually I'm not sure that's necessary for `DELETE`. But I'm pretty sure it's necessary for `PUT/POST/PATCH`, so I went looking for more of these after #1048 pointed out the first one. 