### PR TITLE
don’t use .html ext in links to learn

### DIFF
--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -729,7 +729,7 @@ The process of using Terraform to make real infrastructure match the desired sta
 
 In Terraform Cloud, runs are performed in a series of stages ([plan][], [policy check][], and [apply][]), though not every stage occurs in every run. Terraform Cloud saves information about historical runs.
 
-- [Learn Terraform: Getting Started](https://learn.hashicorp.com/terraform/getting-started/install.html)
+- [Learn Terraform: Getting Started](https://learn.hashicorp.com/terraform/getting-started/install)
 - [Terraform Cloud docs: About Runs](/docs/cloud/run/index.html)
 
 ## S3

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -42,7 +42,7 @@ Documentation for Terraform's core functionality, including:
 
 -> New users can start here.
 
-Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install.html), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
+Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
 
 ### [Guides and Whitepapers ➜](/guides/index.html)
 


### PR DESCRIPTION
currently this throws off our analytics reporting as GA collects these two as separate paths. we will put in logic to merge them in GA but regardless, excluding .html is still a best practice for these links.