### PR TITLE
Add additional egress requirements for TFE

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -22,9 +22,15 @@ If Terraform Enterprise is installed in online mode, it accesses the following h
 
 * api.replicated.com
 * get.replicated.com
-* quay.io
 * registry-data.replicated.com
 * registry.replicated.com
+* quay.io
+* quay-registry.s3.amazonaws.com
+* index.docker.io
+* auth.docker.io
+* registry-1.docker.io
+* download.docker.com
+* production.cloudflare.docker.com
 
 Airgapped installs do not check for updates over the network.
 


### PR DESCRIPTION
TFE installation and startup requires several egress points be accessible during an online install. Our current documentation does not include:
- index.docker.io
- auth.docker.io
- registry-1.docker.io
- download.docker.com
- production.cloudflare.docker.com
- quay-registry.s3.amazonaws.com

Enumerating these provides clarity for users who are running TFE behind a corporate firewall or proxy.