### PR TITLE
Attempt to fix Travis failures due to incompatible Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: required
 services:
   - docker
 language: ruby
+before_install:
+  - gem install bundler -v '1.17.3' --no-document
+install:
+  - bundle _1.17.3_ install --jobs=3 --retry=3
 git:
   submodules: false
 


### PR DESCRIPTION
Travis builds are [exploding](https://travis-ci.org/hashicorp/terraform-website/builds/626196813?utm_source=github_status&utm_medium=notification), and it looks like it's because the default version of Bundler changed. I'll try this to start with, and depending on the result will investigate other solutions. 