### PR TITLE
content: Add redirects for incorrectly named Terraform AWS Provider files

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -137,8 +137,15 @@
 /docs/providers/aws/r/alb_target_group_attachment.html /docs/providers/aws/r/lb_target_group_attachment.html
 /docs/providers/aws/r/alb_target_group.html            /docs/providers/aws/r/lb_target_group.html
 /docs/providers/aws/r/alb.html                         /docs/providers/aws/r/lb.html
+/docs/providers/aws/r/autoscaling_lifecycle_hooks.html /docs/providers/aws/r/autoscaling_lifecycle_hook.html
 /docs/providers/aws/r/code_commit_repository.html      /docs/providers/aws/r/codecommit_repository.html
 /docs/providers/aws/r/code_commit_trigger.html         /docs/providers/aws/r/codecommit_trigger.html
+/docs/providers/aws/r/elastic_transcoder_pipeline.html /docs/providers/aws/r/elastictranscoder_pipeline.html
+/docs/providers/aws/r/elastic_transcoder_preset.html   /docs/providers/aws/r/elastictranscoder_preset.html
+/docs/providers/aws/r/main_route_table_assoc.html      /docs/providers/aws/r/main_route_table_association.html
+/docs/providers/aws/r/vpc_peering_accepter.html        /docs/providers/aws/r/vpc_peering_connection_accepter.html
+/docs/providers/aws/r/vpc_peering_options.html         /docs/providers/aws/r/vpc_peering_connection_options.html
+/docs/providers/aws/r/vpc_peering.html                 /docs/providers/aws/r/vpc_peering_connection.html
 
 # Azure Active Directory Provider
 /docs/providers/azuread/auth/azure_cli.html                             /docs/providers/azuread/guides/azure_cli.html


### PR DESCRIPTION
The correctly named files will be published first via `stable-website` branch, before merging these redirects.