### PR TITLE
Alter ssh-keygen command to explicitly use PEM

### DIFF
--- a/content/source/docs/cloud/vcs/azure-devops-server.html.md
+++ b/content/source/docs/cloud/vcs/azure-devops-server.html.md
@@ -58,7 +58,7 @@ Terraform Cloud uses personal access tokens to connect to Azure DevOps Server. T
 
 ## Step 3: On Workstation, Create an SSH Key for Terraform Cloud
 
-On a secure workstation, create an SSH keypair that Terraform Cloud can use to connect to Azure DevOps Server. The exact command depends on your OS, but is usually something like `ssh-keygen -t rsa -f "/Users/<NAME>/.ssh/service_terraform" -C "service_terraform_enterprise"`. This creates a `service_terraform` file with the private key, and a `service_terraform.pub` file with the public key.
+On a secure workstation, create an SSH keypair that Terraform Cloud can use to connect to Azure DevOps Server. The exact command depends on your OS, but is usually something like `ssh-keygen -t rsa -m PEM -f "/Users/<NAME>/.ssh/service_terraform" -C "service_terraform_enterprise"`. This creates a `service_terraform` file with the private key, and a `service_terraform.pub` file with the public key.
 
 This SSH key **must have an empty passphrase.** Terraform Cloud cannot use SSH keys that require a passphrase.
 

--- a/content/source/docs/cloud/vcs/bitbucket-server.html.md
+++ b/content/source/docs/cloud/vcs/bitbucket-server.html.md
@@ -100,7 +100,7 @@ Leave the page open in a browser tab, and remain logged in as an admin user.
 
 ## Step 3: On Workstation: Create an SSH Key for Terraform Cloud
 
-On a secure workstation, create an SSH keypair that Terraform Cloud can use to connect to Bitbucket Server. The exact command depends on your OS, but is usually something like `ssh-keygen -t rsa -f "/Users/<NAME>/.ssh/service_terraform" -C "service_terraform_enterprise"`. This creates a `service_terraform` file with the private key, and a `service_terraform.pub` file with the public key.
+On a secure workstation, create an SSH keypair that Terraform Cloud can use to connect to Bitbucket Server. The exact command depends on your OS, but is usually something like `ssh-keygen -t rsa -m PEM -f "/Users/<NAME>/.ssh/service_terraform" -C "service_terraform_enterprise"`. This creates a `service_terraform` file with the private key, and a `service_terraform.pub` file with the public key.
 
 This SSH key **must have an empty passphrase.** Terraform Cloud cannot use SSH keys that require a passphrase.
 

--- a/content/source/docs/cloud/workspaces/ssh-keys.html.md
+++ b/content/source/docs/cloud/workspaces/ssh-keys.html.md
@@ -30,7 +30,7 @@ To add a key:
 
 1. Obtain an SSH keypair that Terraform Cloud can use to download modules during a Terraform run. You might already have an appropriate key; if not, create one on a secure workstation and distribute the public key to your VCS provider(s). Do not use or generate a key that has a passphrase; Git is running non-interactively and won't be able to prompt for it.
 
-    The exact command to create a keypair depends on your OS, but is usually something like `ssh-keygen -t rsa -f "/Users/<NAME>/.ssh/service_terraform" -C "service_terraform_enterprise"`. This creates a `service_terraform` file with the private key, and a `service_terraform.pub` file with the public key.
+    The exact command to create a keypair depends on your OS, but is usually something like `ssh-keygen -t rsa -m PEM -f "/Users/<NAME>/.ssh/service_terraform" -C "service_terraform_enterprise"`. This creates a `service_terraform` file with the private key, and a `service_terraform.pub` file with the public key.
 2. Enter a name for the key in the "Name" field. Choose something identifiable, since the name is the only way to tell two SSH keys apart once the key text is hidden.
 3. Paste the text of the **private key** in the "Private SSH Key" field.
 4. Click the "Add Private SSH Key" button.


### PR DESCRIPTION
Website-side changes regarding the necessary updates to ensure that generated SSH keys are PEM encoded. This used to be the default, but OpenSSH <7.8 now defaults to OpenSSH encoded keys. 

We're still having a few discussions around this, hence the `[WIP]`. Once we're set on a direction, it should be ready to merge.

- [Asana](https://app.asana.com/0/1118351459439625/1156925453717675/f)
- [OpenSSH release notes](https://www.openssh.com/txt/release-7.8)