### PR TITLE
updated css so headers with two lines dont look weird

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -37,7 +37,7 @@
 
     margin-top: 20px; // fallback for non-grid browsers
     @supports (display: grid) {
-      margin-top: 0;
+      // margin-top: 0; // commented out to account for two row headers
     }
 
     h3, h4 {

--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -35,10 +35,7 @@
     grid-template-rows: minmax(90px, auto) 32px; // match #inner-header-grid
     margin-bottom: 16px;
 
-    margin-top: 20px; // fallback for non-grid browsers
-    @supports (display: grid) {
-      // margin-top: 0; // commented out to account for two row headers
-    }
+    margin-top: 20px;
 
     h3, h4 {
       grid-column: 1/2;

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -3,12 +3,12 @@
   #inner-header-grid {
     display: grid;
     grid-template-columns: 1fr auto;
-    grid-template-rows: minmax(90px, auto) 32px; // match #sidebar-header-grid
+    grid-template-rows: minmax(44px, auto) 32px; // match #sidebar-header-grid
     margin-bottom: 16px;
 
     margin-top: 20px; // fallback for non-grid browsers
     @supports (display: grid) {
-      margin-top: 0;
+      margin-top: 46px;
     }
 
     h1 {

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -3,12 +3,12 @@
   #inner-header-grid {
     display: grid;
     grid-template-columns: 1fr auto;
-    grid-template-rows: minmax(44px, auto) 32px; // match #sidebar-header-grid
+    grid-template-rows: minmax(90px, auto) 32px; // match #sidebar-header-grid
     margin-bottom: 16px;
 
     margin-top: 20px; // fallback for non-grid browsers
     @supports (display: grid) {
-      margin-top: 46px;
+      // margin-top: 0; // commented out to account for two row headers
     }
 
     h1 {

--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -6,11 +6,8 @@
     grid-template-rows: minmax(90px, auto) 32px; // match #sidebar-header-grid
     margin-bottom: 16px;
 
-    margin-top: 20px; // fallback for non-grid browsers
-    @supports (display: grid) {
-      // margin-top: 0; // commented out to account for two row headers
-    }
-
+    margin-top: 20px;
+    
     h1 {
       grid-column: 1/2;
       grid-row: 1/2;


### PR DESCRIPTION
- update css so headers with two lines don't look weird
- assuming that the line-height is 44px, since it's defined in the css

current:
![image](https://user-images.githubusercontent.com/7556325/72309347-989ed700-3633-11ea-8a76-ae44223deded.png)

proposed: 
![image](https://user-images.githubusercontent.com/7556325/72309353-9d638b00-3633-11ea-95cd-9901133c07f2.png)

single line:
![image](https://user-images.githubusercontent.com/7556325/72309381-ad7b6a80-3633-11ea-8794-85d9bbf4a289.png)

