### PR TITLE
Fixing a typo in the tar command invocation for the terraform-enterprise-push.sh script (ZD 22775)

### DIFF
--- a/content/source/docs/cloud/run/api.html.md
+++ b/content/source/docs/cloud/run/api.html.md
@@ -147,7 +147,7 @@ WORKSPACE_NAME="$(cut -d'/' -f2 <<<"$2")"
 # 2. Create the File for Upload
 
 UPLOAD_FILE_NAME="./content-$(date +%s).tar.gz"
-tar -zcvf "$UPLOAD_FILE_NAME" -C "$CONTENT_DIRECTORY"
+tar -zcvf "$UPLOAD_FILE_NAME" -C "$CONTENT_DIRECTORY" .
 
 # 3. Look Up the Workspace ID
 


### PR DESCRIPTION
## Description

Fixing a typo in the tar command invocation for the terraform-enterprise-push.sh script.

As reported by a customer in ZD ticket 22775