### PR TITLE
Add registry links for HashiCorp providers

### DIFF
--- a/content/source/layouts/inner.erb
+++ b/content/source/layouts/inner.erb
@@ -18,7 +18,34 @@
 
     <%
       external_docs_links = {
-        # '/docs/providers/aws/index.html' => 'https://registry.terraform.io/path/to/provider',
+        '/docs/providers/alicloud/index.html'       => 'https://registry.terraform.io/providers/hashicorp/alicloud/',
+        '/docs/providers/archive/index.html'        => 'https://registry.terraform.io/providers/hashicorp/archive/',
+        '/docs/providers/aws/index.html'            => 'https://registry.terraform.io/providers/hashicorp/aws/',
+        '/docs/providers/azuread/index.html'        => 'https://registry.terraform.io/providers/hashicorp/azuread/',
+        '/docs/providers/azurerm/index.html'        => 'https://registry.terraform.io/providers/hashicorp/azurerm/',
+        '/docs/providers/azurestack/index.html'     => 'https://registry.terraform.io/providers/hashicorp/azurestack/',
+        '/docs/providers/ciscoasa/index.html'       => 'https://registry.terraform.io/providers/hashicorp/ciscoasa/',
+        '/docs/providers/consul/index.html'         => 'https://registry.terraform.io/providers/hashicorp/consul/',
+        '/docs/providers/dns/index.html'            => 'https://registry.terraform.io/providers/hashicorp/dns/',
+        '/docs/providers/external/index.html'       => 'https://registry.terraform.io/providers/hashicorp/external/',
+        '/docs/providers/github/index.html'         => 'https://registry.terraform.io/providers/hashicorp/github/',
+        '/docs/providers/google/index.html'         => 'https://registry.terraform.io/providers/hashicorp/google/',
+        '/docs/providers/helm/index.html'           => 'https://registry.terraform.io/providers/hashicorp/helm/',
+        '/docs/providers/http/index.html'           => 'https://registry.terraform.io/providers/hashicorp/http/',
+        '/docs/providers/kubernetes/index.html'     => 'https://registry.terraform.io/providers/hashicorp/kubernetes/',
+        '/docs/providers/local/index.html'          => 'https://registry.terraform.io/providers/hashicorp/local/',
+        '/docs/providers/nomad/index.html'          => 'https://registry.terraform.io/providers/hashicorp/nomad/',
+        '/docs/providers/null/index.html'           => 'https://registry.terraform.io/providers/hashicorp/null/',
+        '/docs/providers/oci/index.html'            => 'https://registry.terraform.io/providers/hashicorp/oci/',
+        '/docs/providers/opc/index.html'            => 'https://registry.terraform.io/providers/hashicorp/opc/',
+        '/docs/providers/oraclepaas/index.html'     => 'https://registry.terraform.io/providers/hashicorp/oraclepaas/',
+        '/docs/providers/random/index.html'         => 'https://registry.terraform.io/providers/hashicorp/random/',
+        '/docs/providers/template/index.html'       => 'https://registry.terraform.io/providers/hashicorp/template/',
+        '/docs/providers/terraform/index.html'      => 'https://registry.terraform.io/providers/hashicorp/terraform/',
+        '/docs/providers/tfe/index.html'            => 'https://registry.terraform.io/providers/hashicorp/tfe/',
+        '/docs/providers/tls/index.html'            => 'https://registry.terraform.io/providers/hashicorp/tls/',
+        '/docs/providers/vault/index.html'          => 'https://registry.terraform.io/providers/hashicorp/vault/',
+        '/docs/providers/vsphere/index.html'        => 'https://registry.terraform.io/providers/hashicorp/vsphere/',
       }
     %>
     <div id="inner" class="col-sm-8 col-md-9 col-xs-12" role="main">


### PR DESCRIPTION
This commit adds links to the registry pages for all of the HashiCorp providers
that are now available in the Terraform Registry. Omitting the version number
ensures that these links redirect to the current versions.

This uses the capability added in https://github.com/hashicorp/terraform-website/pull/945, so we can add these links without having to edit the actual docs for the affected providers. 

Links are only added to the front page of each provider (`/docs/providers/:name/index.html`).

List of affected providers: 

- alicloud
- archive
- aws
- azuread
- azurerm
- azurestack
- ciscoasa
- consul
- dns
- external
- github
- google
- helm
- http
- kubernetes
- local
- nomad
- null
- oci
- opc
- oraclepaas
- random
- template
- terraform
- tfe
- tls
- vault
- vsphere

![image](https://user-images.githubusercontent.com/484309/72645837-6807b780-3929-11ea-8bd4-85f459a3fbc5.png)
