### PR TITLE
cloud: add "technology preview" notice on the v2 import pages

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -6,9 +6,14 @@ description: |-
 ---
 
 -> **NOTE:** This is documentation for the next version of the `tfconfig`
-Sentinel import, designed specifically for Terraform 0.12's modern data model.
-This import requires Terraform 0.12 or higher, and must currently be loaded by
-path, using an alias, example: `import "tfconfig/v2" as tfconfig`.
+Sentinel import, designed specifically for Terraform 0.12. This import requires
+Terraform 0.12 or higher, and must currently be loaded by path, using an alias,
+example: `import "tfconfig/v2" as tfconfig`.
+
+~> **NOTE:** The Sentinel v2 imports are currently publicly available as a
+**technology preview**. They are supported by HashiCorp, but the API is not yet
+stable and breaking changes could be made. Watch this documentation for any
+changes!
 
 # Import: tfconfig/v2
 

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -5,10 +5,15 @@ description: |-
   The tfplan/v2 import provides access to a Terraform plan.
 ---
 
--> **NOTE:** This is documentation for the next version of the `tfplan`
-Sentinel import, designed specifically for Terraform 0.12's modern data model.
-This import requires Terraform 0.12 or higher, and must currently be loaded by
-path, using an alias, example: `import "tfplan/v2" as tfplan`.
+-> **NOTE:** This is documentation for the next version of the `tfplan` Sentinel
+import, designed specifically for Terraform 0.12. This import requires
+Terraform 0.12 or higher, and must currently be loaded by path, using an alias,
+example: `import "tfplan/v2" as tfplan`.
+
+~> **NOTE:** The Sentinel v2 imports are currently publicly available as a
+**technology preview**. They are supported by HashiCorp, but the API is not yet
+stable and breaking changes could be made. Watch this documentation for any
+changes!
 
 # Import: tfplan/v2
 

--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -6,9 +6,14 @@ description: |-
 ---
 
 -> **NOTE:** This is documentation for the next version of the `tfstate`
-Sentinel import, designed specifically for Terraform 0.12's modern data model.
-This import requires Terraform 0.12 or higher, and must currently be loaded by
-path, using an alias, example: `import "tfstate/v2" as tfstate`.
+Sentinel import, designed specifically for Terraform 0.12. This import requires
+Terraform 0.12 or higher, and must currently be loaded by path, using an alias,
+example: `import "tfstate/v2" as tfstate`.
+
+~> **NOTE:** The Sentinel v2 imports are currently publicly available as a
+**technology preview**. They are supported by HashiCorp, but the API is not yet
+stable and breaking changes could be made. Watch this documentation for any
+changes!
 
 # Import: tfstate/v2
 


### PR DESCRIPTION
## Description

While implemented, supported, and live on production, the Sentinel v2
imports may be undergoing some changes in the next few weeks that would
entail changing the API. We are hence releasing these for a period under
a tech preview before declaring them stable. Hence, there needs to be a
notice indicating as such.

There's also been a small update to the blue info boxes regarding
wording on what the Sentinel imports are designed for.
