### PR TITLE
Update oauth-clients.html.md

### DIFF
--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -162,7 +162,9 @@ Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization that will be connected to the VCS provider. The organization must already exist in the system, and the user must have permissions to initiate the connection.
 
-This endpoint allows you to create a VCS connection between an organization and a VCS provider (GitHub or GitLab) for use when creating or setting up workspaces. By using this API endpoint, you can provide a pre-generated OAuth token string instead of going through the process of creating a GitHub or GitLab OAuth Application. To learn how to generate one of these token strings for your VCS provider, you can read the following documentation:
+This endpoint allows you to create a VCS connection between an organization and a VCS provider (GitHub or GitLab) for use when creating or setting up workspaces. By using this API endpoint, you can provide a pre-generated OAuth token string instead of going through the process of creating a GitHub or GitLab OAuth Application. 
+
+To learn how to generate one of these token strings for your VCS provider, you can read the following documentation:
 
 * [GitHub and GitHub Enterprise](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
 * [GitLab, GitLab Community Edition, and GitLab Enterprise Edition](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#creating-a-personal-access-token)


### PR DESCRIPTION
I think adding some spaces to lines 165-167 or highlighting this text will make it easier for people to see that this API token is required when creating an oauth client. While this information was present, I had a customer ticket run 2 months because she missed this portion of info on the site.

