### PR TITLE
Updating destroy plan behavior

### DIFF
--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -163,7 +163,7 @@ Parameter | Description
 ----------|------------
 `run_id`  | The run ID to apply
 
-Applies a run that is paused waiting for confirmation after a plan. This includes runs in the "needs confirmation" and "policy checked" states. This action is only required for runs that can't be auto-applied. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace, the plan is not a destroy plan, and the plan was not queued by a user without write permissions.)
+Applies a run that is paused waiting for confirmation after a plan. This includes runs in the "needs confirmation" and "policy checked" states. This action is only required for runs that can't be auto-applied. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was not queued by a user without write permissions.)
 
 This endpoint queues the request to perform an apply; the apply might not happen immediately.
 

--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -163,7 +163,7 @@ Parameter | Description
 ----------|------------
 `run_id`  | The run ID to apply
 
-Applies a run that is paused waiting for confirmation after a plan. This includes runs in the "needs confirmation" and "policy checked" states. This action is only required for runs that can't be auto-applied. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was not queued by a user without write permissions.)
+Applies a run that is paused waiting for confirmation after a plan. This includes runs in the "needs confirmation" and "policy checked" states. This action is only required for runs that can't be auto-applied. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was queued by a new VCS commit or by a user with write permissions.)
 
 This endpoint queues the request to perform an apply; the apply might not happen immediately.
 

--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -53,7 +53,7 @@ In more abstract terms, runs can be initiated by VCS webhooks, the manual "Queue
 
 ## Plans and Applies
 
-Terraform Cloud enforces Terraform's division between _plan_ and _apply_ operations. It always plans first, saves the plan's output, and uses that output for the apply. In the default configuration, it waits for user approval before running an apply, but you can configure workspaces to [automatically apply](../workspaces/settings.html#auto-apply-and-manual-apply) successful plans. (Some plans can't be auto-applied, like destroy plans or plans queued by users without write permissions.)
+Terraform Cloud enforces Terraform's division between _plan_ and _apply_ operations. It always plans first, saves the plan's output, and uses that output for the apply. In the default configuration, it waits for user approval before running an apply, but you can configure workspaces to [automatically apply](../workspaces/settings.html#auto-apply-and-manual-apply) successful plans. (Some plans can't be auto-applied, like plans queued by users without write permissions.)
 
 ### Speculative Plans
 

--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -53,7 +53,7 @@ In more abstract terms, runs can be initiated by VCS webhooks, the manual "Queue
 
 ## Plans and Applies
 
-Terraform Cloud enforces Terraform's division between _plan_ and _apply_ operations. It always plans first, saves the plan's output, and uses that output for the apply. In the default configuration, it waits for user approval before running an apply, but you can configure workspaces to [automatically apply](../workspaces/settings.html#auto-apply-and-manual-apply) successful plans. (Some plans can't be auto-applied, like plans queued by users without write permissions.)
+Terraform Cloud enforces Terraform's division between _plan_ and _apply_ operations. It always plans first, saves the plan's output, and uses that output for the apply. In the default configuration, it waits for user approval before running an apply, but you can configure workspaces to [automatically apply](../workspaces/settings.html#auto-apply-and-manual-apply) successful plans. (Some plans can't be auto-applied, like plans queued by [run triggers](../workspaces/run-triggers.html) or by users without write permissions.)
 
 ### Speculative Plans
 

--- a/content/source/docs/cloud/run/states.html.md
+++ b/content/source/docs/cloud/run/states.html.md
@@ -36,7 +36,7 @@ _Leaving this stage:_
 - If the plan succeeded and requires changes:
     - If cost estimation is enabled, the run proceeds automatically to the cost estimation stage.
     - If cost estimation is disabled and [Sentinel policies][] are enabled, the run proceeds automatically to the policy check stage.
-    - If there are no Sentinel policies and the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace, the plan is not a destroy plan, and the plan was not queued by a user without write permissions.)
+    - If there are no Sentinel policies and the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was not queued by a user without write permissions.)
     - If there are no Sentinel policies and the plan can't be auto-applied, the run pauses in the **Needs Confirmation** state until a user with write access to the workspace takes action. The run proceeds to the apply stage if they approve the apply, or skips to completion (**Discarded** state) if they reject the apply.
 
 ## 3. The Cost Estimation Stage
@@ -72,7 +72,7 @@ _Leaving this stage:_
     - If a member of the owners team overrides the failed policy, the run proceeds to the **Policy Checked** state.
     - If an owner or a user with write access discards the run, the run skips to completion (**Discarded** state).
 - If the run reaches the **Policy Checked** state (no mandatory policies failed, or soft-mandatory policies were overridden):
-    - If the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace, the plan is not a destroy plan, and the plan was not queued by a user without write permissions.)
+    - If the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was not queued by a user without write permissions.)
     - If the plan can't be auto-applied, the run pauses in the **Policy Checked** state until a user with write access takes action. The run proceeds to the apply stage if they approve the apply, or skips to completion (**Discarded** state) if they reject the apply.
 
 

--- a/content/source/docs/cloud/run/states.html.md
+++ b/content/source/docs/cloud/run/states.html.md
@@ -36,7 +36,7 @@ _Leaving this stage:_
 - If the plan succeeded and requires changes:
     - If cost estimation is enabled, the run proceeds automatically to the cost estimation stage.
     - If cost estimation is disabled and [Sentinel policies][] are enabled, the run proceeds automatically to the policy check stage.
-    - If there are no Sentinel policies and the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was not queued by a user without write permissions.)
+    - If there are no Sentinel policies and the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was queued by a new VCS commit or by a user with write permissions.)
     - If there are no Sentinel policies and the plan can't be auto-applied, the run pauses in the **Needs Confirmation** state until a user with write access to the workspace takes action. The run proceeds to the apply stage if they approve the apply, or skips to completion (**Discarded** state) if they reject the apply.
 
 ## 3. The Cost Estimation Stage
@@ -72,7 +72,7 @@ _Leaving this stage:_
     - If a member of the owners team overrides the failed policy, the run proceeds to the **Policy Checked** state.
     - If an owner or a user with write access discards the run, the run skips to completion (**Discarded** state).
 - If the run reaches the **Policy Checked** state (no mandatory policies failed, or soft-mandatory policies were overridden):
-    - If the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was not queued by a user without write permissions.)
+    - If the plan can be auto-applied, the run proceeds automatically to the apply stage. (Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was queued by a new VCS commit or by a user with write permissions.)
     - If the plan can't be auto-applied, the run pauses in the **Policy Checked** state until a user with write access takes action. The run proceeds to the apply stage if they approve the apply, or skips to completion (**Discarded** state) if they reject the apply.
 
 
@@ -102,4 +102,3 @@ _States in this stage:_
 - **Plan Errored:** The `terraform plan` command failed (usually requiring fixes to variables or code), or a hard-mandatory Sentinel policy failed. The run cannot be applied.
 - **Discarded:** A user chose not to continue this run.
 - **Canceled:** A user interrupted the `terraform plan` or `terraform apply` command with the "Cancel Run" button.
-

--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -45,7 +45,7 @@ Note that once the plan stage is completed, until you apply or discard a plan, T
 
 ### Auto apply
 
-If you would rather automatically apply plans that don't have errors, you can [enable auto apply](../workspaces/settings.html#auto-apply-and-manual-apply) on the workspace's "General Settings" page. (Some plans can't be auto-applied, like destroy plans or plans queued by users without write permissions.)
+If you would rather automatically apply plans that don't have errors, you can [enable auto apply](../workspaces/settings.html#auto-apply-and-manual-apply) on the workspace's "General Settings" page. (Some plans can't be auto-applied, like plans queued by users without write permissions.)
 
 [plan permissions](../users-teams-organizations/permissions.html#plan)
 

--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -45,7 +45,7 @@ Note that once the plan stage is completed, until you apply or discard a plan, T
 
 ### Auto apply
 
-If you would rather automatically apply plans that don't have errors, you can [enable auto apply](../workspaces/settings.html#auto-apply-and-manual-apply) on the workspace's "General Settings" page. (Some plans can't be auto-applied, like plans queued by users without write permissions.)
+If you would rather automatically apply plans that don't have errors, you can [enable auto apply](../workspaces/settings.html#auto-apply-and-manual-apply) on the workspace's "General Settings" page. (Some plans can't be auto-applied, like plans queued by [run triggers](../workspaces/run-triggers.html) or by users without write permissions.)
 
 [plan permissions](../users-teams-organizations/permissions.html#plan)
 

--- a/content/source/docs/cloud/workspaces/settings.html.md
+++ b/content/source/docs/cloud/workspaces/settings.html.md
@@ -59,6 +59,7 @@ Whether or not Terraform Cloud should automatically apply a successful Terraform
 Auto-apply has the following exception:
 
 - Plans queued by users with [plan permissions](../users-teams-organizations/permissions.html#plan) must be approved by a user with write or admin permissions.
+- Plans queued due to [run triggers](../workspaces/run-triggers.html) from another workspace must always be manually applied.
 
 ### Terraform Version
 

--- a/content/source/docs/cloud/workspaces/settings.html.md
+++ b/content/source/docs/cloud/workspaces/settings.html.md
@@ -56,9 +56,8 @@ To disable remote execution for a workspace, change its execution mode to "Local
 
 Whether or not Terraform Cloud should automatically apply a successful Terraform plan. If you choose manual apply, an operator must confirm a successful plan and choose to apply it.
 
-Auto-apply has a few exceptions:
+Auto-apply has the following exception:
 
-- [Destroy plans](#destruction-and-deletion) must always be manually applied.
 - Plans queued by users with [plan permissions](../users-teams-organizations/permissions.html#plan) must be approved by a user with write or admin permissions.
 
 ### Terraform Version


### PR DESCRIPTION
Terraform Enterprise v201912-1 introduced a change how destroy plans behave when auto apply is enabled on the workspace. This pull request updates the documentation to reflect that new behavior.