### PR TITLE
Fix DefaultFunc example

### DIFF
--- a/content/source/docs/extend/schemas/schema-behaviors.html.md
+++ b/content/source/docs/extend/schemas/schema-behaviors.html.md
@@ -271,13 +271,13 @@ provider "example" {
 ```
 
 
-**Configuration example (default func with `PROVIDER_REGION` set to `us-west` in
+**Configuration example (default func with `PROVIDER_REGION` set to `us-east` in
 the environment):**
 
 ```hcl
 provider "example" {
   api_key = "somesecretkey"
-  # region is "us-west"
+  # region is "us-east"
 }
 ```
 
@@ -287,7 +287,7 @@ environment):**
 ```hcl
 provider "example" {
   api_key = "somesecretkey"
-  # region is "us-east" 
+  # region is "us-west" 
 }
 ```
 


### PR DESCRIPTION
## Description

The default value provided by the default func when `region` attribute is unset in configuration and `PROVIDER_REGION` is unset in the environment is `us-west`, not `us-east`.