### PR TITLE
Updating access for organization tokens

### DIFF
--- a/content/source/docs/cloud/users-teams-organizations/api-tokens.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/api-tokens.html.md
@@ -79,6 +79,6 @@ The following chart illustrates the various access levels for the supported API 
 | Override policy checks         | 🔶          | 🔶          | 🔷                  |
 | **Integrations**               |             |             |                     |
 | Manage VCS connections         | 🔶          | 🔶          | 🔷                  |
-| Manage SSH keys                | 🔶          | 🔶          | 🔷                  |
+| Manage SSH keys                | 🔶          | 🔶          |                     |
 | **Modules**                    |             |             |                     |
 | Manage Terraform modules       | 🔶          | 🔶          |                     |


### PR DESCRIPTION
Organization tokens cannot use the `/ssh-keys` API endpoint as detailed [here](https://www.terraform.io/docs/cloud/api/ssh-keys.html).