### PR TITLE
Redirect moved files in helm provider

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -421,3 +421,7 @@
 
 # Deleted resource type
 /docs/providers/google/r/google_project_services.html               /docs/providers/google/guides/version_3_upgrade.html
+
+# Helm provider got its directory structure normalized, yay
+/docs/providers/helm/release.html                                   /docs/providers/helm/r/release.html
+/docs/providers/helm/repository.html                                /docs/providers/helm/d/repository.html

--- a/content/scripts/testdata/incoming-links.txt
+++ b/content/scripts/testdata/incoming-links.txt
@@ -801,8 +801,8 @@
 /docs/providers/gridscale/index.html
 /docs/providers/hcloud/index.html
 /docs/providers/helm/index.html
-/docs/providers/helm/release.html
-/docs/providers/helm/repository.html
+/docs/providers/helm/r/release.html
+/docs/providers/helm/d/repository.html
 /docs/providers/heroku/index.html
 /docs/providers/heroku/r/app.html
 /docs/providers/heroku/r/build.html


### PR DESCRIPTION
Check it out, incoming-links.txt doing what it's designed to do. These files got
moved in helm provider commit 550cedb61ee87dc69f5d6180adcb8f0eb7da6683, but were
never redirected.