### PR TITLE
cloud: add v1 paths to mock examples

### DIFF
--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -117,10 +117,13 @@ configuration file would look like:
 {
   "mock": {
     "tfconfig": "testdata/mock-tfconfig.sentinel",
+    "tfconfig/v1": "testdata/mock-tfconfig.sentinel",
     "tfconfig/v2": "testdata/mock-tfconfig-v2.sentinel",
     "tfplan": "testdata/mock-tfplan.sentinel",
+    "tfplan/v1": "testdata/mock-tfplan.sentinel",
     "tfplan/v2": "testdata/mock-tfplan-v2.sentinel",
     "tfstate": "testdata/mock-tfstate.sentinel",
+    "tfstate/v1": "testdata/mock-tfstate.sentinel",
     "tfstate/v2": "testdata/mock-tfstate-v2.sentinel",
     "tfrun": "testdata/mock-tfrun.sentinel"
   }
@@ -135,10 +138,13 @@ file. For example, the contents of `pass.json`, asserting that the result of the
 {
   "mock": {
     "tfconfig": "../../testdata/mock-tfconfig.sentinel",
+    "tfconfig/v1": "../../testdata/mock-tfconfig.sentinel",
     "tfconfig/v2": "../../testdata/mock-tfconfig-v2.sentinel",
     "tfplan": "../../testdata/mock-tfplan.sentinel",
+    "tfplan/v1": "../../testdata/mock-tfplan.sentinel",
     "tfplan/v2": "../../testdata/mock-tfplan-v2.sentinel",
     "tfstate": "../../testdata/mock-tfstate.sentinel",
+    "tfstate/v1": "../../testdata/mock-tfstate.sentinel",
     "tfstate/v2": "../../testdata/mock-tfstate-v2.sentinel",
     "tfrun": "../../testdata/mock-tfrun.sentinel"
   },


### PR DESCRIPTION
## Description

It's important to note that the v1 paths exist as we want to start to
get people in the habit of possibly future-proofing some of their legacy
policies if necessary. The v1 path allows them to do that and prepare
for a time when they might be using a workspace with v2 as the default.
