### PR TITLE
Add requisite "s"

### DIFF
--- a/content/source/docs/cloud/run/api.html.md
+++ b/content/source/docs/cloud/run/api.html.md
@@ -79,7 +79,7 @@ WORKSPACE_ID=($(curl \
 Before uploading the configuration files, you must create a `configuration-version` to associate uploaded content with the workspace. This API call performs two tasks: it creates the new configuration version and it extracts the upload URL to be used in the next step.
 
 ```bash
-echo '{"data":{"type":"configuration-version"}}' > ./create_config_version.json
+echo '{"data":{"type":"configuration-versions"}}' > ./create_config_version.json
 
 UPLOAD_URL=($(curl \
   --header "Authorization: Bearer $TOKEN" \
@@ -159,7 +159,7 @@ WORKSPACE_ID=($(curl \
 
 # 4. Create a New Configuration Version
 
-echo '{"data":{"type":"configuration-version"}}' > ./create_config_version.json
+echo '{"data":{"type":"configuration-versions"}}' > ./create_config_version.json
 
 UPLOAD_URL=($(curl \
   --header "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## Description

API call in example and in script were missing the `s` at the end of `configuration-versions`

Docs for reference:
https://www.terraform.io/docs/cloud/api/configuration-versions.html#create-a-configuration-version