### PR TITLE
Bump middleman-hashicorp version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.41"
+VERSION?="0.3.43"
 MKFILE_PATH=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DEPLOY_ENV?="development"
 

--- a/content/Gemfile
+++ b/content/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.41"
+gem "middleman-hashicorp", "0.3.43"

--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.41)
+    middleman-hashicorp (0.3.43)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -155,7 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.41)
+  middleman-hashicorp (= 0.3.43)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Update middleman-hashicorp@0.3.43 to deploy copy change - “HashiCorp Suite” -> “HashiCorp Stack”


