### PR TITLE
update redirects.txt with addtl azure rewrites

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -163,7 +163,7 @@
 /docs/providers/azurerm/authenticating_via_msi.html                     /docs/providers/azurerm/guides/managed_service_identity.html
 /docs/providers/azurerm/authenticating_via_service_principal.html       /docs/providers/azurerm/guides/service_principal_client_secret.html
 /docs/providers/azurerm/r/loadbalancer.html                             /docs/providers/azurerm/r/lb.html
-/docs/docs/providers/azurerm/r/loadbalancer_rule.html                   /docs/providers/azurerm/r/lb_rule.html
+/docs/providers/azurerm/r/loadbalancer_rule.html                   /docs/providers/azurerm/r/lb_rule.html
 
 # Azure Stack Provider
 /docs/providers/azurestack/auth/azure_cli.html                             /docs/providers/azurestack/guides/azure_cli.html

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -162,8 +162,8 @@
 /docs/providers/azurerm/authenticating_via_azure_cli.html               /docs/providers/azurerm/guides/azure_cli.html
 /docs/providers/azurerm/authenticating_via_msi.html                     /docs/providers/azurerm/guides/managed_service_identity.html
 /docs/providers/azurerm/authenticating_via_service_principal.html       /docs/providers/azurerm/guides/service_principal_client_secret.html
-/docs/providers/azurerm/r/loadbalancer.html                           /docs/providers/azurerm/guides
-/docs/docs/providers/azurerm/r/loadbalancer_rule.html                 /docs/providers/azurerm/r/lb_rule.html
+/docs/providers/azurerm/r/loadbalancer.html                             /docs/providers/azurerm/r/lb.html
+/docs/docs/providers/azurerm/r/loadbalancer_rule.html                   /docs/providers/azurerm/r/lb_rule.html
 
 # Azure Stack Provider
 /docs/providers/azurestack/auth/azure_cli.html                             /docs/providers/azurestack/guides/azure_cli.html

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -162,6 +162,8 @@
 /docs/providers/azurerm/authenticating_via_azure_cli.html               /docs/providers/azurerm/guides/azure_cli.html
 /docs/providers/azurerm/authenticating_via_msi.html                     /docs/providers/azurerm/guides/managed_service_identity.html
 /docs/providers/azurerm/authenticating_via_service_principal.html       /docs/providers/azurerm/guides/service_principal_client_secret.html
+/docs/providers/azurerm/r/loadbalancer.html                           /docs/providers/azurerm/guides
+/docs/docs/providers/azurerm/r/loadbalancer_rule.html                 /docs/providers/azurerm/r/lb_rule.html
 
 # Azure Stack Provider
 /docs/providers/azurestack/auth/azure_cli.html                             /docs/providers/azurestack/guides/azure_cli.html


### PR DESCRIPTION
## Description

this is based on a support request ZenDesk#23920 where google was returning results for these two pages but the pages would 404

the URLs that are 404'ing:

1. https://www.terraform.io/docs/providers/azurerm/r/loadbalancer.html
2. https://www.terraform.io/docs/providers/azurerm/r/loadbalancer_rule.html

proposed rewrite locations:

1. https://www.terraform.io/docs/providers/azurerm/r/lb.html
2. https://www.terraform.io/docs/providers/azurerm/r/lb_rule.html

I took my best guess at where they should terminate but I'm not 100% confident so please feel free to weigh in with a better option. 