### PR TITLE
Add references to Terraform login command

### DIFF
--- a/content/source/docs/cloud/migrate/index.html.md
+++ b/content/source/docs/cloud/migrate/index.html.md
@@ -37,8 +37,8 @@ Make sure you have all of the following:
 - A Terraform Cloud user account.
 
     This account must be a member of your organization's [owners team][], so you can create workspaces.
-- A [user API token][user-token] for your Terraform Cloud user account.
-- A [CLI configuration file][cli-credentials], with your user API token configured in a `credentials` block.
+
+You also need to authenticate Terraform with Terraform Cloud.  If you're using Terraform 0.12.21 or later, you can use the `terraform login` command. Alternatively, you can create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
 ## Step 3: Stop Terraform Runs
 

--- a/content/source/docs/cloud/migrate/workspaces.html.md
+++ b/content/source/docs/cloud/migrate/workspaces.html.md
@@ -37,8 +37,8 @@ Make sure you have all of the following:
 - A Terraform Cloud user account.
 
     This account must be a member of your organization's [owners team][], so you can create workspaces.
-- A [user API token][user-token] for your Terraform Cloud user account.
-- A [CLI configuration file][cli-credentials], with your user API token configured in a `credentials` block.
+
+You also need to authenticate Terraform with Terraform Cloud.  If you're using Terraform 0.12.21 or later, you can use the `terraform login` command. Alternatively, you can create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
 ## Step 3: Stop Terraform Runs
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -99,16 +99,9 @@ Within a given Terraform configuration, you should only use modules from one org
 
 #### Configuration
 
-To configure private module access, add a `credentials` block to your [CLI configuration file (`.terraformrc`)](/docs/commands/cli-config.html).
+To configure private module access, you need to authenticate against Terraform Cloud (or your Terraform Enterprise instance).  If you're using Terraform 0.12.21 or later, you can use the `terraform login` command. Alternatively, you can create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
-``` hcl
-credentials "app.terraform.io" {
-  token = "xxxxxx.atlasv1.zzzzzzzzzzzzz"
-}
-```
+Make sure the hostname matches the hostname you use in module sources — if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying the hostname each time.
 
-The block label for the `credentials` block must be Terraform Cloud's hostname (`app.terraform.io` or the hostname of your Terraform Enterprise instance), and the block body must contain a `token` attribute whose value is a Terraform Cloud authentication token. You can generate a personal API token from your user settings page in Terraform Cloud.
-
-Make sure the hostname matches the hostname you use in module sources — if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, you can add two `credentials` blocks with the same `token`.
-
-~> **Important:** Make sure to protect your API token. When adding an authentication token to your CLI config file, check the file permissions and make sure other users on the same computer cannot view its contents.
+[user-token]: ../users-teams-organizations/users.html#api-tokens
+[cli-credentials]: /docs/commands/cli-config.html#credentials

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -52,17 +52,11 @@ terraform {
 }
 ```
 
-A Terraform Cloud [user API token](../users-teams-organizations/users.html#api-tokens) is also needed. It should be set as `credentials` in the [CLI config file](/docs/commands/cli-config.html#credentials). User tokens can be created in the [user settings](../users-teams-organizations/users.html#user-settings).
-
-```hcl
-credentials "app.terraform.io" {
-  token = "xxxxxx.atlasv1.zzzzzzzzzzzzz"
-}
-```
+Next, run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can [manually configure credentials in the CLI config file](/docs/commands/cli-config.html#credentials).
 
 The backend can be initialized with `terraform init`.
 
-```shell
+```
 $ terraform init
 
 Initializing the backend...
@@ -122,7 +116,7 @@ Users can run speculative plans in any workspace where they have [plan access][p
 
 Speculative plans use the configuration code from the local working directory, but will use variable values from the specified workspace.
 
-```shell
+```
 $ terraform plan
 
 Running plan in the remote backend. Output will stream here. Pressing Ctrl-C
@@ -155,7 +149,7 @@ Remote applies use the configuration code from the local working directory, but 
 
 ~> **Important:** You cannot run remote applies in workspaces that are linked to a VCS repository, since the repository serves as the workspace’s source of truth. To apply changes in a VCS-linked workspace, merge your changes to the designated branch.
 
-```shell
+```
 $ terraform apply
 
 Running apply in the remote backend. Output will stream here. Pressing Ctrl-C
@@ -185,7 +179,7 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 If the specified workspace uses Sentinel policies, those policies will run against all speculative plans and remote applies in that workspace. The policy output will be available in the terminal. Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
 
-```shell
+```
 $ terraform apply
 
 [...]


### PR DESCRIPTION
Update guides for the remote backend to point at the new `terraform login` command in [0.12.21](https://github.com/hashicorp/terraform/releases/tag/v0.12.21), as this is the easier and preferred workflow for establishing credentials.