### PR TITLE
Fix maximum page size

### DIFF
--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -172,7 +172,7 @@ Most of the endpoints that return lists of objects support pagination. A client 
 Parameter      | Description
 ---------------|------------
 `page[number]` | **Optional.** If omitted, the endpoint will return the first page.
-`page[size]`   | **Optional.** If omitted, the endpoint will return 20 items per page. The maximum page size is 150.
+`page[size]`   | **Optional.** If omitted, the endpoint will return 20 items per page. The maximum page size is 100.
 
 Additional data is returned in the `links` and `meta` top level attributes of the response.
 


### PR DESCRIPTION
```json
{
    "errors": [
        {
            "detail": "page[size] must be between 1 and 100",
            "status": "422",
            "title": "invalid attribute"
        }
    ]
}
```

## Description

When making requests against our Terraform Enterprise installation, we receive an error with `page[size]` greater than 100.
