### PR TITLE
[Website] Update middleman-hashicorp to 0.3.44

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   images:
-    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.43
+    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.44
 
   cache:
     rubygem: &RUBYGEM_CACHE_KEY static-site-gems-v1-{{ checksum "content/Gemfile.lock" }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.43"
+VERSION?="0.3.44"
 MKFILE_PATH=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DEPLOY_ENV?="development"
 

--- a/content/Gemfile
+++ b/content/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.43"
+gem "middleman-hashicorp", "0.3.44"

--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       uber (~> 0.0.14)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    json (1.8.3.1)
+    json (2.3.0)
     kramdown (1.17.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.43)
+    middleman-hashicorp (0.3.44)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -104,7 +104,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     multi_json (1.14.1)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     padrino-helpers (0.12.9)
       i18n (~> 0.6, >= 0.6.7)
@@ -121,7 +121,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
-    rouge (3.15.0)
+    rouge (3.16.0)
     sass (3.4.25)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -155,7 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.43)
+  middleman-hashicorp (= 0.3.44)
 
 BUNDLED WITH
    1.17.3

--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       uber (~> 0.0.14)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    json (2.3.0)
+    json (1.8.3.1)
     kramdown (1.17.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
## Description

This PR updates the website's `middleman-hashicorp` dependency to `0.3.44`.   This version intends to mitigate potential security issues by upgrading the package's jQuery to the latest 2.x stable.