### PR TITLE
Redirect some moved/removed azurerm pages, remove from incoming-links

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -172,6 +172,16 @@
 /docs/providers/azurerm/r/loadbalancer_probe.html                       /docs/providers/azurerm/r/lb_probe.html
 /docs/providers/azurerm/d/loadbalancer.html                             /docs/providers/azurerm/d/lb.html
 /docs/providers/azurerm/d/loadbalancer_backend_address_pool.html        /docs/providers/azurerm/d/lb_backend_address_pool.html
+# Moved to azuread provider
+/docs/providers/azurerm/d/azurerm_azuread_application.html                  /docs/providers/azuread/d/azurerm_azuread_application.html
+/docs/providers/azurerm/d/azurerm_azuread_service_principal.html            /docs/providers/azuread/d/azurerm_azuread_service_principal.html
+/docs/providers/azurerm/r/azurerm_azuread_application.html                  /docs/providers/azuread/r/azurerm_azuread_application.html
+/docs/providers/azurerm/r/azurerm_azuread_service_principal.html            /docs/providers/azuread/r/azurerm_azuread_service_principal.html
+/docs/providers/azurerm/r/azurerm_azuread_service_principal_password.html   /docs/providers/azuread/r/azurerm_azuread_service_principal_password.html
+# Removed for 2.0
+/docs/providers/azurerm/r/container_service.html                        /docs/providers/azurerm/guides/2.0-upgrade-guide.html
+/docs/providers/azurerm/r/metric_alertrule.html                         /docs/providers/azurerm/guides/2.0-upgrade-guide.html
+
 
 # Azure Stack Provider
 /docs/providers/azurestack/auth/azure_cli.html                             /docs/providers/azurestack/guides/azure_cli.html

--- a/content/scripts/testdata/incoming-links.txt
+++ b/content/scripts/testdata/incoming-links.txt
@@ -568,12 +568,9 @@
 /docs/providers/azurerm/r/app_service.html
 /docs/providers/azurerm/r/application_gateway.html
 /docs/providers/azurerm/r/automation_account.html
-/docs/providers/azurerm/r/azuread_application.html
-/docs/providers/azurerm/r/azuread_service_principal_password.html
 /docs/providers/azurerm/r/cdn_profile.html
 /docs/providers/azurerm/r/container_group.html
 /docs/providers/azurerm/r/container_registry.html
-/docs/providers/azurerm/r/container_service.html
 /docs/providers/azurerm/r/cosmosdb_account.html
 /docs/providers/azurerm/r/dns_caa_record.html
 /docs/providers/azurerm/r/dns_zone.html
@@ -593,7 +590,6 @@
 /docs/providers/azurerm/r/log_analytics_workspace.html
 /docs/providers/azurerm/r/logic_app_workflow.html
 /docs/providers/azurerm/r/managed_disk.html
-/docs/providers/azurerm/r/metric_alertrule.html
 /docs/providers/azurerm/r/monitor_autoscale_setting.html
 /docs/providers/azurerm/r/monitor_diagnostic_setting.html
 /docs/providers/azurerm/r/monitor_metric_alert.html


### PR DESCRIPTION
Hello! It looks like some removed pages in the azurerm provider are on the "popular incoming links" list, and thus need redirects. 

@mbfrahry and/or @tombuildsstuff, I see y'all's names in the relevant azurerm commits. Would you like to redirect any of the other removed resources/datasources to the 2.0 upgrade guide? I could tell there were several of them, but haven't yet tried to derive a full list, and I figure either of you would be faster at that part. 