### PR TITLE
Updated new users URL on users.html.md

### DIFF
--- a/content/source/docs/cloud/users-teams-organizations/users.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/users.html.md
@@ -22,8 +22,8 @@ If someone invited you to join an existing organization, the invitation email sh
 
 Alternately, you can create an account from Terraform Cloud's sign-up page. Navigate to the sign-up page via the link on the login page, or go directly to its URL:
 
-- For the SaaS version of Terraform Cloud, create a new account at [https://app.terraform.io/account/new](https://app.terraform.io/account/new).
-- For Terraform Enterprise, go to `https://<TFE HOSTNAME>/account/new`.
+- For the SaaS version of Terraform Cloud, create a new account at [https://app.terraform.io/signup/account](https://app.terraform.io/signup/account).
+- For Terraform Enterprise, go to `https://<TFE HOSTNAME>/signup/account`.
 
 ### After Creating an Account
 

--- a/content/source/docs/enterprise/saml/troubleshooting.html.md
+++ b/content/source/docs/enterprise/saml/troubleshooting.html.md
@@ -15,7 +15,7 @@ Before starting, disable SAML SSO by going to `https://<TFE HOSTNAME>/app/admin/
 
 Before proceeding with troubleshooting, create a non-SSO admin account that can be used to log in if admin access gets revoked for other admins. The email address assigned to this user should not be one that will be used for SAML.
 
-Open `https://<TFE HOSTNAME>/account/new` to create the account. Make sure to grant admin access to this user and verify they can log in at `https://<TFE HOSTNAME>/`.
+Open `https://<TFE HOSTNAME>/signup/account` to create the account. Make sure to grant admin access to this user and verify they can log in at `https://<TFE HOSTNAME>/`.
 
 ## Enable SAML SSO and SAML debugging
 


### PR DESCRIPTION
## Description

With TFE v202001-01 and the underlying changes made on https://github.com/hashicorp/atlas/pull/8544 the documentation is now pointing to a no longer valid account creation URL.