### PR TITLE
Update TFC Bitbucket Server documentation to include information about URLS with context paths

### DIFF
--- a/content/source/docs/cloud/vcs/bitbucket-server.html.md
+++ b/content/source/docs/cloud/vcs/bitbucket-server.html.md
@@ -53,7 +53,14 @@ Leave the page open in a browser tab, and remain logged in as an admin user.
 
 3. (Optional) Enter a display name for your Bitbucket Server VCS Provider.
 
-4. Enter the URL of your Bitbucket Server instance in the HTTP URL and API URL fields. The API URL should be the same as the HTTP URL.
+4. Enter the URL of your Bitbucket Server instance in the HTTP URL and API URL fields. 
+   
+    If your Bitbucket Server instance does not have a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set, the API URL should be the same as the HTTP URL.
+
+    If your Bitbucket Server instance has a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set:
+
+    1. Set the HTTP URL to the URL of your Bitbucket Server instance with the context path included, `https://<BITBUCKET INSTANCE HOSTNAME>/<CONTEXT PATH>`.
+    1. Set the API URL to the URL of your Bitbucket Server instance **without** the context path, `https://<BITBUCKET INSTANCE HOSTNAME>/`.
 
     ~> **Note:** If Bitbucket Server isn't accessible on the standard ports (for example, if it's using its default ports of 7990 or 8443 and is not behind a reverse proxy), make sure to specify the port in the URL. If you omit the port in the URL, Terraform Cloud uses the standard port for the protocol (80 for HTTP, 443 for HTTPS).
 


### PR DESCRIPTION
## Description

A customer reported an error when trying to create a new VCS connection to Bitbucket Server. The error was occurring because their Bitbucket Server instance was using a context path, so their Bitbucket Server instance URL looked like this:
```
https://bitbucket-server.hostname.com/context-path`
```
instead of this
```
https://bitbucket-server.hostname.com`
```

This requires setting the HTTP and API URLs differently when creating a new VCS connection. I've updated the docs with a small section explaining this. 

<img width="944" alt="Screen Shot 2020-03-19 at 11 09 37 AM" src="https://user-images.githubusercontent.com/12189856/77088241-2ac7b080-69d2-11ea-9e8c-b867d680c853.png">
