### PR TITLE
cloud: remove tech preview status from v2 imports

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -12,11 +12,6 @@ Sentinel import, designed specifically for Terraform 0.12. This import requires
 Terraform 0.12 or higher, and must currently be loaded by path, using an alias,
 example: `import "tfconfig/v2" as tfconfig`.
 
-~> **Important:** The Sentinel v2 imports are currently publicly available as a
-**technology preview**. They are supported by HashiCorp, but the API is not yet
-stable and breaking changes could be made. Watch this documentation for any
-changes!
-
 # Import: tfconfig/v2
 
 The `tfconfig/v2` import provides access to a Terraform configuration.

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -12,11 +12,6 @@ import, designed specifically for Terraform 0.12. This import requires
 Terraform 0.12 or higher, and must currently be loaded by path, using an alias,
 example: `import "tfplan/v2" as tfplan`.
 
-~> **Important:** The Sentinel v2 imports are currently publicly available as a
-**technology preview**. They are supported by HashiCorp, but the API is not yet
-stable and breaking changes could be made. Watch this documentation for any
-changes!
-
 # Import: tfplan/v2
 
 The `tfplan/v2` import provides access to a Terraform plan.

--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -12,11 +12,6 @@ Sentinel import, designed specifically for Terraform 0.12. This import requires
 Terraform 0.12 or higher, and must currently be loaded by path, using an alias,
 example: `import "tfstate/v2" as tfstate`.
 
-~> **Important:** The Sentinel v2 imports are currently publicly available as a
-**technology preview**. They are supported by HashiCorp, but the API is not yet
-stable and breaking changes could be made. Watch this documentation for any
-changes!
-
 # Import: tfstate/v2
 
 The `tfstate/v2` import provides access to a Terraform state.


### PR DESCRIPTION
## Description

The API has been stable for several weeks now and I don't foresee any
further breaking changes. We should be good to go here.
