### PR TITLE
proposed_values to planned_values

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -144,8 +144,8 @@ An element in the collection has the following values:
   name, such as the `googlebeta` provider offering `google_compute_instance`.
 * `values` - An object (map) representation of the attribute values of the
   resource, whose structure depends on the resource type schema. When accessing
-  proposed state through [`proposed_values`](./tfplan-v2.html#the-proposed_values-collection),
-  unknown values will be omitted.
+  proposed state through the [`planned_values`](./tfplan-v2.html#the-planned_values-collection)
+  collection of the tfplan/v2 import, unknown values will be omitted.
 * `depends_on` - The addresses of the resources that this resource depends on.
 * `tainted` - `true` if the resource has been explicitly marked as
   [tainted](/docs/commands/taint.html) in the state.


### PR DESCRIPTION
Change proposed_values to planned_values as name of link to planned_values collection of the tfplan/v2 import.
Also, add some text to clarify what is meant so it reads "When accessing proposed state through the planned_values collection of the tfplan/v2 import, unknown values will be omitted."

## Description

Fix incorrect link as well as the name and clarify what we mean.
