### PR TITLE
cloud: correct Sentinel config file modules syntax

### DIFF
--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -65,7 +65,7 @@ To configure a module, add a `module` entry to your `sentinel.hcl` file:
 
 ```hcl
 module "foo" {
-    path = "./modules/foo.sentinel"
+    source = "./modules/foo.sentinel"
 }
 ```
 


### PR DESCRIPTION
## Description

"path" needed to be changed to "source".


