### PR TITLE
add a note that install.sh must run form its directory

### DIFF
--- a/content/source/docs/enterprise/install/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/install/automating-the-installer.html.md
@@ -294,6 +294,8 @@ cd /tmp
     public-address=5.6.7.8
 ```
 
+-> **Note**: The `./install.sh` script must be executed from the directory in which it is placed.
+
 ## Waiting for Terraform Enterprise to become ready
 
 Once the installer finishes, you may poll the `/_health_check` endpoint until a `200` is returned by the application, indicating that it is fully started:


### PR DESCRIPTION
## Description

Adding a note that the TFE installer bootstrapper must be run from the directory in which it is placed.

There were cases where people were not doing that and run into problems, so it seems like it might be helpful.
