### PR TITLE
Configure home page promo bar for swag campaign

### DIFF
--- a/content/source/assets/stylesheets/_home.scss
+++ b/content/source/assets/stylesheets/_home.scss
@@ -54,7 +54,7 @@
 
   .notification {
     display: inline-flex;
-    margin: 0 0 64px;
+    margin-top: 40px;
 
     @media (max-width: $screen-xs-max) {
       margin-bottom: 48px;
@@ -350,7 +350,7 @@
 
     span.circle {
       &:before {
-        content: "\25CF";
+        content: '\25CF';
         color: $white;
         font-size: 20px;
         line-height: 100%;

--- a/content/source/assets/stylesheets/_notification.scss
+++ b/content/source/assets/stylesheets/_notification.scss
@@ -16,6 +16,7 @@
 
   & .notification-tag {
     margin: -1px 18px 0 0;
+    flex-shrink: 0;
 
     & span {
       border: 1px solid $terraform;
@@ -39,7 +40,7 @@
     display: none;
     margin-left: 32px;
     text-decoration: underline;
-    
+
     @media (min-width: $screen-md-min) {
       display: inline-flex;
     }

--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -4,6 +4,7 @@ description: |-
   infrastructure. It is an open source tool that codifies APIs into
   declarative configuration files that can be shared amongst team members,
   treated as code, edited, reviewed, and versioned.
+show_notification: true
 ---
 
 <% content_for(:custom_share) do %>

--- a/content/source/layouts/_notification.erb
+++ b/content/source/layouts/_notification.erb
@@ -1,10 +1,10 @@
 
-<a class="notification" href="https://app.terraform.io/signup?utm_source=banner&utm_campaign=intro_tf_cloud_remote">
+<a class="notification" href="https://terraform.cloud/goodie-pack?utm_source=banner&utm_campaign=swag_campaign">
   <div class="notification-tag">
-    <span>New</span>
+    <span>Get yours today</span>
   </div>
   <div class="notification-text">
-    <span>Introducing Terraform Cloud Remote State Management</span>
+    <span>Try Terraform Cloud and get your goodie pack</span>
     <span class="notification-link">
         Sign Up For Free
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 12H20" stroke="#5F43E9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 6L20 12L14 18" stroke="#5F43E9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
## Description

In support of the goodie pack promo campaign, this adds a promo bar to the homepage linking over to the promo campaign landing page.

<img width="1601" alt="Screenshot 2020-04-07 11 19 34" src="https://user-images.githubusercontent.com/845983/78687001-ac1fae00-78c1-11ea-8f6c-768dff76f35d.png">

