### PR TITLE
Updated the clustering information warning

### DIFF
--- a/content/source/docs/enterprise/before-installing/cluster-architecture.html.md
+++ b/content/source/docs/enterprise/before-installing/cluster-architecture.html.md
@@ -7,7 +7,7 @@ page_title: "Clustered Deployment Architecture - Before Installing - Terraform E
 
 Terraform Enterprise's clustered deployment method deploys Terraform Enterprise in a flexible and scalable architecture, which can range from a three-node cluster to over a hundred nodes.
 
-~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
+~> **Important:** The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Terraform-based Deployment
 

--- a/content/source/docs/enterprise/before-installing/cluster-architecture.html.md
+++ b/content/source/docs/enterprise/before-installing/cluster-architecture.html.md
@@ -7,7 +7,7 @@ page_title: "Clustered Deployment Architecture - Before Installing - Terraform E
 
 Terraform Enterprise's clustered deployment method deploys Terraform Enterprise in a flexible and scalable architecture, which can range from a three-node cluster to over a hundred nodes.
 
-~> **Important:** Terraform Enterprise clustering is in Controlled Availability; the application is fully ready for production use, but due to the variability in deployment environments the installation process requires consultation with a Technical Account Manager. Please contact your TAM to request access.
+~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Terraform-based Deployment
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -25,7 +25,7 @@ There are two ways to install Terraform Enterprise:
 
 - **Clustered deployment:** Deploy Terraform Enterprise as a cluster of three or more instances using a Terraform module. Installation is automated, and you configure your deployment via the module's input variables. The cluster's secondary instances can scale horizontally to fit your enterprise's workloads.
 
-    ~> **Important:** Terraform Enterprise clustering is in Controlled Availability; the application is fully ready for production use, but due to the variability in deployment environments the installation process requires consultation with a Technical Account Manager. Please contact your TAM to request access.
+    ~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
     For more information, see [Cluster Architecture](./cluster-architecture.html).
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -25,7 +25,7 @@ There are two ways to install Terraform Enterprise:
 
 - **Clustered deployment:** Deploy Terraform Enterprise as a cluster of three or more instances using a Terraform module. Installation is automated, and you configure your deployment via the module's input variables. The cluster's secondary instances can scale horizontally to fit your enterprise's workloads.
 
-    ~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
+    ~> **Important:** The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
     For more information, see [Cluster Architecture](./cluster-architecture.html).
 

--- a/content/source/docs/enterprise/install/cluster-aws.html.md
+++ b/content/source/docs/enterprise/install/cluster-aws.html.md
@@ -14,7 +14,7 @@ page_title: "AWS - Clustered Deployment - Install and Config - Terraform Enterpr
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster on Amazon Web Services (AWS).
 
-~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
+~> **Important:** The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-aws.html.md
+++ b/content/source/docs/enterprise/install/cluster-aws.html.md
@@ -14,7 +14,7 @@ page_title: "AWS - Clustered Deployment - Install and Config - Terraform Enterpr
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster on Amazon Web Services (AWS).
 
-~> **Important:** Terraform Enterprise clustering is in Controlled Availability; the application is fully ready for production use, but due to the variability in deployment environments the installation process requires consultation with a Technical Account Manager. Please contact your TAM to request access.
+~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-azure.html.md
+++ b/content/source/docs/enterprise/install/cluster-azure.html.md
@@ -14,7 +14,7 @@ page_title: "Azure - Clustered Deployment - Install and Config - Terraform Enter
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster on Azure.
 
-~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
+~> **Important:** The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-azure.html.md
+++ b/content/source/docs/enterprise/install/cluster-azure.html.md
@@ -14,7 +14,7 @@ page_title: "Azure - Clustered Deployment - Install and Config - Terraform Enter
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster on Azure.
 
-~> **Important:** Terraform Enterprise clustering is in Controlled Availability; the application is fully ready for production use, but due to the variability in deployment environments the installation process requires consultation with a Technical Account Manager. Please contact your TAM to request access.
+~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-custom.html.md
+++ b/content/source/docs/enterprise/install/cluster-custom.html.md
@@ -7,7 +7,7 @@ page_title: "Custom - Clustered Deployment - Install and Config - Terraform Ente
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster into a custom environment, using any type of cloud or on-premises infrastructure.
 
-~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
+~> **Important:** The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-custom.html.md
+++ b/content/source/docs/enterprise/install/cluster-custom.html.md
@@ -7,7 +7,7 @@ page_title: "Custom - Clustered Deployment - Install and Config - Terraform Ente
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster into a custom environment, using any type of cloud or on-premises infrastructure.
 
-~> **Important:** Terraform Enterprise clustering is in Controlled Availability; the application is fully ready for production use, but due to the variability in deployment environments the installation process requires consultation with a Technical Account Manager. Please contact your TAM to request access.
+~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-gcp.html.md
+++ b/content/source/docs/enterprise/install/cluster-gcp.html.md
@@ -14,7 +14,7 @@ page_title: "GCP - Clustered Deployment - Install and Config - Terraform Enterpr
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster on Google Cloud Platform (GCP).
 
-~> **Important:** Terraform Enterprise clustering is in Controlled Availability; the application is fully ready for production use, but due to the variability in deployment environments the installation process requires consultation with a Technical Account Manager. Please contact your TAM to request access.
+~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 

--- a/content/source/docs/enterprise/install/cluster-gcp.html.md
+++ b/content/source/docs/enterprise/install/cluster-gcp.html.md
@@ -14,7 +14,7 @@ page_title: "GCP - Clustered Deployment - Install and Config - Terraform Enterpr
 
 This page outlines the procedure for deploying a Terraform Enterprise cluster on Google Cloud Platform (GCP).
 
-~> **Important**: The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
+~> **Important:** The clustered version of Terraform Enterprise is in Controlled Availability as we refine the installation experience. Access is currently restricted to a select group of existing customers, and you should not attempt to install it until it reaches General Availability.
 
 ## Summary
 


### PR DESCRIPTION
## Description
Our previous **Information** warning about clustering was leading customers to believe that they could open support tickets or ask their TAMs in order to be allowed to install v5. @glasner and I updated the wording to be less vague to deter customers from opening support tickets asking for v5.

_Describe why you're making this change._
