### PR TITLE
Add note explaining that GitHub App is only available in Terraform Cloud

### DIFF
--- a/content/source/docs/cloud/vcs/github-app.html.md
+++ b/content/source/docs/cloud/vcs/github-app.html.md
@@ -17,6 +17,8 @@ Using GitHub this way does not require any action from a Terraform Cloud [organi
 
 This method uses a preconfigured GitHub App, and only works with GitHub.com. There are separate instructions for connecting to [GitHub.com via OAuth](./github.html), connecting to [GitHub Enterprise](./github-enterprise.html), and connecting to [other supported VCS providers.](./index.html)
 
+-> **Note:** This VCS Provider is only available on Terraform Cloud. If you are using Terraform Enterprise, you will need to follow the instructions for connecting to [GitHub.com via OAuth](./github.html)
+
 ## Using GitHub Repositories
 
 Choose "GitHub.com" on the "Connect to a version control provider" screen, which is shown when [creating a new workspace][create] or [changing a workspace's VCS connection][vcs settings]. Authorize access to GitHub if necessary. On the next screen, select a GitHub account or organization from the drop-down menu (or add a new organization) and choose a repository from the list.

--- a/content/source/docs/cloud/vcs/github.html.md
+++ b/content/source/docs/cloud/vcs/github.html.md
@@ -5,7 +5,7 @@ page_title: "GitHub.com (OAuth) - VCS Providers - Terraform Cloud"
 
 # Configuring GitHub.com Access (OAuth)
 
-These instructions are for using GitHub.com for Terraform Cloud's VCS features, using a per-organization OAuth connection with the permissions of one particular GitHub user. For beginning users, we recommend using our [configuration-free GitHub App](./github-app.html) to access repositories instead.
+These instructions are for using GitHub.com for Terraform Cloud's VCS features, using a per-organization OAuth connection with the permissions of one particular GitHub user. For beginning users on Terraform Cloud, we recommend using our [configuration-free GitHub App](./github-app.html) to access repositories instead.
 
 [GitHub Enterprise has separate instructions,](./github-enterprise.html) as do the [other supported VCS providers.](./index.html)
 


### PR DESCRIPTION
## Description

The GitHub App documentation doesn't make it clear that this VCS provider is only available on Terraform Cloud currently. I've added a note box to call this out and made a small tweak to the beginning of the docs on GitHub OAuth.

## Screenshots

![Screenshot_2020-04-14 GitHub com (GitHub App) - VCS Providers - Terraform Cloud - Terraform by HashiCorp](https://user-images.githubusercontent.com/12189856/79246482-e697c680-7e3e-11ea-828e-442170d40154.png)

![Screenshot_2020-04-14 GitHub com (OAuth) - VCS Providers - Terraform Cloud - Terraform by HashiCorp](https://user-images.githubusercontent.com/12189856/79246508-ea2b4d80-7e3e-11ea-956c-5639fc0b1721.png)
