### PR TITLE
CSS: Restore size of code spans within headers

### DIFF
--- a/content/source/assets/stylesheets/_inner.scss
+++ b/content/source/assets/stylesheets/_inner.scss
@@ -197,7 +197,7 @@
   h4 > code,
   h5 > code h6 > code {
     color: inherit;
-    font-size: 50%;
+    font-size: 90%;
     margin: 0 5px;
   }
 


### PR DESCRIPTION
Partial revert of c353899183.

@kylemac, this was your commit that I'm proposing we back out, so I wanted to pull you in for context and approval! Do you remember what visual problem the original commit was addressing? Did it predate the most recent font stack refresh? 

Right now, code spans within headers look tiny, like they got lost and don't belong in the header:

![Screenshot_2020-04-20 Enforcing Policies - Getting Started - Terraform Cloud - Terraform by HashiCorp(1)](https://user-images.githubusercontent.com/484309/79813217-e06a8400-832f-11ea-8a89-836fe284a725.png)

Going back to 90% makes them look less distracting:

![Screenshot_2020-04-20 Enforcing Policies - Getting Started - Terraform Cloud - Terraform by HashiCorp](https://user-images.githubusercontent.com/484309/79813243-eceedc80-832f-11ea-83f2-4b8ede37820a.png)