### PR TITLE
Removing Gitlab Subgroups unsupported note

### DIFF
--- a/content/source/docs/cloud/registry/publish.html.md
+++ b/content/source/docs/cloud/registry/publish.html.md
@@ -7,8 +7,6 @@ page_title: "Publishing Private Modules - Private Module Registry - Terraform Cl
 
 # Publishing Modules to the Terraform Cloud Private Module Registry
 
--> **Note:** Currently, the private module registry works with all supported VCS providers; however, the private module registry does not support [GitLab subgroups](https://about.gitlab.com/features/subgroups/).
-
 Terraform Cloud's private module registry lets you publish Terraform modules to be consumed by users across your organization. It works much like the public [Terraform Registry](/docs/registry/index.html), except that it uses your configured [VCS integrations][vcs] instead of requiring public GitHub repositories.
 
 Only members of the "owners" team can publish new modules. Once a module is published, the ability to release new versions is managed by your VCS provider.


### PR DESCRIPTION
Gitlab subgroups are now supported, so removing the note indicating they aren't

## Description

We've had several customers confirm the work we did to unify the VCS experience has corrected this problem, so removing the statement in the docs that it exists