### PR TITLE
Documentation for new TFE "allow speculative plans on pull requests from forks" setting

### DIFF
--- a/content/source/docs/cloud/api/admin/settings.html.md
+++ b/content/source/docs/cloud/api/admin/settings.html.md
@@ -20,6 +20,8 @@ page_title: "Terraform Enterprise Settings - API Docs - Terraform Cloud"
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
+[speculative plans]: /docs/cloud/run/index.html#speculative-plans
+
 # Terraform Enterprise Settings API
 
 -> **Terraform Enterprise feature:** The admin API is exclusive to Terraform Enterprise, and can only be used by the admins and operators who install and maintain their organization's Terraform Enterprise instance.
@@ -55,7 +57,9 @@ curl \
     "attributes": {
       "limit-user-organization-creation": true,
       "api-rate-limiting-enabled": true,
-      "api-rate-limit": 30
+      "api-rate-limit": 30,
+      "send-passing-statuses-for-untriggered-speculative-plans": true,
+      "allow-speculative-plans-on-pull-requests-from-forks": false
     }
   }
 }
@@ -75,11 +79,13 @@ Status  | Response                                     | Reason
 
 This PATCH endpoint requires a JSON object with the following properties as a request payload.
 
-Key path                                          | Type     | Default                   | Description
---------------------------------------------------|----------|---------------------------|------------
-`data.attributes.limit-user-organization-creation`| bool     | `true`                    | When set to `true`, limits the ability to create organizations to users with the `site-admin` permission only.
-`data.attributes.api-rate-limiting-enabled`       | bool     | `true`                    | Whether or not rate limiting is enabled for API requests. To learn more about API Rate Limiting, refer to the [rate limiting documentation][]
-`data.attributes.api-rate-limit`                  | integer  | 30                        | The number of allowable API requests per second for any client. This value cannot be less than 30. To learn more about API Rate Limiting, refer to the [rate limiting documentation][]
+Key path                                                                 | Type     | Default                   | Description
+-------------------------------------------------------------------------|----------|---------------------------|------------
+`data.attributes.limit-user-organization-creation`                       | bool     | `true`                    | When set to `true`, limits the ability to create organizations to users with the `site-admin` permission only.
+`data.attributes.api-rate-limiting-enabled`                              | bool     | `true`                    | Whether or not rate limiting is enabled for API requests. To learn more about API Rate Limiting, refer to the [rate limiting documentation][]
+`data.attributes.api-rate-limit`                                         | integer  | 30                        | The number of allowable API requests per second for any client. This value cannot be less than 30. To learn more about API Rate Limiting, refer to the [rate limiting documentation][]
+`data.attributes.send-passing-statuses-for-untriggered-speculative-plans`| bool     | `true`                    | When set to `true`, workspaces automatically send passing commit statuses for any pull requests that don't affect its tracked files.
+`data.attributes.allow-speculative-plans-on-pull-requests-from-forks`    | bool     | `false`                   | When set to `false`, [speculative plans][] are not run on pull requests from forks of a repository. This setting is available in Terraform Enterprise versions v202005-1 or later. It is currently supported for the following VCS providers: GitHub.com, GitHub.com (OAuth), GitHub Enterprise, Bitbucket Cloud, Azure DevOps Server, Azure DevOps Services. To learn more about this setting, refer to the [documentation](/docs/enterprise/admin/general.html#allow-speculative-plans-on-pull-requests-from-forks)
 
 [rate limiting documentation]: ../index.html#rate-limiting
 
@@ -113,12 +119,14 @@ curl \
 ```json
 {
   "data": {
-    "id":"general",
-    "type":"general-settings",
+    "id": "general",
+    "type": "general-settings",
     "attributes": {
       "limit-user-organization-creation": true,
       "api-rate-limiting-enabled": true,
-      "api-rate-limit": 50
+      "api-rate-limit": 50,
+      "send-passing-statuses-for-untriggered-speculative-plans": true,
+      "allow-speculative-plans-on-pull-requests-from-forks": false
     }
   }
 }

--- a/content/source/docs/cloud/api/admin/settings.html.md
+++ b/content/source/docs/cloud/api/admin/settings.html.md
@@ -84,7 +84,7 @@ Key path                                                                 | Type 
 `data.attributes.limit-user-organization-creation`                       | bool     | `true`                    | When set to `true`, limits the ability to create organizations to users with the `site-admin` permission only.
 `data.attributes.api-rate-limiting-enabled`                              | bool     | `true`                    | Whether or not rate limiting is enabled for API requests. To learn more about API Rate Limiting, refer to the [rate limiting documentation][]
 `data.attributes.api-rate-limit`                                         | integer  | 30                        | The number of allowable API requests per second for any client. This value cannot be less than 30. To learn more about API Rate Limiting, refer to the [rate limiting documentation][]
-`data.attributes.send-passing-statuses-for-untriggered-speculative-plans`| bool     | `true`                    | When set to `true`, workspaces automatically send passing commit statuses for any pull requests that don't affect its tracked files.
+`data.attributes.send-passing-statuses-for-untriggered-speculative-plans`| bool     | `true`                    | When set to `true`, workspaces automatically send passing commit statuses for any pull requests that don't affect their tracked files.
 `data.attributes.allow-speculative-plans-on-pull-requests-from-forks`    | bool     | `false`                   | When set to `false`, [speculative plans][] are not run on pull requests from forks of a repository. This setting is available in Terraform Enterprise versions v202005-1 or later. It is currently supported for the following VCS providers: GitHub.com, GitHub.com (OAuth), GitHub Enterprise, Bitbucket Cloud, Azure DevOps Server, Azure DevOps Services. To learn more about this setting, refer to the [documentation](/docs/enterprise/admin/general.html#allow-speculative-plans-on-pull-requests-from-forks)
 
 [rate limiting documentation]: ../index.html#rate-limiting
@@ -790,4 +790,3 @@ curl \
   }
 }
 ```
-

--- a/content/source/docs/cloud/api/organization-memberships.html.md
+++ b/content/source/docs/cloud/api/organization-memberships.html.md
@@ -20,8 +20,6 @@ page_title: "Organization Memberships - API Docs - Terraform Cloud"
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
 [JSON API error object]: http://jsonapi.org/format/#error-objects
 
-[speculative plans]: ../run/index.html#speculative-plans
-
 # Organization Memberships API
 
 Users are added to organizations by inviting them to join. Once accepted, they become members of the organization. The Organization Membership resource represents this membership.

--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -59,7 +59,7 @@ Speculative plans for PRs are based on the contents of the head branch (the bran
 
 -> **Note:** To avoid executing malicious code or exposing sensitive information, Terraform Cloud doesn't run speculative plans for pull requests that originate from other forks of a repository. 
 
-On Terraform Enterprise versions v202005-1 or later, the ability to perform speculative plans on pull requests that originate from forks can be enabled by an administrator. To learn more about this setting, refer to the [general settings documentation](/docs/enterprise/admin/general.html#allow-speculative-plans-on-pull-requests-from-forks)
+On Terraform Enterprise versions v202005-1 or later, administrators can allow speculative plans on pull requests that originate from forks. To learn more about this setting, refer to the [general settings documentation](/docs/enterprise/admin/general.html#allow-speculative-plans-on-pull-requests-from-forks)
 
 ## Speculative Plans During Development
 

--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -15,7 +15,7 @@ Terraform Cloud has three workflows for managing Terraform runs.
 
 In the UI and VCS workflow, every workspace is associated with a specific branch of a VCS repo of Terraform configurations. Terraform Cloud registers webhooks with your VCS provider when you create a workspace, then automatically queues a Terraform run whenever new commits are merged to that branch of workspace's linked repository.
 
-Terraform Cloud also performs a [speculative plan][] when a pull request is opened against that branch from another branch in the linked repository. Terraform Cloud posts a link to the plan in the pull request, and re-runs the plan if the pull request is updated.
+Terraform Cloud also performs a [speculative plan][] when a pull request is opened against that branch. Terraform Cloud posts a link to the plan in the pull request, and re-runs the plan if the pull request is updated.
 
 [speculative plan]: ./index.html#speculative-plans
 
@@ -57,7 +57,9 @@ Speculative plans are re-run if the code in a pull request is updated.
 
 Speculative plans for PRs are based on the contents of the head branch (the branch that the PR proposes to merge into the destination branch), and they compare against the workspace's current state at the time the plan was run. This means that if the destination branch changes significantly after the head branch is created, the speculative plan might not accurately show the results of accepting the PR. To get a more accurate view, you can rebase the head branch onto a more recent commit, or merge the destination branch into the head branch.
 
--> **Note:** To avoid executing malicious code or exposing sensitive information, Terraform Cloud doesn't run speculative plans for pull requests that originate from other forks of a repository.
+-> **Note:** To avoid executing malicious code or exposing sensitive information, Terraform Cloud doesn't run speculative plans for pull requests that originate from other forks of a repository. 
+
+On Terraform Enterprise versions v202005-1 or later, the ability to perform speculative plans on pull requests that originate from forks can be enabled by an administrator. To learn more about this setting, refer to the [general settings documentation](/docs/enterprise/admin/general.html#allow-speculative-plans-on-pull-requests-from-forks)
 
 ## Speculative Plans During Development
 

--- a/content/source/docs/cloud/vcs/index.html.md
+++ b/content/source/docs/cloud/vcs/index.html.md
@@ -48,7 +48,7 @@ To use configurations from VCS, Terraform Cloud needs to do several things:
 Terraform Cloud uses webhooks to monitor new commits and pull requests.
 
 - When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace.
-- When someone submits a pull request/merge request to a branch from another branch in the same repository, Terraform Cloud performs a [speculative plan](../run/index.html#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
+- When someone submits a pull request/merge request to a branch, any Terraform Cloud workspaces based on that branch will perform a [speculative plan](../run/index.html#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
 
 ### SSH Keys
 

--- a/content/source/docs/enterprise/admin/general.html.md
+++ b/content/source/docs/enterprise/admin/general.html.md
@@ -3,6 +3,8 @@ layout: "enterprise"
 page_title: "General Settings - Application Administration - Terraform Enterprise"
 ---
 
+[speculative plans]: /docs/cloud/run/index.html#speculative-plans
+
 # Administration: General Settings
 
 General settings control global behavior in Terraform Enterprise. To access general settings, visit the site admin area and click **Settings** in the left menu. To save the settings, click **Save Settings** at the bottom of the page.
@@ -36,3 +38,17 @@ These are configurable on a global level:
 or in the Admin settings at an organization level:
 
 ![screenshot: organization run timeout page](./images/admin-org-timeout-settings.png)
+
+## Commit Statuses for Untriggered Speculative Plans
+
+This setting affects Terraform Enterprise's behavior with shared VCS repositories that contain multiple Terraform configurations.
+
+Workspaces that use part of a shared repository typically don't run plans for changes that don't affect their files; this includes [speculative plans][] on pull requests. Since "pending" status checks can block pull requests, a workspace will automatically send passing commit statuses for any PRs that don't affect its files.
+
+However, if this results in sending too many status checks to your VCS provider due to a large number of workspaces sharing one VCS repository, you can disable this behavior and ignore the pending status checks for unaffected workspaces.
+
+## Allow Speculative Plans on Pull Requests from Forks
+
+~> **Note:** This setting is available in Terraform Enterprise versions v202005-1 or later. It is currently supported for the following VCS providers: GitHub.com, GitHub.com (OAuth), GitHub Enterprise, Bitbucket Cloud, Azure DevOps Server, Azure DevOps Services.
+
+By default, this setting is disabled because Terraform Enterprise assumes that forks of a trusted repository are not necessarily themselves trusted. Enabling this setting may allow Terraform Enterprise to execute malicious code or expose sensitive information through [speculative plans][] on pull requests that originated from a repository fork.

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -312,6 +312,8 @@ Different VCS providers handle forks differently, but a fork is usually owned by
 
 Terraform Cloud makes extensive use of VCS repos, and assumes that forks of a trusted repo are not necessarily trusted. As such, Terraform Cloud avoids evaluating any code from external forks, which prevents Terraform Cloud from running [speculative plans][] for [pull requests][] from forks.
 
+On [Terraform Enterprise][], [speculative plans][] on [pull requests][] from forks can be enabled by an administrator. 
+
 ## Git
 
 [git]: glossary.html#git

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -734,6 +734,16 @@ In Terraform Cloud, runs are performed in a series of stages ([plan][], [policy 
 - [Learn Terraform: Getting Started](https://learn.hashicorp.com/terraform/getting-started/install)
 - [Terraform Cloud docs: About Runs](/docs/cloud/run/index.html)
 
+## Run Triggers
+
+[run triggers]: glossary.html#run-triggers
+
+-> Terraform Cloud
+
+Terraform Cloud provides a way to connect a given workspace to one or more workspaces within an organization, known as "source workspaces". These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces.
+
+- [Terraform Cloud docs: Runs Triggers](/docs/cloud/workspaces/run-triggers.html)
+
 ## S3
 
 [s3]: glossary.html#s3


### PR DESCRIPTION
## Description

We are adding a new setting to the TFE admin to allow admins to choose to allow speculative plans on pull requests from forks. This PR updates the documentation to make note of this setting. 

I also added run triggers to the glossary and documentation for the "commit statuses for untriggered speculative plans" setting, since both were missing.

## Screenshots

#### Admin settings API:
![admin-api](https://user-images.githubusercontent.com/12189856/80121603-23a43d00-8552-11ea-9198-6f171a9e221d.png)

#### TFE admin general settings docs:
![admin-general-settings](https://user-images.githubusercontent.com/12189856/80121650-3454b300-8552-11ea-83d5-dafbf7a8caae.png)

#### Run UI docs:
![run-ui-1](https://user-images.githubusercontent.com/12189856/80121622-29018780-8552-11ea-96fe-baf4c6917455.png)
![run-ui-2](https://user-images.githubusercontent.com/12189856/80121632-2bfc7800-8552-11ea-9ea5-f6c3dfee45d5.png)

#### VCS index docs:
![vcs-index](https://user-images.githubusercontent.com/12189856/80121639-2ef76880-8552-11ea-970c-a65b7200d38f.png)

#### Glossary:
No screenshots of the glossary as it doesn't seem to run properly locally.
