### PR TITLE
Update index.html.md

### DIFF
--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -81,4 +81,4 @@ For full details about the stages of a run, see [Run States and Stages][].
 
 Terraform Cloud does not support remote execution for `terraform import`. For this command the workspace acts only as a remote backend for Terraform state, with all execution occuring on your own workstations or continuous integration workers.
 
-Terraform variables defined in the workspace are available, however environment variables defined in the workspace are not available to `terraform import`, and must be defined within your local execution scope.
+Since `terraform import` runs locally, environment variables defined in the workspace are not available. Any environment variables required by the provider you're importing from must be defined within your local execution scope.

--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -76,3 +76,9 @@ In the list of workspaces on Terraform Cloud's main page, each workspace shows t
 For full details about the stages of a run, see [Run States and Stages][].
 
 [Run States and Stages]: ./states.html
+
+## Import
+
+Terraform Cloud does not support remote execution for `terraform import`. For this command the workspace acts only as a remote backend for Terraform state, with all execution occuring on your own workstations or continuous integration workers.
+
+Terraform variables defined in the workspace are available, however environment variables defined in the workspace are not available to `terraform import`, and must be defined within your local execution scope.


### PR DESCRIPTION
## Description

Re https://github.com/hashicorp/terraform/issues/23407

I could not find any documentation making it clear that import will run never on Terraform Cloud's own servers even if Remote execution is configured.

I didn't know if there was a bug with my Terraform version, provider version or configuration & it took a fair bit of digging to find the relevant issue in github.