### PR TITLE
adding permissions considerations for vcs/terraform

### DIFF
--- a/content/source/docs/cloud/vcs/index.html.md
+++ b/content/source/docs/cloud/vcs/index.html.md
@@ -41,7 +41,7 @@ To use configurations from VCS, Terraform Cloud needs to do several things:
 - Register webhooks with your VCS provider, to get notified of new commits to a chosen branch.
 - Download the contents of a repository at a specific commit in order to run Terraform with that code.
 
-~> **Important:** Terraform Cloud's authorization controls are not inherited from your VCS provider. This means that the user you use when integrating Terraform Cloud with a VCS may have a different level of access to repositories than it does within Terraform Cloud itself. Keep this in mind when selecting a user, as it may affect your security posture in one or both systems.
+~> **Important:** Terraform Cloud usually performs VCS actions using a designated VCS user account, but it has no other knowledge about your VCS's authorization controls and does not associate Terraform Cloud user accounts with VCS user accounts. This means Terraform Cloud's VCS user might have a different level of access to repositories than any given Terraform Cloud user. Keep this in mind when selecting a VCS user, as it may affect your security posture in one or both systems.
 
 ### Webhooks
 

--- a/content/source/docs/cloud/vcs/index.html.md
+++ b/content/source/docs/cloud/vcs/index.html.md
@@ -41,6 +41,8 @@ To use configurations from VCS, Terraform Cloud needs to do several things:
 - Register webhooks with your VCS provider, to get notified of new commits to a chosen branch.
 - Download the contents of a repository at a specific commit in order to run Terraform with that code.
 
+~> **Important:** Terraform Cloud's authorization controls are not inherited from your VCS provider. This means that the user you use when integrating Terraform Cloud with a VCS may have a different level of access to repositories than it does within Terraform Cloud itself. Keep this in mind when selecting a user, as it may affect your security posture in one or both systems.
+
 ### Webhooks
 
 Terraform Cloud uses webhooks to monitor new commits and pull requests.


### PR DESCRIPTION
per TOB-TFE-036 in the recent TFE security assessment, it was noted that we are not explicit that permissions between VCS and TFC/E are not synchronized. This PR adds information to indicate that customers should be aware of the security implications of using any given VCS user as a conduit between these two systems.
