### PR TITLE
Custom Provider – Specify the go mod init command

### DIFF
--- a/content/source/docs/extend/writing-custom-providers.html.md
+++ b/content/source/docs/extend/writing-custom-providers.html.md
@@ -103,11 +103,10 @@ This establishes the main function to produce a valid, executable Go binary. The
 contents of the main function consume Terraform's `plugin` library. This library
 deals with all the communication between Terraform core and the plugin.
 
-The plugin will need to be created as a go module, so you should run the 
-command to initialize the go module.
+We recommend using Go modules for dependency management, to define this directory as the root of a module, use the `go mod init` command:
 
 ```shell
- go mod init terraform-provider-example
+ go mod init example.com/terraform-provider-example
 ```
 
 Next, build the plugin using the Go toolchain:

--- a/content/source/docs/extend/writing-custom-providers.html.md
+++ b/content/source/docs/extend/writing-custom-providers.html.md
@@ -103,6 +103,13 @@ This establishes the main function to produce a valid, executable Go binary. The
 contents of the main function consume Terraform's `plugin` library. This library
 deals with all the communication between Terraform core and the plugin.
 
+The plugin will need to be created as a go module, so you should run the 
+command to initialize the go module.
+
+```shell
+ go mod init terraform-provider-example
+```
+
 Next, build the plugin using the Go toolchain:
 
 ```shell


### PR DESCRIPTION
As a rookie to go, I ran into problems with the commands of the blog post.

I found that I was not the first person to run into these problems building a terraform provider:
https://stackoverflow.com/questions/58700756/setting-up-go-environment-for-creating-custom-terraform-providers

Running this command helped for me.