### PR TITLE
Updated the Managing Sentinel Policies documentation to incl. Sentinel Modules

### DIFF
--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -104,7 +104,7 @@ Sentinel policies themselves are defined in individual files (one per policy) in
 
 Using the `enforce-terraform-maintenance-windows.sentinel` policy as an example, we can use the `time` and `tfrun` imports along with our custom `timezone` module to enforce checks that:
 
-1. Load the time when the Terraform Run occurred
+1. Load the time when the Terraform run occurred
 1. Convert the loaded time to PST
 1. Verify that the provisioning operation is only going to occur on an agreed upon day
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -69,6 +69,8 @@ module "timezone" {
 }
 ```
 
+-> **NOTE:** At this point in time, you cannot load modules from outside of the policy set working directory hierarchy. This means in the above example, a `source` of `../modules/timezone.sentinel` will not work.
+
 Create a `modules` directory within the policy set working directory, and create a `timezone.sentinel` that looks as follows:
 
 ```sentinel
@@ -95,8 +97,6 @@ offset = func(abbr) {
 ```
 
 The above configuration would tell a policy check to load the code at `./modules/timezone.sentinel` relative to the policy set working directory and make it available to be imported with the statement `import "timezone"` at the top of your Sentinel policy code. This module will be available to all of the policies within the policy set.
-
--> **NOTE:** At this point in time, you cannot load modules from outside of policy set working directory hierarchy. This means in the above example, a `source` of `../modules/timezone.sentinel` will not work.
 
 ### Sentinel policy code files
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -48,12 +48,12 @@ Every policy set requires a configuration file named `sentinel.hcl`. This config
 The `sentinel.hcl` configuration file may contain any number of entries which look like this:
 
 ```hcl
-policy "enforce-terraform-maintenance-windows" {
+policy "terraform-maintenance-windows" {
     enforcement_level = "hard-mandatory"
 }
 ```
 
-In the above, a policy named `enforce-terraform-maintenance-windows` is defined with a `hard-mandatory` [enforcement level](#enforcement-levels).
+In the above, a policy named `terraform-maintenance-windows` is defined with a `hard-mandatory` [enforcement level](#enforcement-levels).
 
 #### Modules
 
@@ -100,9 +100,9 @@ The above configuration would tell a policy check to load the code at `./modules
 
 ### Sentinel policy code files
 
-Sentinel policies themselves are defined in individual files (one per policy) in the same directory as the `sentinel.hcl` file. These files must match the name of the policy from the configuration file and carry the `.sentinel` suffix. Using the configuration example above, a policy file named `enforce-terraform-maintenance-windows.sentinel` should also exist alongside the `sentinel.hcl` file to complete the policy set. 
+Sentinel policies themselves are defined in individual files (one per policy) in the same directory as the `sentinel.hcl` file. These files must match the name of the policy from the configuration file and carry the `.sentinel` suffix. Using the configuration example above, a policy file named `terraform-maintenance-windows.sentinel` should also exist alongside the `sentinel.hcl` file to complete the policy set. 
 
-Using the `enforce-terraform-maintenance-windows.sentinel` policy as an example, we can use the `time` and `tfrun` imports along with our custom `timezone` module to enforce checks that:
+Using the `terraform-maintenance-windows.sentinel` policy as an example, we can use the `time` and `tfrun` imports along with our custom `timezone` module to enforce checks that:
 
 1. Load the time when the Terraform run occurred
 1. Convert the loaded time to PST

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -81,8 +81,8 @@ request = http.get(uri)
 response = json.unmarshal(request.body)
 
 offset = func(abbr) {
-	timezone = filter response as _, tz {
-		tz.abbr is strings.to_upper(abbr)
+	timezone = filter response as _, r {
+		r.abbr is strings.to_upper(abbr)
 	}
 	for timezone as tz {
 		print("Getting timezone data for", tz.value)

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -129,7 +129,9 @@ main = rule {
 }
 ```
 
--> **NOTE:** The above examples uses parameters to to facilitate module reuse within Terraform. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters/). We could expand the enforcement logic to also restrict provisioning to occur out of hours using the [time.hour](https://docs.hashicorp.com/sentinel/imports/time/#time-hour) function.
+For a more robust or flexible policy, we could expand the enforcement logic to also restrict provisioning to occur out of hours using the [time.hour](https://docs.hashicorp.com/sentinel/imports/time/#time-hour) function.
+
+The above examples use parameters to to facilitate module reuse within Terraform. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters/). 
 
 ## Managing Policy Sets
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -96,7 +96,7 @@ offset = func(abbr) {
 }
 ```
 
-The above configuration would tell a policy check to load the code at `./modules/timezone.sentinel` relative to the policy set working directory and make it available to be imported with the statement `import "timezone"` at the top of your Sentinel policy code. This module will be available to all of the policies within the policy set.
+The above configuration would tell a policy check to load the code at `./modules/timezone.sentinel` relative to the policy set working directory and make it available to be imported with the statement `import "timezone"`, located at the top of the Sentinel policy code. This module will be available to all of the policies within the policy set.
 
 ### Sentinel policy code files
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -120,7 +120,7 @@ param timezone_abbreviation default "PST"
 
 tfrun_created_at = time.load(tfrun.created_at)
 
-supported_maintenance_day = rule {
+supported_maintenance_day = rule when tfrun.workspace.auto_apply is true {
 	tfrun_created_at.add(time.hour * timezone.offset(timezone_abbreviation)).weekday_name in maintenance_days
 }
 
@@ -128,6 +128,8 @@ main = rule {
 	supported_maintenance_day
 }
 ```
+
+In the example above we have used a [rule expression](https://docs.hashicorp.com/sentinel/language/spec/#rule-expressions) with the `when` predicate. If the value of `tfrun.workspace.auto_apply` is false, the rule will not be evaluated and return true
 
 For a more robust or flexible policy, we could expand the enforcement logic to also restrict provisioning to occur out of hours using the [time.hour](https://docs.hashicorp.com/sentinel/imports/time/#time-hour) function.
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -102,7 +102,13 @@ The above configuration would tell a policy check to load the code at `./modules
 
 Sentinel policies themselves are defined in individual files (one per policy) in the same directory as the `sentinel.hcl` file. These files must match the name of the policy from the configuration file and carry the `.sentinel` suffix. Using the configuration example above, a policy file named `enforce-terraform-maintenance-windows.sentinel` should also exist alongside the `sentinel.hcl` file to complete the policy set. 
 
-An example configuration for the `enforce-terraform-maintenance-windows.sentinel` policy would be similar to the following:
+Using the `enforce-terraform-maintenance-windows.sentinel` policy as an example, we can use the `time` and `tfrun` imports along with our custom `timezone` module to enforce checks that:
+
+1. Load the time when the Terraform Run occurred
+1. Convert the loaded time to PST
+1. Verify that the provisioning operation is only going to occur on an agreed upon day
+
+An example policy would be as follows:
 
 ```sentinel
 import "time"
@@ -123,7 +129,7 @@ main = rule {
 }
 ```
 
--> **NOTE:** The above examples uses parameters to to facilitate module reuse within Terraform. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters/).
+-> **NOTE:** The above examples uses parameters to to facilitate module reuse within Terraform. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters/). We could expand the enforcement logic to also restrict provisioning to occur out of hours using the [time.hour](https://docs.hashicorp.com/sentinel/imports/time/#time-hour) function.
 
 ## Managing Policy Sets
 


### PR DESCRIPTION
Updating the Constructing a Policy Set guidance 

## Description

Updating the [Constructing a Policy Set](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#constructing-a-policy-set) to provide a working example of how Terraform Cloud users can take advantage of modules within Sentinel to abstract away a lot of the boiler-plate and re-use Sentinel code as an `import`.
