### PR TITLE
fix 404ing links to hashicorp.com/security

### DIFF
--- a/content/source/downloads.html.erb
+++ b/content/source/downloads.html.erb
@@ -33,7 +33,7 @@ show_notification: false
         <a href="https://releases.hashicorp.com/terraform/<%= latest_version %>/terraform_<%= latest_version %>_SHA256SUMS.sig">
           verify the checksums signature file
         </a>
-        which has been signed using <a href="https://hashicorp.com/security.html" target="_blank" rel="nofollow noopener noreferrer">HashiCorp's GPG key</a>.
+        which has been signed using <a href="https://hashicorp.com/security" target="_blank" rel="nofollow noopener noreferrer">HashiCorp's GPG key</a>.
         You can also <a href="https://releases.hashicorp.com/terraform/" target="_blank" rel="nofollow noopener noreferrer">download older versions of Terraform</a> from the releases service.
       </p>
       <p>

--- a/content/source/security.html.erb
+++ b/content/source/security.html.erb
@@ -19,7 +19,7 @@ description: |-
 
 <p>
   If you would like to report a vulnerability, please see the <a
-  href="https://www.hashicorp.com/security.html">HashiCorp security
+  href="https://www.hashicorp.com/security">HashiCorp security
   page</a>, which has the proper email to communicate with as well as our
   PGP key. Please <strong>do not create an GitHub issue for security
   concerns</strong>.


### PR DESCRIPTION
An external party reported a broken link to https://hashicorp.com/security.html.  This updates two links to point to the correct location.