### PR TITLE
Clarify that Docker v19.x is unsupported at this time.

### DIFF
--- a/content/source/docs/enterprise/before-installing/centos-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/centos-requirements.html.md
@@ -12,8 +12,8 @@ When installing Terraform Enterprise on CentOS Linux, ensure your OS and Docker 
 * CentOS Linux version 7.4 - 7.8
 * A suitable version of Docker:
    * Docker 1.13.1 (available in the `extras` repository).
-   * [Docker CE](https://docs.docker.com/install/linux/docker-ce/centos/) version 17.06 or later.
-   * [Docker EE](https://docs.docker.com/install/linux/docker-ee/centos/) version 17.06 or later.
+   * [Docker CE](https://docs.docker.com/install/linux/docker-ce/centos/) version 17.06 through 18.x (Docker v19.x is currently unsupported.)
+   * [Docker EE](https://docs.docker.com/install/linux/docker-ee/centos/) version 17.06 through 18.x (Docker v19.x is currently unsupported.)
    * Or you can allow the installer to install Docker for you.
 * A properly configured docker storage backend, either:
    * Devicemapper configured for production usage, in accordance with the [Docker documentation](https://docs.docker.com/storage/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-for-production). This configuration requires a second block device available to the system to be used as a thin-pool for Docker. You may need to configure this block device before the host system is booted, depending on the hosting platform.

--- a/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
@@ -10,7 +10,7 @@ When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure y
 ## Install Requirements
 
 * RedHat Enterprise Linux version 7.4 - 7.8.
-* Docker 1.13.1 (available in RHEL extras), or Docker EE version 17.06 or later. The later versions are not available in the standard RHEL yum repositories.
+* Docker 1.13.1 (available in RHEL extras), or Docker EE version 17.06 through 18.x (Docker v19.x is currently unsupported.) The later versions are not available in the standard RHEL yum repositories.
    * For Docker EE, [these](https://docs.docker.com/install/linux/docker-ee/rhel/) are the explicit RHEL instructions to follow.
    * For Docker from RHEL extras, the following should enable the RHEL extras repository:
       * `yum-config-manager --enable rhel-7-server-extras-rpms`


### PR DESCRIPTION
## Description

The site currently states we support Docker version 17.06 or greater, but that is untrue and has lead to customers attempting to use v19.x with no success. This update clarifies the supported versions.
