### PR TITLE
Backup and restore updates

### DIFF
--- a/content/source/docs/enterprise/admin/backup-restore.html.md
+++ b/content/source/docs/enterprise/admin/backup-restore.html.md
@@ -90,6 +90,8 @@ Status  | Response           | Reason
 [400][] | (none)             | Invalid request
 [500][] | (none)             | Internal server error
 
+~> **Important:** A successful backup **must** return `200`. If `200` is not returned and the call silently closes, the backup blob may be incomplete, resulting in data loss.
+
 ### Request Body
 
 This POST endpoint requires a JSON object with the following properties as a request payload.
@@ -139,8 +141,6 @@ Status  | Response           | Reason
 [200][] | (none)             | Successfully restored a backup
 [400][] | (none)             | Invalid request
 [500][] | (none)             | Internal server error
-
-~> **Important:** A successful backup **must** return `200`. If `200` is not returned and the call silently closes, the backup blob may be incomplete, resulting in data loss.
 
 ### Request Body
 

--- a/content/source/docs/enterprise/admin/backup-restore.html.md
+++ b/content/source/docs/enterprise/admin/backup-restore.html.md
@@ -5,14 +5,14 @@ page_title: "Backups and Restores - Infrastructure Administration - Terraform En
 
 # Terraform Enterprise Backups and Restores
 
-Terraform Enterprise provides an API to backup and restore all of its application data. This backup and restore API works the same for both Standalone and Clustered installations.
+Terraform Enterprise provides an API to backup and restore all of its application data. This backup and restore API works the same for both standalone and clustered installations.
 
-The backup and restore API is separate from the Terraform Enterprise application-level APIs. As such, a separate authorization token is required to use the backup and restore API. See [Authentication](#Authentication) for more details.
+The backup and restore API is separate from the Terraform Enterprise application-level APIs. As such, a separate authorization token is required to use the backup and restore API. See [Authentication](#authentication) below for more details.
 
 Using the backup and restore API is the only supported way to:
 
-- Migrate between deployment types (Standalone, Clustered).
-- Migrate between operational modes (Mounted Disk, External Services).
+- Migrate between deployment types (standalone, clustered).
+- Migrate between operational modes (mounted disk, external services).
 
 ## About Backups and Restores
 
@@ -125,7 +125,9 @@ curl \
 
 `POST /_backup/api/v1/restore`
 
-Before restoring, you must first create a new Terraform Enterprise installation. This can be a Standalone or Clustered installation.
+Before restoring, you must first create a new Terraform Enterprise installation. This can be a standalone or clustered installation.
+
+-> **Note:** The authorization token used to restore the backup is specific to the Terraform Enterprise installation. If restoring to a separate Terraform Enterprise installation, the authorization token will be different for the restore than it was for the backup. See [Authentication](#authentication) above for more details.
 
 Once the Terraform Enterprise application is up and running, you can initiate a restore by making a POST request to the restore endpoint.
 

--- a/content/source/docs/enterprise/admin/backup-restore.html.md
+++ b/content/source/docs/enterprise/admin/backup-restore.html.md
@@ -34,7 +34,7 @@ The backup and restore API uses a separate authorization token which can be foun
 
 ![Screenshot: the TFE install dashboard, with the API token visible](./images/token.png)
 
--> **Note:** This authorization token is specific to the Terraform Enterprise installation. As such, the authorization token used to create a backup will be different than the authorization token used to perform a restore.
+-> **Note:** This authorization token is specific to the Terraform Enterprise installation. Unless otherwise specified during installation of the new Terraform Enteprise instance, the authorization token used to create a backup will be different than the authorization token used to perform a restore.
 
 The backup and restore API is separate from the Terraform Enterprise application-level APIs and cannot be accessed with Terraform Enterprise user, team, or organization API tokens.
 

--- a/content/source/docs/enterprise/admin/backup-restore.html.md
+++ b/content/source/docs/enterprise/admin/backup-restore.html.md
@@ -34,7 +34,7 @@ The backup and restore API uses a separate authorization token which can be foun
 
 ![Screenshot: the TFE install dashboard, with the API token visible](./images/token.png)
 
--> **Note:** This authorization token is specific to the Terraform Enterprise installation. Unless otherwise specified during installation of the new Terraform Enteprise instance, the authorization token used to create a backup will be different than the authorization token used to perform a restore.
+-> **Note:** This authorization token is specific to the Terraform Enterprise installation. As a result, the authorization token used to create a backup may be different than the authorization token used to perform a restore. Please ensure you are using the correct authorization token when performing a backup or restore operation.
 
 The backup and restore API is separate from the Terraform Enterprise application-level APIs and cannot be accessed with Terraform Enterprise user, team, or organization API tokens.
 
@@ -139,6 +139,8 @@ Status  | Response           | Reason
 [200][] | (none)             | Successfully restored a backup
 [400][] | (none)             | Invalid request
 [500][] | (none)             | Internal server error
+
+~> **Important:** A successful backup **must** return `200`. If `200` is not returned and the call silently closes, the backup blob may be incomplete, resulting in data loss.
 
 ### Request Body
 


### PR DESCRIPTION
Updating the backup and restore documentation with the following
changes.

- Highlight the significance of the `password` provided to the backup
  and restore operations.
- Detail that the Terraform Enterprise version must remain the same
  between a backup and a restore.
- Various readability improvements.