### PR TITLE
Update required OS versions for Clustered install

### DIFF
--- a/content/source/docs/enterprise/before-installing/centos-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/centos-requirements.html.md
@@ -9,7 +9,7 @@ When installing Terraform Enterprise on CentOS Linux, ensure your OS and Docker 
 
 ## Install Requirements
 
-* CentOS Linux version 7.4 - 7.8
+* A [supported version](/docs/enterprise/before-installing/index.html#operating-system-requirements) of CentOS.
 * A suitable version of Docker:
    * Docker 1.13.1 (available in the `extras` repository).
    * [Docker CE](https://docs.docker.com/install/linux/docker-ce/centos/) version 17.06 through 18.x (Docker v19.x is currently unsupported.)

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -127,8 +127,8 @@ Terraform Enterprise currently supports running under the following operating sy
 
 - **Clustered deployment:**
     - Ubuntu 16.04.3 - 16.04.5 / 18.04
-    - Red Hat Enterprise Linux 7.4 - 7.8
-    - CentOS 7.4 - 7.8
+    - Red Hat Enterprise Linux 7.4 - 7.7
+    - CentOS 7.4 - 7.7
 
     Clusters currently do not support other Linux variants.
 

--- a/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
@@ -9,7 +9,7 @@ When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure y
 
 ## Install Requirements
 
-* RedHat Enterprise Linux version 7.4 - 7.8.
+* A [supported version](https://www.terraform.io/docs/enterprise/before-installing/index.html#operating-system-requirements) of RedHat Enterprise Linux.
 * Docker 1.13.1 (available in RHEL extras), or Docker EE version 17.06 through 18.x (Docker v19.x is currently unsupported.) The later versions are not available in the standard RHEL yum repositories.
    * For Docker EE, [these](https://docs.docker.com/install/linux/docker-ee/rhel/) are the explicit RHEL instructions to follow.
    * For Docker from RHEL extras, the following should enable the RHEL extras repository:


### PR DESCRIPTION
Terraform Enterprise Clustering does not yet support CentOS/RHEL 7.8.
