### PR TITLE
specify that cost estimation makes calls in "us-east-1".

### DIFF
--- a/content/source/docs/enterprise/admin/integration.html.md
+++ b/content/source/docs/enterprise/admin/integration.html.md
@@ -24,7 +24,7 @@ To access the Cost Estimation settings, click **Cost Estimation** in the left me
 
 ![screenshot: the Cost Estimation admin page](./images/admin-cost-estimation.png)
 
-* **AWS Access Key ID**: The AWS Access Key ID for a given IAM user. The role associated to these credentials must have full access to the "Price List" service and all of that service's resources.
+* **AWS Access Key ID**: The AWS Access Key ID for a given IAM user. The role associated to these credentials must have full access to the "Price List" service and all of that service's resources. Cost Estimation makes API calls in the `us-east-1` region.
 * **AWS Secret Key**: The AWS Secret Key pair for the same Access Key ID.
 * **GCP Credentials**: The contents of the JSON that is downloaded when you create a GCP Service Account.
 * **Azure Client ID**: The Azure Client ID for a given Service Account. The role associated to these credentials must have full access to the `RateCard` service and all of that service's resources.


### PR DESCRIPTION
## Description

We should let users know what region we make API calls in, so they can tune permissions appropriately.
