### PR TITLE
Fix pagination note for list workspaces API

### DIFF
--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -398,7 +398,7 @@ This endpoint supports pagination [with standard URL query parameters](./index.h
 Parameter      | Description
 ---------------|------------
 `page[number]` | **Optional.** If omitted, the endpoint will return the first page.
-`page[size]`   | **Optional.** If omitted, the endpoint will return 150 workspaces per page.
+`page[size]`   | **Optional.** If omitted, the endpoint will return 20 workspaces per page.
 
 ### Sample Request
 


### PR DESCRIPTION
At some point, I know we deliberately changed this behavior to 150 for some
reason. (cf. c46d4a9837) But today, it's using the same default of 20 from the
kaminari config, so that must have been reverted at some point.

Fixes #1260