### PR TITLE
cloud/api and cloud/sentinel: add information about targeted runs

### DIFF
--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -51,6 +51,7 @@ Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
 `data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources.
 `data.attributes.message` | string | "Queued manually via the Terraform Enterprise API" | Specifies the message to be associated with this run.
+`data.attributes.target-addrs` | array[string] | | Specifies a list of resource addresses to be passed to the `-target` flag.
 `data.relationships.workspace.data.id` | string | | Specifies the workspace ID where the run will be executed.
 `data.relationships.configuration-version.data.id` | string | (nothing) | Specifies the configuration version to use for this run. If the `configuration-version` object is omitted, the run will be created using the workspace's latest configuration version.
 
@@ -68,8 +69,9 @@ Status  | Response                               | Reason
 {
   "data": {
     "attributes": {
-      "is-destroy":false,
-      "message": "Custom message"
+      "is-destroy": false,
+      "message": "Custom message",
+      "target-addrs": ["example.resource_address"]
     },
     "type":"runs",
     "relationships": {
@@ -120,6 +122,7 @@ curl \
       "terraform-version": "0.10.8",
       "created-at": "2017-11-29T19:56:15.205Z",
       "has-changes": false,
+      "target-addrs": ["example.resource_address"],
       "actions": {
         "is-cancelable": true,
         "is-confirmable": false,

--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -51,8 +51,8 @@ Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
 `data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources.
 `data.attributes.message` | string | "Queued manually via the Terraform Enterprise API" | Specifies the message to be associated with this run.
-`data.attributes.target-addrs` | array[string] | | Specifies a list of resource addresses to be passed to the `-target` flag.
-`data.relationships.workspace.data.id` | string | | Specifies the workspace ID where the run will be executed.
+`data.attributes.target-addrs` | array[string] | (nothing) | Specifies an optional list of resource addresses to be passed to the `-target` flag.
+`data.relationships.workspace.data.id` | string | (nothing) | Specifies the workspace ID where the run will be executed.
 `data.relationships.configuration-version.data.id` | string | (nothing) | Specifies the configuration version to use for this run. If the `configuration-version` object is omitted, the run will be created using the workspace's latest configuration version.
 
 Status  | Response                               | Reason

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -313,7 +313,7 @@ and data sources within this plan.
 This includes all resources that have been found in the configuration and state,
 regardless of whether or not they are changing.
 
-~> When [resource targeting](/docs/commands/plan.html#resource-targeting) is in effect, the `resource_changes` collection will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to always exist. To prohibit targeted runs altogether, use [`tfrun.target_addrs`](./tfrun.html#value-target_addrs).
+~> When [resource targeting](/docs/commands/plan.html#resource-targeting) is in effect, the `resource_changes` collection will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to be present in the plan. To prohibit targeted runs altogether, ensure [`tfrun.target_addrs`](./tfrun.html#value-target_addrs) is undefined or empty.
 
 This collection is indexed on the complete resource address as the key. If
 `deposed` is non-empty, it is appended to the end, and may look something like

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -313,6 +313,8 @@ and data sources within this plan.
 This includes all resources that have been found in the configuration and state,
 regardless of whether or not they are changing.
 
+~> When [resource targeting](/docs/commands/plan.html#resource-targeting) is in effect, the `resource_changes` collection will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to always exist. To prohibit targeted runs altogether, use [`tfrun.target_addrs`](./tfrun.html#value-target_addrs).
+
 This collection is indexed on the complete resource address as the key. If
 `deposed` is non-empty, it is appended to the end, and may look something like
 `aws_instance.foo:deposed-abc123`.

--- a/content/source/docs/cloud/sentinel/import/tfplan.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan.html.md
@@ -354,7 +354,7 @@ Some examples of multi-level access are below:
   `tfplan.resources.aws_instance`, with names being the next level down, and so
   on.
 
-~> When [resource targeting](/docs/commands/plan.html#resource-targeting) is in effect, `tfplan.resources` will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to always exist. To prohibit targeted runs altogether, use [`tfrun.target_addrs`](/docs/cloud/sentinel/import/tfrun.html#value-target_addrs).
+~> When [resource targeting](/docs/commands/plan.html#resource-targeting) is in effect, `tfplan.resources` will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to be present in the plan. To prohibit targeted runs altogether, ensure [`tfrun.target_addrs`](./tfrun.html#value-target_addrs) is undefined or empty.
 
 Further explanation of the namespace will be in the context of resources. As
 mentioned, when operating on data sources, use the same syntax, except with

--- a/content/source/docs/cloud/sentinel/import/tfplan.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan.html.md
@@ -354,6 +354,8 @@ Some examples of multi-level access are below:
   `tfplan.resources.aws_instance`, with names being the next level down, and so
   on.
 
+~> When [resource targeting](/docs/commands/plan.html#resource-targeting) is in effect, `tfplan.resources` will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to always exist. To prohibit targeted runs altogether, use [`tfrun.target_addrs`](/docs/cloud/sentinel/import/tfrun.html#value-target_addrs).
+
 Further explanation of the namespace will be in the context of resources. As
 mentioned, when operating on data sources, use the same syntax, except with
 `data` in place of `resources`.

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -99,13 +99,14 @@ variables (map of keys)
 
 * **Value Type:** An array of strings representing [resource addresses](/docs/internals/resource-addressing.html).
 
-Provides the targets specified using the [`-target`](/docs/commands/plan.html#resource-targeting) flag in the CLI or the `target-addrs` attribute in the API.
+Provides the targets specified using the [`-target`](/docs/commands/plan.html#resource-targeting) flag in the CLI or the `target-addrs` attribute in the API. Will be undefined if no resource targets are specified.
 
-To prohibit targeted runs altogether, check that the length of this collection is zero:
+To prohibit targeted runs altogether, make sure the `target_addrs` value is undefined or empty:
 
 ```
 import "tfrun"
-main = length(tfrun.target_addrs) == 0
+
+main = (length(tfrun.target_addrs) else 0) == 0
 ```
 
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -21,6 +21,7 @@ tfrun
 ├── speculative (boolean)
 ├── is_destroy (boolean)
 ├── variables (map of keys)
+├── target_addrs (array of strings)
 ├── organization
 │   └── name (string)
 ├── workspace
@@ -93,6 +94,20 @@ variables (map of keys)
     └── category (string)
     └── sensitive (boolean)
 ```
+
+### Value: `target_addrs`
+
+* **Value Type:** An array of strings representing [resource addresses](/docs/internals/resource-addressing.html).
+
+Provides the targets specified using the [`-target`](/docs/commands/plan.html#resource-targeting) flag in the CLI or the `target-addrs` attribute in the API.
+
+To prohibit targeted runs altogether, check that the length of this collection is zero:
+
+```
+import "tfrun"
+main = length(tfrun.target_addrs) == 0
+```
+
 
 ## Namespace: organization
 
@@ -179,6 +194,8 @@ vcs_repo (map of keys)
 The **cost_estimation namespace** contains data associated with the current run's cost estimate.
 
 This namespace is only present if a cost estimate is available.
+
+-> Cost estimation is disabled for runs using (resource targeting)[/docs/commands/plan.html#resource-targeting], which may cause unexpected failures.
 
 -> **Note:** Cost estimates are not available for Terraform 0.11.
 


### PR DESCRIPTION
## Description

Updates the API endpoint for creating runs to describe the new `target_addrs` attribute.

Also updates several places in the Sentinel documentation to warn about the possible side effects of using resource targeting, and how to write a policy that prohibits targeted runs altogether.

## Screenshots

#### cloud/api/run

<img width="886" alt="Screen Shot 2020-05-19 at 6 57 52 PM" src="https://user-images.githubusercontent.com/17039873/82396537-005e9780-9a03-11ea-8b15-2f4b606180e5.png">

#### cloud/sentinel/import/tfrun

<img width="924" alt="Screen Shot 2020-05-19 at 6 56 29 PM" src="https://user-images.githubusercontent.com/17039873/82396558-0b192c80-9a03-11ea-9f25-c95ddd0142e3.png">

#### cloud/sentinel/import/tfplan

<img width="904" alt="Screen Shot 2020-05-19 at 6 57 31 PM" src="https://user-images.githubusercontent.com/17039873/82396543-048ab500-9a03-11ea-9d34-82d1d57decbd.png">

#### cloud/sentinel/import/tfplan-v2

<img width="924" alt="Screen Shot 2020-05-19 at 6 56 57 PM" src="https://user-images.githubusercontent.com/17039873/82396549-0785a580-9a03-11ea-9e00-0168d3349193.png">


