### PR TITLE
Update writing-custom.providers.html.md

### DIFF
--- a/content/source/docs/extend/writing-custom-providers.html.md
+++ b/content/source/docs/extend/writing-custom-providers.html.md
@@ -50,7 +50,7 @@ To start, create a file named `provider.go`. This is the root of the provider
 and should include the following boilerplate code:
 
 ```go
-package main
+package provider_name
 
 import (
         "github.com/hashicorp/terraform-plugin-sdk/helper/schema"


### PR DESCRIPTION

## Description
the package name in the provider.go file should be equal to the provider name as far as I could see in other providers like aws or vsphere. 
The _main_ package name is used to tell the Go compiler to create an executable file 
_Describe why you're making this change._
