### PR TITLE
Remove provisioner plugin from docs

### DIFF
--- a/content/source/docs/extend/index.html.md
+++ b/content/source/docs/extend/index.html.md
@@ -37,7 +37,7 @@ components of Terraform (Core vs. Plugins) and the basics of how they interact.
 
 ## [Plugin Types](/docs/extend/plugin-types.html)
 
-Learn about Terraform plugins, currently Providers.
+Learn about Terraform plugins that you can develop using the Terraform Plugin SDK (currently only Providers).
 
 ## [Writing Custom Providers](/docs/extend/writing-custom-providers.html)
 

--- a/content/source/docs/extend/index.html.md
+++ b/content/source/docs/extend/index.html.md
@@ -13,10 +13,8 @@ Terraform can be extended to allow users to manage more infrastructure providers
 [Providers](/docs/providers/index.html)
 (containing [Resources](/docs/configuration/resources.html)
 and/or [Data Sources](/docs/configuration/data-sources.html)),
-more options to store Terraform state with [Backends](/docs/backends)
-and more options to provision instance with
-[Provisioners](/docs/provisioners/index.html). **Providers**
-and **Provisioners** are collectively categorized as "Plugins".
+more options to store Terraform state with [Backends](/docs/backends). **Providers**
+are a type of Terraform "Plugin".
 
 ~> This is an advanced section! If you are looking for information on using
 Terraform with any of the existing Plugins, please refer to the
@@ -39,7 +37,7 @@ components of Terraform (Core vs. Plugins) and the basics of how they interact.
 
 ## [Plugin Types](/docs/extend/plugin-types.html)
 
-Learn about the different types of Terraform plugins — Providers and Provisioners.
+Learn about Terraform plugins, currently Providers.
 
 ## [Writing Custom Providers](/docs/extend/writing-custom-providers.html)
 
@@ -54,8 +52,8 @@ guide design and decision making for all providers.
 ## [Schemas](/docs/extend/schemas/index.html)
 
 The Schema package is a high-level framework for easily writing Plugins for
-Terraform. Providers (with Resources and/or Data Sources), and Provisioners
-are all defined in terms of the Schema package, which includes builtin types
+Terraform. Providers (with Resources and/or Data Sources)
+are defined in terms of the Schema package, which includes builtin types
 and methods for developers to use when writing plugins.
 
 ## [Resources](/docs/extend/resources/index.html)

--- a/content/source/docs/extend/plugin-types.html.md
+++ b/content/source/docs/extend/plugin-types.html.md
@@ -18,7 +18,7 @@ The network communication and RPC is handled automatically by higher-level Terra
 libraries, so developers need only worry about the implementation of their specific
 Plugin behavior. 
 
-There is currently one type of plugin supported by Terraform:
+The Terraform Plugin SDK currently supports one type of plugin: providers.
 
 ## Providers
 

--- a/content/source/docs/extend/plugin-types.html.md
+++ b/content/source/docs/extend/plugin-types.html.md
@@ -11,13 +11,14 @@ description: |-
 
 Terraform is logically split into two main parts: Terraform Core and Terraform
 Plugins. Each plugin exposes an implementation for a specific service, such as
-the AWS provider or bash provisioner. Terraform Plugins are written in Go and are
-executable binaries executed as a separate process and communicate with the main
-Terraform binary over an RPC interface. The network communication and RPC is
-handled automatically by higher-level Terraform libraries, so developers need
-only worry about the implementation of their specific Plugin behavior. 
+the AWS provider or the [cloud-init provider](/docs/providers/cloudinit/).
+Terraform Plugins are written in Go and are executable binaries executed as a separate 
+process and communicate with the main Terraform binary over an RPC interface.
+The network communication and RPC is handled automatically by higher-level Terraform
+libraries, so developers need only worry about the implementation of their specific
+Plugin behavior. 
 
-There are two types of plugins supported by Terraform:
+There is currently one type of plugin supported by Terraform:
 
 ## Providers
 
@@ -49,18 +50,3 @@ Organization](https://github.com/terraform-providers).
 
 Visit the [Provider index](/docs/providers/index.html) in our documentation
 section to learn more about our existing Providers.
-
-## Provisioners
-
-Provisioners are used to execute scripts on a local or remote machine as part of
-resource creation or destruction. Provisioners can be used to bootstrap a
-resource, cleanup before destroy, run configuration management, etc.
-
-The official Terraform Provisioners are included in the Terraform Core codebase
-and are compiled into the `terraform` binary. While they are built in,
-Provisioners are still executed in a separate process over RPC, and benefit from
-the same discovery process as Terraform Providers, making custom Provisioners
-just as easy to create and use. 
-
-Visit the [Provisioners index](/docs/provisioners/index.html) in our
-documentation section to learn more about our existing Provisioners. 

--- a/content/source/docs/extend/schemas/schema-types.html.md
+++ b/content/source/docs/extend/schemas/schema-types.html.md
@@ -11,9 +11,8 @@ description: |-
 # Schema Attributes and Types
 
 Almost every Terraform Plugin offers user configurable parameters, examples such
-as a Provisioner `secret_key`, a Provider’s `region`, or a Resources `name`.
-Each parameter is  defined in the items schema, which is a map of string names
-to schema structs. 
+as a Provider’s `region` or a Resource's `name`. Each parameter is  defined in
+the items schema, which is a map of string names to schema structs.
 
 In the below example implementation of a Resource you see parameters `uuid` and
 `name` defined: 


### PR DESCRIPTION
## Description

Provisioner plugins are not supported in the current SDK, so remove mention of them from the docs.