### PR TITLE
Added missing ports needed

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -9,11 +9,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ## Ingress
 
-### Source - User/Client/VCS
-
-* **443**: To access the Terraform Enterprise application via HTTPS 
-
-### Source - Administrators
+### Exposed ports on the instance:
 
 * **22**: To access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
 * **8800**: To access the installer dashboard.
@@ -21,6 +17,29 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 ### Source - TFE Server(s)
 * **9870-9880 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
 * **23000-23100 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
+
+### Higher ports and their functions
+
+* **2003**: Graphite (Carbon) feeding port (monitoring, metrics)
+* **2004**:	Graphite (Carbon) feeding port (monitoring, metrics)
+* **4150-4151, 4160-4161, 4170-4171**:	Replicated NSQD (messaging platform-daemon for internal communication)
+* **5432**:	Internal Postgres
+* **5672**:	RabbitMQ TFE worker coordination
+* **6379**:	Redis (Caching and coordination between web and background workers in the application layer)
+* **7586**:	TFE ingress - pulls in version control systems (VCS) (GitHub, BitBUcket, etc) data and stores via Archivist
+* **7588**:	TFE State parser
+* **7675**:	TFE Archivist - stores data in object storage, encrypts it via Vault
+* **8089**:	InfluxDB default UDP Service (monitoring, metrics)
+* **8125**:	StatsD (monitoring, metrics)
+* **8200**:	TFE node Vault (built-in) for encrypting practically everything
+* **8800**:	ReplicatedUI (TFE setup Dashboard)
+* **9292**:	Atlas engine (old name of TFE engine)
+* **9873**:	ReplicatedUI retraced engine API (replicated audit subcomponent)
+* **9874-9879**: ReplicatedUI entry point span
+* **23005**: TFE Health Check point
+* **23020**: Nomad (built-in) scheduler (for Sentinel runs)
+* **32774-32776**: ReplicatedUI internal StatsD ports mapped then to standard (see above 2003⁄2004 and 8125 )
+* **32846**: TFE Admin Console which is is ReplicatedUI service
 
 ## Egress
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -9,16 +9,18 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ## Ingress
 
-### Exposed ports on the instance:
+### Source — User/Client/VCS
 
-* **22:** To access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
 * **80:** To access the Terraform Enterprise application via HTTP. This port redirects to port 443 for HTTPS.
 * **443:** To access the Terraform Enterprise application via HTTPS.
-* **8800:** To access the installer dashboard.
-* **9870-9880 (inclusive):** For internal communication on the host and its subnet; not publicly accessible.
-* **23000-23100 (inclusive):** For internal communication on the host and its subnet; not publicly accessible.
 
-### Higher ports and their functions
+### Source — Administrators
+
+* **22:** SSH access to the instance. This is required for administration and debugging.
+* **8800:** ReplicatedUI (TFE setup dashboard)
+* **32846:** TFE admin console (a ReplicatedUI service)
+
+### Source — TFE Server(s)
 
 * **2003:** Graphite (Carbon) feeding port (monitoring, metrics)
 * **2004:** Graphite (Carbon) feeding port (monitoring, metrics)
@@ -26,20 +28,20 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **5432:** Internal Postgres
 * **5672:** RabbitMQ TFE worker coordination
 * **6379:** Redis (Caching and coordination between web and background workers in the application layer)
-* **7586:** TFE ingress - pulls in version control systems (VCS) (GitHub, BitBUcket, etc) data and stores via Archivist
-* **7588:** TFE State parser
+* **7586:** TFE ingress - pulls in version control system (VCS) (GitHub, BitBucket, etc.) data and stores via Archivist
+* **7588:** TFE state parser
 * **7675:** TFE Archivist - stores data in object storage, encrypts it via Vault
 * **8089:** InfluxDB default UDP Service (monitoring, metrics)
 * **8125:** StatsD (monitoring, metrics)
 * **8200:** TFE node Vault (built-in) for encrypting practically everything
-* **8800:** ReplicatedUI (TFE setup Dashboard)
 * **9292:** Atlas engine (old name of TFE engine)
-* **9873:** ReplicatedUI retraced engine API (replicated audit subcomponent)
-* **9874-9879:** ReplicatedUI entry point span
-* **23005:** TFE Health Check point
-* **23020:** Nomad (built-in) scheduler (for Sentinel runs)
-* **32774-32776:** ReplicatedUI internal StatsD ports mapped then to standard (see above 2003⁄2004 and 8125 )
-* **32846:** TFE Admin Console which is is ReplicatedUI service
+* **9870-9880 (inclusive):** For internal communication on the host and its subnet; not publicly accessible
+    * **9873:** ReplicatedUI retraced engine API (replicated audit subcomponent)
+    * **9874-9879:** ReplicatedUI entry point span
+* **23000-23100 (inclusive):** For internal communication on the host and its subnet; not publicly accessible
+    * **23005:** TFE health check point
+    * **23020:** Nomad (built-in) scheduler (for Sentinel runs)
+* **32774-32776:** ReplicatedUI internal StatsD ports, which get mapped to standard ports for their services (2003, 2004, and 8125)
 
 ## Egress
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -11,35 +11,35 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ### Exposed ports on the instance:
 
-* **22**: To access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
-* **8800**: To access the installer dashboard.
-
-### Source - TFE Server(s)
-* **9870-9880 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
-* **23000-23100 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
+* **22:** To access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
+* **80:** To access the Terraform Enterprise application via HTTP. This port redirects to port 443 for HTTPS.
+* **443:** To access the Terraform Enterprise application via HTTPS.
+* **8800:** To access the installer dashboard.
+* **9870-9880 (inclusive):** For internal communication on the host and its subnet; not publicly accessible.
+* **23000-23100 (inclusive):** For internal communication on the host and its subnet; not publicly accessible.
 
 ### Higher ports and their functions
 
-* **2003**: Graphite (Carbon) feeding port (monitoring, metrics)
-* **2004**:	Graphite (Carbon) feeding port (monitoring, metrics)
-* **4150-4151, 4160-4161, 4170-4171**:	Replicated NSQD (messaging platform-daemon for internal communication)
-* **5432**:	Internal Postgres
-* **5672**:	RabbitMQ TFE worker coordination
-* **6379**:	Redis (Caching and coordination between web and background workers in the application layer)
-* **7586**:	TFE ingress - pulls in version control systems (VCS) (GitHub, BitBUcket, etc) data and stores via Archivist
-* **7588**:	TFE State parser
-* **7675**:	TFE Archivist - stores data in object storage, encrypts it via Vault
-* **8089**:	InfluxDB default UDP Service (monitoring, metrics)
-* **8125**:	StatsD (monitoring, metrics)
-* **8200**:	TFE node Vault (built-in) for encrypting practically everything
-* **8800**:	ReplicatedUI (TFE setup Dashboard)
-* **9292**:	Atlas engine (old name of TFE engine)
-* **9873**:	ReplicatedUI retraced engine API (replicated audit subcomponent)
-* **9874-9879**: ReplicatedUI entry point span
-* **23005**: TFE Health Check point
-* **23020**: Nomad (built-in) scheduler (for Sentinel runs)
-* **32774-32776**: ReplicatedUI internal StatsD ports mapped then to standard (see above 2003⁄2004 and 8125 )
-* **32846**: TFE Admin Console which is is ReplicatedUI service
+* **2003:** Graphite (Carbon) feeding port (monitoring, metrics)
+* **2004:** Graphite (Carbon) feeding port (monitoring, metrics)
+* **4150-4151, 4160-4161, 4170-4171:** Replicated NSQD (messaging platform-daemon for internal communication)
+* **5432:** Internal Postgres
+* **5672:** RabbitMQ TFE worker coordination
+* **6379:** Redis (Caching and coordination between web and background workers in the application layer)
+* **7586:** TFE ingress - pulls in version control systems (VCS) (GitHub, BitBUcket, etc) data and stores via Archivist
+* **7588:** TFE State parser
+* **7675:** TFE Archivist - stores data in object storage, encrypts it via Vault
+* **8089:** InfluxDB default UDP Service (monitoring, metrics)
+* **8125:** StatsD (monitoring, metrics)
+* **8200:** TFE node Vault (built-in) for encrypting practically everything
+* **8800:** ReplicatedUI (TFE setup Dashboard)
+* **9292:** Atlas engine (old name of TFE engine)
+* **9873:** ReplicatedUI retraced engine API (replicated audit subcomponent)
+* **9874-9879:** ReplicatedUI entry point span
+* **23005:** TFE Health Check point
+* **23020:** Nomad (built-in) scheduler (for Sentinel runs)
+* **32774-32776:** ReplicatedUI internal StatsD ports mapped then to standard (see above 2003⁄2004 and 8125 )
+* **32846:** TFE Admin Console which is is ReplicatedUI service
 
 ## Egress
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -11,37 +11,37 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ### Source — User/Client/VCS
 
-* **80:** To access the Terraform Enterprise application via HTTP. This port redirects to port 443 for HTTPS.
-* **443:** To access the Terraform Enterprise application via HTTPS.
+* **80:** Terraform Enterprise application access (HTTP; redirects to HTTPS)
+* **443:** Terraform Enterprise application access (HTTPS)
 
 ### Source — Administrators
 
-* **22:** SSH access to the instance. This is required for administration and debugging.
-* **8800:** ReplicatedUI (TFE setup dashboard)
-* **32846:** TFE admin console (a ReplicatedUI service)
+* **22:** SSH access (administration and debugging)
+* **8800:** Replicated (TFE setup dashboard, HTTPS)
+* **32846:** TFE admin console (a Replicated service)
 
 ### Source — TFE Server(s)
 
 * **2003:** Graphite (Carbon) feeding port (monitoring, metrics)
 * **2004:** Graphite (Carbon) feeding port (monitoring, metrics)
-* **4150-4151, 4160-4161, 4170-4171:** Replicated NSQD (messaging platform-daemon for internal communication)
-* **5432:** Internal Postgres
+* **4150-4151, 4160-4161, 4170-4171:** Replicated NSQD (messaging platform daemon for internal communication)
+* **5432:** PostgreSQL
 * **5672:** RabbitMQ TFE worker coordination
-* **6379:** Redis (Caching and coordination between web and background workers in the application layer)
-* **7586:** TFE ingress - pulls in version control system (VCS) (GitHub, BitBucket, etc.) data and stores via Archivist
+* **6379:** Redis (application-level caching and coordination)
+* **7586:** TFE ingress (pulls in version control system data for application, stores it via Archivist)
 * **7588:** TFE state parser
-* **7675:** TFE Archivist - stores data in object storage, encrypts it via Vault
+* **7675:** TFE Archivist (stores data in object storage, encrypts it via Vault)
 * **8089:** InfluxDB default UDP Service (monitoring, metrics)
 * **8125:** StatsD (monitoring, metrics)
-* **8200:** TFE node Vault (built-in) for encrypting practically everything
+* **8200:** Vault (encryption service)
 * **9292:** Atlas engine (old name of TFE engine)
-* **9870-9880 (inclusive):** For internal communication on the host and its subnet; not publicly accessible
-    * **9873:** ReplicatedUI retraced engine API (replicated audit subcomponent)
-    * **9874-9879:** ReplicatedUI entry point span
-* **23000-23100 (inclusive):** For internal communication on the host and its subnet; not publicly accessible
+* **9870-9880 (inclusive):** host and subnet traffic only; not publicly accessible
+    * **9873:** Replicated Retraced engine API (Replicated audit subcomponent)
+    * **9874-9879:** Replicated entry point span
+* **23000-23100 (inclusive):** host and subnet traffic only; not publicly accessible
     * **23005:** TFE health check point
-    * **23020:** Nomad (built-in) scheduler (for Sentinel runs)
-* **32774-32776:** ReplicatedUI internal StatsD ports, which get mapped to standard ports for their services (2003, 2004, and 8125)
+    * **23020:** Nomad (scheduler for Sentinel runs)
+* **32774-32776:** Replicated internal Graphite and StatsD ports (mapped to external ports 2003, 2004, and 8125)
 
 ## Egress
 


### PR DESCRIPTION
Support article had a lot more ports listen than the documentation.  See https://support.hashicorp.com/hc/en-us/articles/360043237973-Detailed-list-of-the-ports-used-by-Terraform-Enterprise

Furthermore this ticket 28893 indicated that port 32846 was also missing.

Not having a list of all the ports is causing confusion upon installation.

## Description

_Describe why you're making this change._
