### PR TITLE
Documentation for the ip ranges API

### DIFF
--- a/content/source/docs/cloud/api/ip-ranges.html.md
+++ b/content/source/docs/cloud/api/ip-ranges.html.md
@@ -1,0 +1,76 @@
+---
+layout: "cloud"
+page_title: "IP Ranges - API Docs - Terraform Cloud"
+---
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[JSON API document]: /docs/cloud/api/index.html#json-api-documents
+[JSON API error object]: http://jsonapi.org/format/#error-objects
+[CIDR Notation]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
+
+# IP Ranges API
+IP Ranges provides a list of Terraform Cloud and Enterprise's egress IP ranges. For more information about Terraform Cloud's IP ranges, view our documentation about [Terraform Cloud IP Ranges](../architectural-details/ip-ranges.html).
+
+## IP Ranges Payload
+
+Name                             | Type   | Description
+---------------------------------|--------|-------------
+`sentinel`                       | array  | List of IP ranges in [CIDR notation] used for outbound requests from Sentinel policies
+`notifications`                  | array  | List of IP ranges in [CIDR notation] used for notifications
+`vcs`                            | array  | List of IP ranges in [CIDR notation] used for connecting to VCS providers
+
+-> **Note:** The IP ranges for each feature returned by the IP Ranges API may overlap. Additionally, these published ranges do not currently allow for execution of Terraform runs against local resources.
+
+## Get IP Ranges
+
+-> **Note:** The IP Ranges API does not require authentication
+
+`GET /meta/ip-ranges`
+
+Status  | Response                                        | Reason
+--------|-------------------------------------------------|----------
+[200][] | `application/json`                              | The request was successful
+
+### Sample Request
+
+```shell
+curl \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/meta/ip-ranges
+```
+
+### Sample Response
+
+```json
+{
+  "notifications": [
+    "10.0.0.1/32",
+    "192.168.0.1/32",
+    "172.16.0.1/32"
+  ],
+  "sentinel": [
+    "10.0.0.1/32",
+    "192.168.0.1/32",
+    "172.16.0.1/32"
+  ],
+  "vcs": [
+    "10.0.0.1/32",
+    "192.168.0.1/32",
+    "172.16.0.1/32"
+  ]
+}
+```

--- a/content/source/docs/cloud/architectural-details/index.html.md
+++ b/content/source/docs/cloud/architectural-details/index.html.md
@@ -1,0 +1,10 @@
+---
+layout: "cloud"
+page_title: "Architectural Details - Terraform Cloud"
+---
+
+# Architectural Details
+
+This section collects information about the architecture and operational characteristics of Terraform Cloud.
+
+For the most part, documents in this section are not intended as task-oriented instructions. Instead, they are offered as background information to help inform your own use of Terraform Cloud.

--- a/content/source/docs/cloud/architectural-details/ip-ranges.html.md
+++ b/content/source/docs/cloud/architectural-details/ip-ranges.html.md
@@ -1,0 +1,12 @@
+---
+layout: "cloud"
+page_title: "IP Ranges - Terraform Cloud"
+---
+
+# Terraform Cloud IP Ranges
+
+Terraform Cloud uses static IP ranges for certain features that make outbound requests such as notifications and VCS connections. These IP ranges are retrievable through the [IP Ranges API](../api/ip-ranges.html).
+
+-> **Note:** The IP ranges for each feature returned by the IP Ranges API may overlap. Additionally, these published ranges do not currently allow for execution of Terraform runs against local resources.
+
+Since Terraform Cloud is a shared service, the use of these IP ranges to permit access to restricted resources and their impact on your security posture should be carefully considered. Additionally, these IP ranges may change. If you do choose to make use of these ranges we strongly recommend regularly checking the IP Ranges API for the most up-to-date information.

--- a/content/source/layouts/cloud.erb
+++ b/content/source/layouts/cloud.erb
@@ -283,6 +283,9 @@
             <a href="/docs/cloud/api/cost-estimates.html">Cost Estimates</a>
           </li>
           <li>
+            <a href="/docs/cloud/api/ip-ranges.html">IP Ranges</a>
+          </li>
+          <li>
             <a href="/docs/cloud/api/notification-configurations.html">Notification Configurations</a>
           </li>
           <li>
@@ -388,6 +391,15 @@
           </li>
           <li>
             <a href="/docs/cloud/api/stability-policy.html">API Stability Policy</a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="/docs/cloud/architectural-details/index.html">Architectural Details</a>
+        <ul class="nav">
+          <li>
+            <a href="/docs/cloud/architectural-details/ip-ranges.html">IP Ranges</a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
## Description

This branch adds documentation for the ip-ranges API. It includes an additional page in the API section describing this change, as well as a new "Architectural details" section, which currently only includes a page describing Terraform Cloud's static ip ranges.
