### PR TITLE
Update documentation on VCS SSH keys to specify what git operations they are used for

### DIFF
--- a/content/source/docs/cloud/api/ssh-keys.html.md
+++ b/content/source/docs/cloud/api/ssh-keys.html.md
@@ -26,7 +26,7 @@ The `ssh-key` object represents an SSH key which includes a name and the SSH pri
 
 SSH keys can be used in two places:
 
-- They can be assigned to VCS provider integrations ([available in the API as `oauth-tokens`](./oauth-tokens.html)). Bitbucket Server requires an SSH key; other providers only need an SSH key if your repositories include submodules that are only accessible via SSH (instead of your VCS provider's API).
+- They can be assigned to VCS provider integrations ([available in the API as `oauth-tokens`](./oauth-tokens.html)). Azure DevOps Server and Bitbucket Server require an SSH key. Other providers only need an SSH key if your repositories include submodules that are only accessible via SSH (instead of your VCS provider's API).
 - They can be [assigned to workspaces](./workspaces.html#assign-an-ssh-key-to-a-workspace) and used when Terraform needs to clone modules from a Git server. This is only necessary when your configurations directly reference modules from a Git server; you do not need to do this if you use Terraform Cloud's [private module registry](../registry/index.html).
 
 Listing and viewing SSH keys requires either permission to manage VCS settings for the organization, or admin access to at least one workspace. ([More about permissions.](../users-teams-organizations/permissions.html))

--- a/content/source/docs/cloud/vcs/azure-devops-services.html.md
+++ b/content/source/docs/cloud/vcs/azure-devops-services.html.md
@@ -90,6 +90,7 @@ Most organizations will not need to add an SSH private key. However, if the orga
 
 ### Important Notes
 
+- SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 - Do not use your personal SSH key to connect Terraform Cloud and Azure DevOps Services; generate a new one or use an existing key reserved for service access.
 - In the following steps, you must provide Terraform Cloud with the private key. Although Terraform Cloud does not display the text of the key to users after it is entered, it retains it and will use it for authenticating to Azure DevOps Services.
 - **Protect this private key carefully.** It can push code to the repositories you use to manage your infrastructure. Take note of your organization's policies for protecting important credentials and be sure to follow them.

--- a/content/source/docs/cloud/vcs/bitbucket-cloud.html.md
+++ b/content/source/docs/cloud/vcs/bitbucket-cloud.html.md
@@ -101,6 +101,7 @@ Most organizations will not need to add an SSH private key. However, if the orga
 
 ### Important Notes
 
+- SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 - Do not use your personal SSH key to connect Terraform Cloud and Bitbucket Cloud; generate a new one or use an existing key reserved for service access.
 - In the following steps, you must provide Terraform Cloud with the private key. Although Terraform Cloud does not display the text of the key to users after it is entered, it retains it and will use it for authenticating to Bitbucket Cloud.
 - **Protect this private key carefully.** It can push code to the repositories you use to manage your infrastructure. Take note of your organization's policies for protecting important credentials and be sure to follow them.

--- a/content/source/docs/cloud/vcs/github-enterprise.html.md
+++ b/content/source/docs/cloud/vcs/github-enterprise.html.md
@@ -110,6 +110,7 @@ Most organizations will not need to add an SSH private key. However, if the orga
 
 ### Important Notes
 
+- SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 - Do not use your personal SSH key to connect Terraform Cloud and GitHub Enterprise; generate a new one or use an existing key reserved for service access.
 - In the following steps, you must provide Terraform Cloud with the private key. Although Terraform Cloud does not display the text of the key to users after it is entered, it retains it and will use it for authenticating to GitHub Enterprise.
 - **Protect this private key carefully.** It can push code to the repositories you use to manage your infrastructure. Take note of your organization's policies for protecting important credentials and be sure to follow them.

--- a/content/source/docs/cloud/vcs/github.html.md
+++ b/content/source/docs/cloud/vcs/github.html.md
@@ -99,6 +99,7 @@ Most organizations will not need to add an SSH private key. However, if the orga
 
 ### Important Notes
 
+- SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 - Do not use your personal SSH key to connect Terraform Cloud and GitHub; generate a new one or use an existing key reserved for service access.
 - In the following steps, you must provide Terraform Cloud with the private key. Although Terraform Cloud does not display the text of the key to users after it is entered, it retains it and will use it for authenticating to GitHub.
 - **Protect this private key carefully.** It can push code to the repositories you use to manage your infrastructure. Take note of your organization's policies for protecting important credentials and be sure to follow them.

--- a/content/source/docs/cloud/vcs/gitlab-com.html.md
+++ b/content/source/docs/cloud/vcs/gitlab-com.html.md
@@ -96,6 +96,7 @@ Most organizations will not need to add an SSH private key. However, if the orga
 
 ### Important Notes
 
+- SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 - Do not use your personal SSH key to connect Terraform Cloud and GitLab; generate a new one or use an existing key reserved for service access.
 - In the following steps, you must provide Terraform Cloud with the private key. Although Terraform Cloud does not display the text of the key to users after it is entered, it retains it and will use it for authenticating to GitLab.
 - **Protect this private key carefully.** It can push code to the repositories you use to manage your infrastructure. Take note of your organization's policies for protecting important credentials and be sure to follow them.

--- a/content/source/docs/cloud/vcs/gitlab-eece.html.md
+++ b/content/source/docs/cloud/vcs/gitlab-eece.html.md
@@ -111,6 +111,7 @@ Most organizations will not need to add an SSH private key. However, if the orga
 
 ### Important Notes
 
+- SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 - Do not use your personal SSH key to connect Terraform Cloud and GitLab; generate a new one or use an existing key reserved for service access.
 - In the following steps, you must provide Terraform Cloud with the private key. Although Terraform Cloud does not display the text of the key to users after it is entered, it retains it and will use it for authenticating to GitLab.
 - **Protect this private key carefully.** It can push code to the repositories you use to manage your infrastructure. Take note of your organization's policies for protecting important credentials and be sure to follow them.

--- a/content/source/docs/cloud/vcs/index.html.md
+++ b/content/source/docs/cloud/vcs/index.html.md
@@ -56,9 +56,11 @@ Terraform Cloud uses webhooks to monitor new commits and pull requests.
 
 ### SSH Keys
 
-For most supported VCS providers, Terraform Cloud does not need an SSH key — it can do everything it needs with the provider's API and an OAuth token. The exception is Bitbucket Server, which requires an SSH key for downloading repository contents. The [setup instructions for Bitbucket Server](./bitbucket-server.html) include this step.
+For most supported VCS providers, Terraform Cloud does not need an SSH key — it can do everything it needs with the provider's API and an OAuth token. The exceptions are Azure DevOps Server and Bitbucket Server, which require an SSH key for downloading repository contents. The setup instructions for  [Azure DevOps Server](./azure-devops-server.html) and [Bitbucket Server](./bitbucket-server.html) include this step.
 
-For other VCS providers, most organizations will not need to add an SSH private key. However, if the organization repositories include Git submodules that can only be accessed via SSH, an SSH key can be added along with the OAuth credentials.
+For other VCS providers, most organizations will not need to add an SSH private key. However, if the organization repositories include Git submodules that can only be accessed via SSH, an SSH key can be added along with the OAuth credentials. 
+
+For VCS providers where adding an SSH private key is optional, SSH will only be used to clone Git submodules. All other Git operations will still use HTTPS.
 
 If submodules will be cloned via SSH from a private VCS instance, SSH must be running on the standard port 22 on the VCS server.
 

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -808,7 +808,7 @@ A type of access credential based on public key cryptography, used to log into s
 Terraform Cloud uses SSH private keys for two kinds of operations:
 
 - Downloading private Terraform [modules][] with [Git][]-based sources during a Terraform run. Keys for downloading modules are assigned per-workspace.
-- Bringing content from a connected [VCS provider][] into Terraform Cloud, usually when pulling in a Terraform [configuration][] for a [workspace][] or importing a module into the [private module registry][]. Only some VCS providers require an SSH key, but others can optionally use SSH if an SSH key is provided.
+- Bringing content from a connected [VCS provider][] into Terraform Cloud, usually when pulling in a Terraform [configuration][] for a [workspace][] or importing a module into the [private module registry][]. Only some VCS providers require an SSH key, but other providers only need an SSH key if your repositories include submodules that are only accessible via SSH (instead of your VCS provider's API).
 
 - [Wikipedia: SSH](https://en.wikipedia.org/wiki/Secure_Shell)
 - [Terraform Cloud docs: SSH Keys for Cloning Modules](/docs/cloud/workspaces/ssh-keys.html)


### PR DESCRIPTION
## PR Objective

- [ x ] Making some docs easier to understand

## Description

This PR updates the docs on VCS SSH keys to explain that VCS SSH keys are only used for git submodule cloning when they are specified for VCS providers where SSH keys are optional. 
We've gotten a number of questions about this so we thought it would be good to update the docs to be a little more explicit about it. 

#### SSH keys
![Screenshot_2020-06-09 SSH Keys - API Docs - Terraform Cloud - Terraform by HashiCorp](https://user-images.githubusercontent.com/12189856/84200656-cb2aef80-aa6c-11ea-8bd5-3df6aabd3754.png)

#### Optional SSH key docs
![Screenshot_2020-06-09 Azure DevOps Services - VCS Providers - Terraform Cloud - Terraform by HashiCorp](https://user-images.githubusercontent.com/12189856/84200652-ca925900-aa6c-11ea-81b3-791b1fb5697d.png)

#### VCS index - SSH keys
![Screenshot_2020-06-09 Connecting VCS Providers - Terraform Cloud - Terraform by HashiCorp](https://user-images.githubusercontent.com/12189856/84200654-cb2aef80-aa6c-11ea-866e-259a33a42856.png)

#### Glossary
The glossary doesn't build successfully locally so I couldn't get a screenshot.
