### PR TITLE
Clarifying CA bundle usage for alternative image

### DIFF
--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -143,8 +143,8 @@ TFE runs `terraform plan` and `terraform apply` operations in a disposable Docke
 ### Requirements
  - The base image must be `ubuntu:xenial`.
  - The image must exist on the Terraform Enterprise host. It can be added by running `docker pull` from a local registry or any other similar method.
- - CA certificates must be available when Terraform runs. During image creation, a file containing all necessary PEM encoded CA certificates must be placed in `/etc/ssl/certs/ca-certificates.crt`.
- - Terraform must not be installed on the image. TFE will take care of that at runtime.
+ - A file containing all necessary PEM-encoded CA certificates must be placed in `/etc/ssl/certs/ca-certificates.crt`. This includes both custom CA certificates and default CA certificates that come with the operating system. The CA certificates configured in the [CA Bundle settings](#certificate-authority-ca-bundle) will not be automatically added to this image at runtime.
+ - Terraform must not be installed on the image. Terraform Enterprise will take care of that at runtime.
 
  This is a sample `Dockerfile` you can use to start building your own image:
 
@@ -152,10 +152,10 @@ TFE runs `terraform plan` and `terraform apply` operations in a disposable Docke
 # This Dockerfile builds the image used for the worker containers.
 FROM ubuntu:xenial
 
-# Inject the ssl certificates
+# Inject the CA certificates.
 ADD ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-# Install software used by TFE
+# Install software used by Terraform Enterprise.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo unzip daemontools git-core ssh wget curl psmisc iproute2 openssh-client redis-tools netcat-openbsd
  ```


### PR DESCRIPTION
##  PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [x] Clarifying CA bundle usage for alternative image

## Description
When using an alternative worker image, Terraform Enterprise no longer
automatically copies the CA bundle into the worker image. This is
because Terraform Enterprise no longer manages the worker image, the
user does. Making this behavior more clear to the reader.
