### PR TITLE
Remove unnecessary header from ip ranges example

### DIFF
--- a/content/source/docs/cloud/api/ip-ranges.html.md
+++ b/content/source/docs/cloud/api/ip-ranges.html.md
@@ -48,7 +48,6 @@ Status  | Response                                        | Reason
 
 ```shell
 curl \
-  --header "Content-Type: application/vnd.api+json" \
   --request GET \
   https://app.terraform.io/api/meta/ip-ranges
 ```


### PR DESCRIPTION
## PR Objective

- [x ] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

## Description

Tiny change - removing an unnecessary header from the ip ranges example, as to not imply that this api is JSON:API compliant.
