### PR TITLE
Adding identified hostname to egress requirements

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -25,6 +25,7 @@ If Terraform Enterprise is installed in online mode, it accesses the following h
 * `registry-data.replicated.com`
 * `registry.replicated.com`
 * `quay.io`
+* `cdn.quay.io`
 * `quay-registry.s3.amazonaws.com`
 * `cloudfront.net`
 * `index.docker.io`


### PR DESCRIPTION
## PR Objective

- [ ] Fixing inaccurate docs

## Description

Identified a hostname that wasn't documented and identified during the installation part of TFE. This is particularly important when customers are not permitted to use wildcards.
