### PR TITLE
Fix name of application-settings.json to match other citations

### DIFF
--- a/content/source/docs/enterprise/install/automating-the-installer.html.md
+++ b/content/source/docs/enterprise/install/automating-the-installer.html.md
@@ -242,7 +242,7 @@ See the full set of configuration parameters in the [Replicated documentation](h
     "TlsBootstrapCert":             "/etc/server.crt",
     "TlsBootstrapKey":              "/etc/server.key",
     "BypassPreflightChecks":        true,
-    "ImportSettingsFrom":           "/path/to/application-settings.json",
+    "ImportSettingsFrom":           "/path/to/settings.json",
     "LicenseFileLocation":          "/path/to/license.rli"
 }
 ```
@@ -273,7 +273,7 @@ The following is an example `/etc/replicated.conf` suitable for an automated air
     "TlsBootstrapCert":                  "/etc/server.crt",
     "TlsBootstrapKey":                   "/etc/server.key",
     "BypassPreflightChecks":             true,
-    "ImportSettingsFrom":                "/path/to/application-settings.json",
+    "ImportSettingsFrom":                "/path/to/settings.json",
     "LicenseFileLocation":               "/path/to/license.rli",
     "LicenseBootstrapAirgapPackagePath": "/path/to/bundle.airgap"
 }


### PR DESCRIPTION
## PR Objective

- [x] Fixing inaccurate docs
- [x] Making some docs easier to understand


## Description
Replicated settings has been changed in automating-the-installer from replicated-settings.json to just settings.json.  All good, except in the snippet for replicated.conf, the file path is to 'application-settings.json' which is misleading.  This makes all citations of the filename the same.

