### PR TITLE
Add recommendation around exposing ports

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -34,6 +34,7 @@ If Terraform Enterprise is installed in online mode, it accesses the following h
 * `cdn.quay.io`
 * `quay-registry.s3.amazonaws.com`
 * `*.cloudfront.net`
+* `hub.docker.com`
 * `index.docker.io`
 * `auth.docker.io`
 * `registry-1.docker.io`

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -9,13 +9,18 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ## Ingress
 
+### Source - User/Client/VCS
+
+* **443**: To access the Terraform Enterprise application via HTTPS 
+
+### Source - Administrators
+
 * **22**: To access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
-* **443**: To access the Terraform Enterprise application via HTTPS.
 * **8800**: To access the installer dashboard.
+
+### Source - TFE Server(s)
 * **9870-9880 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
 * **23000-23100 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
-
-~> **Important:** Access to port 22 and port 8800 should be restricted to administrators only. The use of a secure jumphost or limited source IP range is recommened for access to these ports.
 
 ## Egress
 
@@ -25,10 +30,10 @@ If Terraform Enterprise is installed in online mode, it accesses the following h
 * `get.replicated.com`
 * `registry-data.replicated.com`
 * `registry.replicated.com`
-* `quay.io`
+* `*.quay.io`
 * `cdn.quay.io`
 * `quay-registry.s3.amazonaws.com`
-* `cloudfront.net`
+* `*.cloudfront.net`
 * `index.docker.io`
 * `auth.docker.io`
 * `registry-1.docker.io`

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -10,11 +10,12 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 ## Ingress
 
 * **22**: To access the instance via SSH from your computer. SSH access to the instance is required for administration and debugging.
-* **80**: To access the Terraform Enterprise application via HTTP. This port redirects to port 443 for HTTPS.
 * **443**: To access the Terraform Enterprise application via HTTPS.
 * **8800**: To access the installer dashboard.
 * **9870-9880 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
 * **23000-23100 (inclusive)**: For internal communication on the host and its subnet; not publicly accessible.
+
+~> **Important:** Access to port 22 and port 8800 should be restricted to administrators only. The use of a secure jumphost or limited source IP range is recommened for access to these ports.
 
 ## Egress
 


### PR DESCRIPTION
## PR Objective

Clarify TFE network port information.

- [x] Fixing inaccurate docs
- [x] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

## Description

Port 80 is unnecessary - removed it from the list entirely.

Ports 22 and 8800 should be considered high risk and limited access should be granted to these.


