### PR TITLE
Adding SLA info around HashiCorp's commitment to pre-update IP range endpoint

### DIFF
--- a/content/source/docs/cloud/api/ip-ranges.html.md
+++ b/content/source/docs/cloud/api/ip-ranges.html.md
@@ -34,6 +34,8 @@ Name                             | Type   | Description
 
 -> **Note:** The IP ranges for each feature returned by the IP Ranges API may overlap. Additionally, these published ranges do not currently allow for execution of Terraform runs against local resources.
 
+-> **Note:** Under normal circumstances, HashiCorp will publish any expected changes to Terraform Cloud's IP ranges at least 24 hours in advance of implementing them. This should allow sufficient time for users to update any connected systems to reflect the changes. In the event of an emergency outage or failover operation, it may not be possible to pre-publish these changes. 
+
 ## Get IP Ranges
 
 -> **Note:** The IP Ranges API does not require authentication

--- a/content/source/docs/cloud/architectural-details/ip-ranges.html.md
+++ b/content/source/docs/cloud/architectural-details/ip-ranges.html.md
@@ -10,3 +10,5 @@ Terraform Cloud uses static IP ranges for certain features that make outbound re
 -> **Note:** The IP ranges for each feature returned by the IP Ranges API may overlap. Additionally, these published ranges do not currently allow for execution of Terraform runs against local resources.
 
 Since Terraform Cloud is a shared service, the use of these IP ranges to permit access to restricted resources and their impact on your security posture should be carefully considered. Additionally, these IP ranges may change. While changes are not expected to be frequent, we strongly recommend checking the IP Ranges API every 24 hours for the most up-to-date information if you do choose to make use of these ranges.
+
+-> **Note:** Under normal circumstances, HashiCorp will publish any expected changes to Terraform Cloud's IP ranges at least 24 hours in advance of implementing them. This should allow sufficient time for users to update any connected systems to reflect the changes. In the event of an emergency outage or failover operation, it may not be possible to pre-publish these changes. 


### PR DESCRIPTION
We are committing to give our customers 24h advance notice of any network changes via the ip-ranges API, under normal non-emergency circumstances. These two updates reflect that commitment. When we implement the API timestamps, we will want to add additional info around using/comparing those; so for now this is a process-only change

@nfagerlund hopefully I used the Note boxes properly, if not please feel free to reformat accordingly. I think this works but happy for your input on style.