### PR TITLE
Fix broken link to creating github action secrets

### DIFF
--- a/content/source/docs/github-actions/setup-terraform.html.md
+++ b/content/source/docs/github-actions/setup-terraform.html.md
@@ -55,7 +55,7 @@ The workflow file below expects a secret named `TF_API_TOKEN`, whose value is a 
 
 See also:
 
-- [Configuring GitHub Actions secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-)
+- [Configuring GitHub Actions secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 
 ### GitHub Actions Workflow YAML
 


### PR DESCRIPTION
<!--

Hello! Thank you for submitting a docs PR to terraform.io! Feel free to delete
this message.

- For advice or edits from a tech writer or education engineer,
  please request review from the "hashicorp/terraform-education" GitHub team.

- When updating screenshots of a web UI, please try to capture
  the full width of the page, with the viewport size set to 1024px wide.

- If you're a HashiCorp employee with permission to merge to this repo,
  please get an approving review before merging your own PRs. (If you got
  review approval on the private fork, that's fine too; just announce it in a
  comment before merging!) When in doubt, ask in the #proj-terraform-docs channel.

- To learn more about how the website is built and deployed, how to preview your
  changes, which content lives where, and more, check out the README.md in the
  root of this repo.

-->

## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [x] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

## Description

<!-- (Add whatever you'd like to say here.) -->

Currently, the "Configuring GitHub Actions secrets" link one this [page](https://www.terraform.io/docs/github-actions/setup-terraform.html) points to a broken link. It looks like the source only has a partial path of the actual endpoint.
