### PR TITLE
initial_token generation adapted for automation

### DIFF
--- a/content/source/docs/enterprise/install/automating-initial-user.html.md
+++ b/content/source/docs/enterprise/install/automating-initial-user.html.md
@@ -28,7 +28,7 @@ initial_token=$(replicated admin retrieve-iact)   # no --tty=0 otherwise automat
 initial_token=${initial_token//$'\r'}             # needed to remove carrier return for the usage with curl
 ```
 
-The command outputs only the complete IACT, which facilitates use in automation.
+The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.
 
 ### Via API
 

--- a/content/source/docs/enterprise/install/automating-initial-user.html.md
+++ b/content/source/docs/enterprise/install/automating-initial-user.html.md
@@ -24,7 +24,8 @@ replicated admin --tty=0 retrieve-iact
 If you want to create the initial user in an automated deployment script, run a command like the following instead so that you can capture the IACT:
 
 ```shell
-initial_token=$(replicated admin --tty=0 retrieve-iact)
+initial_token=$(replicated admin retrieve-iact)   # no --tty=0 otherwise automation gets stuck
+initial_token=${initial_token//$'\r'}             # needed to remove carrier return for the usage with curl
 ```
 
 The command outputs only the complete IACT, which facilitates use in automation.

--- a/content/source/docs/enterprise/install/automating-initial-user.html.md
+++ b/content/source/docs/enterprise/install/automating-initial-user.html.md
@@ -24,8 +24,7 @@ replicated admin --tty=0 retrieve-iact
 If you want to create the initial user in an automated deployment script, run a command like the following instead so that you can capture the IACT:
 
 ```shell
-initial_token=$(replicated admin retrieve-iact)   # no --tty=0 otherwise automation gets stuck
-initial_token=${initial_token//$'\r'}             # needed to remove carrier return for the usage with curl
+initial_token=$(replicated admin retrieve-iact | tr -d '\r')
 ```
 
 The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.


### PR DESCRIPTION
## PR Objective

- [x] Fixing inaccurate docs
- [x] Making some docs easier to understand

## Description

Adapted the docs for creation of initial_token to be usable for automation.
Here an example, cause I ran into problems using the token inside a bash script with curl.

```bash
[user@server]$ initial_token=$(replicated admin retrieve-iact)
[user@server]$ printf '%q\n' "$initial_token"
$'ExampleToken32chars\r'
[user@server]$ initial_token=${initial_token//$'\r'};printf '%q\n' "$initial_token"
ExampleToken32chars
```

