### PR TITLE
Update Azure cost estimation egress

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -11,7 +11,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ### Source - User/Client/VCS
 
-* **443**: To access the Terraform Enterprise application via HTTPS 
+* **443**: To access the Terraform Enterprise application via HTTPS
 
 ### Source - Administrators
 
@@ -56,7 +56,7 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
 * `api.pricing.us-east-1.amazonaws.com`
 * `cloud.google.com`
-* `azure.microsoft.com`
+* `ratecard.azure-api.net`
 
 ## Other Configuration
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -56,6 +56,7 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
 * `api.pricing.us-east-1.amazonaws.com`
 * `cloud.google.com`
+* `management.azure.com`
 * `ratecard.azure-api.net`
 
 ## Other Configuration

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -11,7 +11,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 ### Source - User/Client/VCS
 
-* **443**: To access the Terraform Enterprise application via HTTPS
+* **443**: To access the Terraform Enterprise application via HTTPS 
 
 ### Source - Administrators
 


### PR DESCRIPTION
## PR Objective

- [x] Fixing inaccurate docs

## Description

👋  

The 302 issued by the RateCard REST API is currently `ratecard.azure-api.net`, the redirect location isn't [officially documented](https://docs.microsoft.com/en-us/previous-versions/azure/reference/mt219004(v=azure.100)#response) but intercepting the client's requests shows it.