### PR TITLE
add terraform configuration for Fastly redirect dictionaries

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,33 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "remote" {
+    hostname = "app.terraform.io"
+    organization = "hashicorp-terraform"
+
+    workspaces {
+      name = "static-sites-terraform-website-fastly"
+    }
+  }
+}

--- a/terraform/fastly.tf
+++ b/terraform/fastly.tf
@@ -1,0 +1,87 @@
+provider "fastly" {
+  version = "~> 0.17.0"
+}
+
+locals {
+  static_sites_service_id              = "7GrxRJP3PVBuqQbyxYQ0MV"
+  tf_registry_docs_type_dictionary_id  = "2meQ4j47Me81w1jSb5m9lh"
+  tf_provider_namespaces_dictionary_id = "7Rye8KM48sHfEE7kzcZTWU"
+  tf_external_redirects_dictionary_id = "44DagwD5TIm8Qq4jPTsEMi"
+}
+
+# The following dictionaries update Terraform redirects for the terraform.io/docs -> registry.terraform.io move.
+# We do not currently manage the VCL in this Terraform configuration. The relevant VCL configuration that uses these dictionaries
+# are shown below and the relevant RFC is "TFR-013: Deprecating provider docs on terraform.io":
+
+# # Redirect docs to the registry.terraform.io
+# # This is for the index page only
+# if (req.url ~ "/docs/providers/([^/]+)/index.html$") {
+#     if (table.lookup(tf_provider_namespaces, re.group.1)) {
+#         set req.http.x-varnish-redirect = "https://registry.terraform.io/providers/" table.lookup(tf_provider_namespaces, re.group.1) "/latest/docs";
+#         error 750 req.http.x-varnish-redirect;
+#     }
+# }
+# # This is for resources, data sources, guides
+# # re.group.1 = provider name; ex: github
+# # re.group.2 = doc type; r/d/guides
+# # re.group.3 = doc path including optional anchor; issue_label.html#argument-reference
+# declare local var.doc_path STRING;
+# if (req.url ~ "/docs/providers/([^/]+)/([^/]+)/([^/]+)$") {
+#     if (table.lookup(tf_provider_namespaces, re.group.1)) {
+#         if(table.lookup(tf_registry_docs_type, re.group.2)){
+#             set var.doc_path = regsub(re.group.3, "\.[^#]+", "");
+#             set req.http.x-varnish-redirect = "https://registry.terraform.io/providers/" table.lookup(tf_provider_namespaces, re.group.1) "/latest/docs/" table.lookup(tf_registry_docs_type, re.group.2) "/" var.doc_path;
+#             error 750 req.http.x-varnish-redirect;
+#         }
+#     }
+# }
+# # Redirects any external links
+# if (table.lookup(tf_external_redirects, req.url.path)) {
+#   set req.http.x-varnish-redirect = table.lookup(tf_external_redirects, req.url.path);
+#   error 750 req.http.x-varnish-redirect;
+# }
+
+resource "fastly_service_dictionary_items_v1" "tf_provider_namespaces_dictionary_id" {
+  service_id    = local.static_sites_service_id # we do not manage this service in Terraform at this time
+  dictionary_id = local.tf_provider_namespaces_dictionary_id
+  items = {
+    "null" : "hashicorp/null"
+    "random" : "hashicorp/random"
+  }
+
+  # prevent destroying this dictionary to cause redirects to break
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "fastly_service_dictionary_items_v1" "tf_external_redirects_dictionary_id" {
+  service_id    = local.static_sites_service_id # we do not manage this service in Terraform at this time
+  dictionary_id = local.tf_external_redirects_dictionary_id
+  items = {
+    "/docs/providers/null/data_source.html" : "https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source"
+    "/docs/providers/null/resource.html" : "https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource"
+  }
+
+  # prevent destroying this dictionary to cause redirects to break
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# These should not need changing, these are static mappings of r,d,guides in the old docs site to the equivalents
+# in the Terraform Registry
+resource "fastly_service_dictionary_items_v1" "tf_registry_docs_type" {
+  service_id    = local.static_sites_service_id # we do not manage this service in Terraform at this time
+  dictionary_id = local.tf_registry_docs_type_dictionary_id
+  items = {
+    "r" : "resources"
+    "d" : "data-sources"
+    "guides" : "guides"
+  }
+
+  # prevent destroying this dictionary to cause redirects to break
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
## PR Objective

Add Terraform configuration for Fastly dictionaries used in redirects to the new equivalent registry.terraform.io domain.

## Description

The configuration of the actual Fastly service is not handled in this Terraform configuration. The VCL is published to Fastly directly. However, the VCL consumes dictionaries as shown in the code snippets in this PR. This Terraform configuration only modifies these dictionaries to make it easier on the team so they do not need to do it in the Fastly interface.