### PR TITLE
Add support for PostgreSQL-compatible databases

### DIFF
--- a/content/source/docs/enterprise/before-installing/postgres-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/postgres-requirements.html.md
@@ -10,7 +10,8 @@ page_title: "PostgreSQL Requirements - Before Installing - Terraform Enterprise"
 To use an external PostgreSQL database with Terraform Enterprise, the following
 requirements must be met:
 
-* The PostgreSQL Server version must be one of the following:
+* A PostgreSQL server or PostgreSQL-compatible server such as Amazon Aurora PostgreSQL must be used.
+* The PostgreSQL server version must be one of the following:
   * 9.4, 9.5, 9.6, 10.x, 11.x.
 * A PostgreSQL user must be created with the following permissions on the database:
   * The ability to create, modify, and read all tables and indices on all schemas within the database. Usually this is granted if the user is an owner of the database.


### PR DESCRIPTION
## PR Objective

- [x] Adding/updating docs for new feature

## Description

Terraform Enterprise is compatible with Amazon Aurora PostgreSQL since
it is a PostgreSQL-compatible database server.