### PR TITLE
Updating docs for enforcement levels

### DIFF
--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -33,7 +33,7 @@ Policy sets are managed at an organization level; viewing and modifying them req
 Enforcement levels in Sentinel are used for defining behavior when policies fail to evaluate successfully. Sentinel provides three enforcement modes:
 
 * `hard-mandatory` requires that the policy passes. If a policy fails, the run is halted and may not be applied until the failure is resolved.
-* `soft-mandatory` is much like `hard-mandatory`, but allows an administrator to override policy failures on a case-by-case basis.
+* `soft-mandatory` is much like `hard-mandatory`, but allows any user with the [Manage Policies](../users-teams-organizations/permissions.html#manage-policies) permission to override policy failures on a case-by-case basis.
 * `advisory` will never interrupt the run, and instead will only surface policy failures as informational to the user.
 
 ## Constructing a policy set


### PR DESCRIPTION
## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [ ] Fixing inaccurate docs
- [x] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

## Description

This PR includes a minor change to the Manage Policies section in the Terraform Cloud documentation. In the docs, we explain the differences between the different enforcement levels that are available in Sentinel and which personas have the ability to override certain behaviour. This can be confusing for the reader so we are changing the messaging to move away from the concept of a persona (i.e administrator) and explicitly call out the permissions that are required instead. 
