### PR TITLE
Updating Data security documentation to include Terraform Cloud

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -392,6 +392,7 @@
 /docs/enterprise/run/cli.html                                       /docs/cloud/run/cli.html
 /docs/enterprise/run/ui.html                                        /docs/cloud/run/ui.html
 /docs/enterprise/run/states.html                                    /docs/cloud/run/states.html
+/docs/enterprise/system-overview/data-security.html                 /docs/cloud/architectural-details/data-security.html
 
 /docs/enterprise/private                                            /docs/enterprise
 /docs/enterprise/private/                                           /docs/enterprise/
@@ -410,7 +411,7 @@
 /docs/enterprise/private/capacity.html                              /docs/enterprise/system-overview/capacity.html
 /docs/enterprise/private/centos-install-guide.html                  /docs/enterprise/before-installing/centos-requirements.html
 /docs/enterprise/private/config.html                                /docs/enterprise/install/config.html
-/docs/enterprise/private/data-security.html                         /docs/enterprise/system-overview/data-security.html
+/docs/enterprise/private/data-security.html                         /docs/cloud/architectural-details/data-security.html
 /docs/enterprise/private/diagnostics.html                           /docs/enterprise/support/index.html
 /docs/enterprise/private/encryption-password                        /docs/enterprise/install/encryption-password.html
 /docs/enterprise/private/faq.html                                   /docs/enterprise/index.html

--- a/content/source/docs/cloud/architectural-details/data-security.html.md
+++ b/content/source/docs/cloud/architectural-details/data-security.html.md
@@ -27,6 +27,7 @@ seriously. This table lists which parts of the Terraform Cloud and Terraform Ent
 | Vault Unseal Key                     | PostgreSQL    | ChaCha20+Poly1305                     |
 
 ### Terraform Enterprise Specific
+
 | Object                               | Storage       | Encrypted                             |
 |:-------------------------------------|:--------------|:--------------------------------------|
 | Twilio Account Configuration         | PostgreSQL    | Vault Transit Encryption              |

--- a/content/source/docs/cloud/architectural-details/data-security.html.md
+++ b/content/source/docs/cloud/architectural-details/data-security.html.md
@@ -10,6 +10,7 @@ seriously. This table lists which parts of the Terraform Cloud and Terraform Ent
 
 
 ### Terraform Cloud and Enterprise
+
 | Object                               | Storage       | Encrypted                             |
 |:-------------------------------------|:--------------|:--------------------------------------|
 | Ingressed VCS Data                   | Blob Storage  | Vault Transit Encryption              |

--- a/content/source/docs/cloud/architectural-details/data-security.html.md
+++ b/content/source/docs/cloud/architectural-details/data-security.html.md
@@ -25,7 +25,6 @@ seriously. This table lists which parts of the Terraform Cloud and Terraform Ent
 | User/Team/Organization Tokens        | PostgreSQL    | HMAC SHA512                           |
 | OAuth Client ID + Secret             | PostgreSQL    | Vault Transit Encryption              |
 | OAuth User Tokens                    | PostgreSQL    | Vault Transit Encryption              |
-| Vault Unseal Key                     | PostgreSQL    | ChaCha20+Poly1305                     |
 
 ### Terraform Enterprise Specific
 
@@ -34,6 +33,7 @@ seriously. This table lists which parts of the Terraform Cloud and Terraform Ent
 | Twilio Account Configuration         | PostgreSQL    | Vault Transit Encryption              |
 | SMTP Configuration                   | PostgreSQL    | Vault Transit Encryption              |
 | SAML Configuration                   | PostgreSQL    | Vault Transit Encryption              |
+| Vault Unseal Key                     | PostgreSQL    | ChaCha20+Poly1305                     |
 
 ## Vault Transit Encryption
 

--- a/content/source/docs/cloud/architectural-details/data-security.html.md
+++ b/content/source/docs/cloud/architectural-details/data-security.html.md
@@ -1,13 +1,15 @@
 ---
-layout: "enterprise"
-page_title: "Data Security - System Overview - Terraform Enterprise"
+layout: "cloud"
+page_title: "Data Security - Architectural Details - Terraform Cloud and Terraform Enterprise"
 ---
 
 # Data Security
 
-Terraform Enterprise takes the security of the data it manages
-seriously. This table lists which parts of the Terraform Enterprise app can contain sensitive data, what storage is used, and what encryption is used.
+Terraform Cloud takes the security of the data it manages
+seriously. This table lists which parts of the Terraform Cloud and Terraform Enterprise app can contain sensitive data, what storage is used, and what encryption is used.
 
+
+### Terraform Cloud and Enterprise
 | Object                               | Storage       | Encrypted                             |
 |:-------------------------------------|:--------------|:--------------------------------------|
 | Ingressed VCS Data                   | Blob Storage  | Vault Transit Encryption              |
@@ -22,10 +24,14 @@ seriously. This table lists which parts of the Terraform Enterprise app can cont
 | User/Team/Organization Tokens        | PostgreSQL    | HMAC SHA512                           |
 | OAuth Client ID + Secret             | PostgreSQL    | Vault Transit Encryption              |
 | OAuth User Tokens                    | PostgreSQL    | Vault Transit Encryption              |
+| Vault Unseal Key                     | PostgreSQL    | ChaCha20+Poly1305                     |
+
+### Terraform Enterprise Specific
+| Object                               | Storage       | Encrypted                             |
+|:-------------------------------------|:--------------|:--------------------------------------|
 | Twilio Account Configuration         | PostgreSQL    | Vault Transit Encryption              |
 | SMTP Configuration                   | PostgreSQL    | Vault Transit Encryption              |
 | SAML Configuration                   | PostgreSQL    | Vault Transit Encryption              |
-| Vault Unseal Key                     | PostgreSQL    | ChaCha20+Poly1305                     |
 
 ## Vault Transit Encryption
 

--- a/content/source/docs/enterprise/admin/backup-restore.html.md
+++ b/content/source/docs/enterprise/admin/backup-restore.html.md
@@ -23,7 +23,7 @@ Please note the following when using the backup and restore API:
 
 See also:
 
-- [Data Security](../system-overview/data-security.html) for details about the contents of Terraform Enterprise's blob storage and PostgreSQL database.
+- [Data Security](../../cloud/architectural-details/data-security.html) for details about the contents of Terraform Enterprise's blob storage and PostgreSQL database.
 
 ### Authentication
 

--- a/content/source/layouts/_cloud_content.erb
+++ b/content/source/layouts/_cloud_content.erb
@@ -379,6 +379,9 @@
           <li>
             <a href="/docs/cloud/architectural-details/ip-ranges.html">IP Ranges</a>
           </li>
+          <li>
+            <a href="/docs/cloud/architectural-details/data-security.html">Data Security</a>
+          </li>
         </ul>
       </li>
 

--- a/content/source/layouts/_enterprise_content.erb
+++ b/content/source/layouts/_enterprise_content.erb
@@ -230,9 +230,6 @@
             <a href="/docs/enterprise/system-overview/reliability-availability.html">Reliability &amp; Availability</a>
           </li>
           <li>
-            <a href="/docs/enterprise/system-overview/data-security.html">Data Security</a>
-          </li>
-          <li>
             <a href="/docs/enterprise/system-overview/capacity.html">Capacity &amp; Performance</a>
           </li>
         </ul>


### PR DESCRIPTION

## PR Objective
- [X] Making some docs easier to understand
- [X] Changing behavior or layout of website

## Description

This change moves the "Data Security" documentation page into the "Terraform Cloud and Enterprise" section, as well as separates the table in the page to distinguish which data is Terraform Enterprise specific.

This should hopefully clear up any confusion about Terraform Cloud's data security practices.
