### PR TITLE
Redirect `external` data source docs to registry

### DIFF
--- a/terraform/external-redirects.csv
+++ b/terraform/external-redirects.csv
@@ -28,3 +28,4 @@ newrelic - v1 docs,/docs/providers/newrelic/r/v1/workload.html,https://registry.
 newrelic - v1 docs,/docs/providers/newrelic/v1/index.html,https://registry.terraform.io/providers/newrelic/newrelic/1.19.1/docs/
 null - malformed,/docs/providers/null/data_source.html,https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source
 null - malformed,/docs/providers/null/resource.html,https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource
+external - malformed,/docs/providers/external/data_source.html,https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source


### PR DESCRIPTION
## PR Objective

- [x] Fixing redirects

## Description

This provider didn't follow the standard URL pattern, so it needs a little help. (Note that if you go to https://www.terraform.io/docs/providers/external/d/data_source.html, it'll redirect just fine because that matches the expected format.)