### PR TITLE
Remove broken link to a TFE page in data-security

### DIFF
--- a/content/source/docs/cloud/architectural-details/data-security.html.md
+++ b/content/source/docs/cloud/architectural-details/data-security.html.md
@@ -37,4 +37,4 @@ seriously. This table lists which parts of the Terraform Cloud and Terraform Ent
 
 ## Vault Transit Encryption
 
-The [Vault Transit Secret Engine](https://www.vaultproject.io/docs/secrets/transit/index.html) handles encryption for data in-transit and is used when encrypting data from the application to the applicable [storage layer](./reliability-availability.html#components).
+The [Vault Transit Secret Engine](https://www.vaultproject.io/docs/secrets/transit/index.html) handles encryption for data in-transit and is used when encrypting data from the application to persistent storage.


### PR DESCRIPTION
## PR Objective

- [x] Fixing inaccurate docs

## Description

This relative link broke when we moved the file into the TFC application docs.

I'm removing it instead of fixing it because the extra context from the link
isn't really necessary to understand the explanation.
