### PR TITLE
added until block in script examples

### DIFF
--- a/content/source/docs/enterprise/admin/automated-recovery.html.md
+++ b/content/source/docs/enterprise/admin/automated-recovery.html.md
@@ -88,11 +88,11 @@ apt-get install -y jq
 curl https://install.terraform.io/ptfe/stable | bash -s fast-timeouts
 
 # Wait for replicated to start before proceeding
-until replicatedctl system status | grep -q -e '"Replicated": "ready",i' -e '"Retraced": "ready"'; do :
-  sleep 1;
-  echo "Replicated is not yet ready";
-done;
-echo 'Replicated is ready.'
+until replicatedctl system status --template '{{and (eq .Replicated "ready") (eq .Retraced "ready")}}' | grep -q true; do
+  sleep 1
+  echo "Replicated is not yet ready."
+done
+echo "Replicated is ready."
 
 # This retrieves a list of all the snapshots currently available.
 replicatedctl snapshot ls $access -o json > /tmp/snapshots.json
@@ -149,11 +149,11 @@ apt-get install -y jq
 curl https://install.terraform.io/ptfe/stable | bash -s fast-timeouts
 
 # Wait for replicated to start before proceeding
-until replicatedctl system status | grep -q -e '"Replicated": "ready",i' -e '"Retraced": "ready"'; do :
-  sleep 1;
-  echo "Replicated is not yet ready";
-done;
-echo 'Replicated is ready.'
+until replicatedctl system status --template '{{and (eq .Replicated "ready") (eq .Retraced "ready")}}' | grep -q true; do
+  sleep 1
+  echo "Replicated is not yet ready."
+done
+echo "Replicated is ready."
 
 # This retrieves a list of all the snapshots currently available.
 replicatedctl snapshot ls $access -o json > /tmp/snapshots.json
@@ -209,11 +209,11 @@ apt-get install -y jq
 curl https://install.terraform.io/ptfe/stable | bash -s fast-timeouts
 
 # Wait for replicated to start before proceeding
-until replicatedctl system status | grep -q -e '"Replicated": "ready",i' -e '"Retraced": "ready"'; do :
-  sleep 1;
-  echo "Replicated is not yet ready";
-done;
-echo 'Replicated is ready.'
+until replicatedctl system status --template '{{and (eq .Replicated "ready") (eq .Retraced "ready")}}' | grep -q true; do
+  sleep 1
+  echo "Replicated is not yet ready."
+done
+echo "Replicated is ready."
 
 # This retrieves a list of all the snapshots currently available.
 replicatedctl snapshot ls $access -o json > /tmp/snapshots.json

--- a/content/source/docs/enterprise/admin/automated-recovery.html.md
+++ b/content/source/docs/enterprise/admin/automated-recovery.html.md
@@ -87,6 +87,13 @@ apt-get install -y jq
 
 curl https://install.terraform.io/ptfe/stable | bash -s fast-timeouts
 
+# Wait for replicated to start before proceeding
+until replicatedctl system status | grep -q -e '"Replicated": "ready",i' -e '"Retraced": "ready"'; do :
+  sleep 1;
+  echo "Replicated is not yet ready";
+done;
+echo 'Replicated is ready.'
+
 # This retrieves a list of all the snapshots currently available.
 replicatedctl snapshot ls $access -o json > /tmp/snapshots.json
 
@@ -141,6 +148,13 @@ apt-get install -y jq
 
 curl https://install.terraform.io/ptfe/stable | bash -s fast-timeouts
 
+# Wait for replicated to start before proceeding
+until replicatedctl system status | grep -q -e '"Replicated": "ready",i' -e '"Retraced": "ready"'; do :
+  sleep 1;
+  echo "Replicated is not yet ready";
+done;
+echo 'Replicated is ready.'
+
 # This retrieves a list of all the snapshots currently available.
 replicatedctl snapshot ls $access -o json > /tmp/snapshots.json
 
@@ -193,6 +207,13 @@ apt-get install -y jq
 # Run the installer.
 
 curl https://install.terraform.io/ptfe/stable | bash -s fast-timeouts
+
+# Wait for replicated to start before proceeding
+until replicatedctl system status | grep -q -e '"Replicated": "ready",i' -e '"Retraced": "ready"'; do :
+  sleep 1;
+  echo "Replicated is not yet ready";
+done;
+echo 'Replicated is ready.'
 
 # This retrieves a list of all the snapshots currently available.
 replicatedctl snapshot ls $access -o json > /tmp/snapshots.json


### PR DESCRIPTION
## PR Objective

- [ ] Fixing inaccurate docs
- [ ] Making some docs easier to understand

## Description

Working with @sudomateo  I've added "until" blocks in the example bash scripts for automated recovery of TFE using Replicated snapshots. Without this, it is a common occurrence for the script to fail because it issues replicatedctl before Replicated is in the ready state.  While this could have been accomplished using 'jq', or other more elegant means, I felt it was important to keep it simple and stick with 'grep' as the script is most likely to be used during a high stress recovery situation.
