### PR TITLE
Removing "Gitlab Subgroups unsupported" note from TFC PMR index page

### DIFF
--- a/content/source/docs/cloud/registry/index.html.md
+++ b/content/source/docs/cloud/registry/index.html.md
@@ -11,5 +11,3 @@ Terraform Cloud's private module registry helps you share [Terraform modules](/d
 
 By design, the private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already used the public registry, Terraform Cloud's registry will feel familiar.
 
--> **Note:** Currently, the private module registry works with all supported VCS providers; however, the private module registry does not support [GitLab subgroups](https://about.gitlab.com/features/subgroups/).
-


### PR DESCRIPTION
## Description

As per Asana [10908 TFE modules and GitLab subgroups](https://app.asana.com/0/852068279639184/862570025625495) _Gitlab subgroups_ are now supported in TFC PMR, and the note indicating they aren't was removed from [Publishing Modules to the Terraform Cloud Private Module Registry](https://www.terraform.io/docs/cloud/registry/publish.html) page with the following [PR](https://github.com/hashicorp/terraform-website/pull/1215/files/31110d70fb254b2887c95e77bc6fd6ce9ba0aa7b) however the `unsupported note` is still present on the [index](https://www.terraform.io/docs/cloud/registry/index.html) page, so removing the statement from there will fix the inconsistency in the documentation. 




