### PR TITLE
Context Path

### DIFF
--- a/content/source/docs/cloud/vcs/bitbucket-server.html.md
+++ b/content/source/docs/cloud/vcs/bitbucket-server.html.md
@@ -59,14 +59,16 @@ Leave the page open in a browser tab, and remain logged in as an admin user.
 
 1. Enter the URL of your Bitbucket Server instance in the **HTTP URL** and **API URL** fields.
 
--> **Context Path**  If your Bitbucket Server instance does not have a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set, the **API URL** should be the same as the **HTTP URL**.
+    ~> **Important:** The values for the **HTTP URL** and **API URL** fields differ depending on whether or not your Bitbucket Server instance has a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set.
+    
+    If your Bitbucket Server instance does not have a context path set, the **API URL** should be the same as the **HTTP URL**.
 
-    If your Bitbucket Server instance has a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set:
+    If your Bitbucket Server instance has a context path set:
 
     1. Set the **HTTP URL** to the URL of your Bitbucket Server instance with the context path included, `https://<BITBUCKET INSTANCE HOSTNAME>/<CONTEXT PATH>`.
-    1. Set the **API URL** to the URL of your Bitbucket Server instance **without** the context path, `https://<BITBUCKET INSTANCE HOSTNAME>/`.
+    1. Set the **API URL** to the URL of your Bitbucket Server instance **without** the context path, `https://<BITBUCKET INSTANCE HOSTNAME>`.
 
-~> **Note:** If Bitbucket Server isn't accessible on the standard ports (for example, if it's using its default ports of 7990 or 8443 and is not behind a reverse proxy), make sure to specify the port in the URL. If you omit the port in the URL, Terraform Cloud uses the standard port for the protocol (80 for HTTP, 443 for HTTPS).
+    ~> **Important:** If Bitbucket Server isn't accessible on the standard ports (for example, if it's using its default ports of 7990 or 8443 and is not behind a reverse proxy), make sure to specify the port in the URL. If you omit the port in the URL, Terraform Cloud uses the standard port for the protocol (80 for HTTP, 443 for HTTPS).
 
     ![Terraform Cloud screenshot: text fields for adding a Bitbucket Server VCS provider](./images/bitbucket-server-tfe-add-url-fields.png)
 
@@ -147,4 +149,3 @@ This SSH key **must have an empty passphrase.** Terraform Cloud cannot use SSH k
 ## Finished
 
 At this point, Bitbucket Server access for Terraform Cloud is fully configured, and you can create Terraform workspaces based on your organization's shared repositories.
-

--- a/content/source/docs/cloud/vcs/bitbucket-server.html.md
+++ b/content/source/docs/cloud/vcs/bitbucket-server.html.md
@@ -59,14 +59,14 @@ Leave the page open in a browser tab, and remain logged in as an admin user.
 
 1. Enter the URL of your Bitbucket Server instance in the **HTTP URL** and **API URL** fields.
 
-    If your Bitbucket Server instance does not have a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set, the **API URL** should be the same as the **HTTP URL**.
+-> **Context Path**  If your Bitbucket Server instance does not have a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set, the **API URL** should be the same as the **HTTP URL**.
 
     If your Bitbucket Server instance has a [context path](https://confluence.atlassian.com/bitbucketserver/moving-bitbucket-server-to-a-different-context-path-776640153.html) set:
 
     1. Set the **HTTP URL** to the URL of your Bitbucket Server instance with the context path included, `https://<BITBUCKET INSTANCE HOSTNAME>/<CONTEXT PATH>`.
     1. Set the **API URL** to the URL of your Bitbucket Server instance **without** the context path, `https://<BITBUCKET INSTANCE HOSTNAME>/`.
 
-    ~> **Note:** If Bitbucket Server isn't accessible on the standard ports (for example, if it's using its default ports of 7990 or 8443 and is not behind a reverse proxy), make sure to specify the port in the URL. If you omit the port in the URL, Terraform Cloud uses the standard port for the protocol (80 for HTTP, 443 for HTTPS).
+~> **Note:** If Bitbucket Server isn't accessible on the standard ports (for example, if it's using its default ports of 7990 or 8443 and is not behind a reverse proxy), make sure to specify the port in the URL. If you omit the port in the URL, Terraform Cloud uses the standard port for the protocol (80 for HTTP, 443 for HTTPS).
 
     ![Terraform Cloud screenshot: text fields for adding a Bitbucket Server VCS provider](./images/bitbucket-server-tfe-add-url-fields.png)
 


### PR DESCRIPTION
Add note or box to point out special settings for context path. Customer did not see special configuration settings for context path. Is there a way that we can make this more visible by adding a blue box or bold print?

<!--

Hello! Thank you for submitting a docs PR to terraform.io! Feel free to delete
this message.

- For advice or edits from a tech writer or education engineer,
  please request review from the "hashicorp/terraform-education" GitHub team.

- When updating screenshots of a web UI, please try to capture
  the full width of the page, with the viewport size set to 1024px wide.

- If you're a HashiCorp employee with permission to merge to this repo,
  please get an approving review before merging your own PRs. (If you got
  review approval on the private fork, that's fine too; just announce it in a
  comment before merging!) When in doubt, ask in the #proj-terraform-docs channel.

- To learn more about how the website is built and deployed, how to preview your
  changes, which content lives where, and more, check out the README.md in the
  root of this repo.

-->

## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [ ] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

## Description

<!-- (Add whatever you'd like to say here.) -->
