### PR TITLE
Fix workspace variables update method typo

### DIFF
--- a/content/source/docs/cloud/api/workspace-variables.html.md
+++ b/content/source/docs/cloud/api/workspace-variables.html.md
@@ -185,7 +185,7 @@ Parameter       | Description
 
 ### Request Body
 
-This POST endpoint requires a JSON object with the following properties as a request payload.
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
 
 Properties without a default value are required.
 


### PR DESCRIPTION
## PR Objective

- [x] Fixing inaccurate docs

## Description

The workspace variables update API endpoint is a `PATCH` method, but the description has a typo referring to a `POST` endpoint. [Reported in this discussion thread](https://discuss.hashicorp.com/t/updating-variable-with-terraform-cloud-api-404s/12260).