### PR TITLE
Change alert banner to direct to 0.13 release post

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -54,7 +54,7 @@
   </head>
 
   <body id="<%= body_id_for(current_page) %>" class="<%= body_classes_for(current_page) %>">
-    <%= partial("layouts/alert_banner", locals: {show: true, theme: 'terraform', url:"https://www.hashicorp.com/blog/announcing-the-terraform-0-13-beta", tag:"New", text:"Announcing Terraform 0.13, which includes new usability improvements for modules, as well as provider source. Read more."}) %>
+    <%= partial("layouts/alert_banner", locals: {show: true, theme: 'terraform', url:"https://www.hashicorp.com/blog/announcing-hashicorp-terraform-0-13", tag:"New", text:"Announcing Terraform 0.13, which includes new usability improvements for modules, as well as provider source. Read more."}) %>
 
     <%= mega_nav :terraform %>
 


### PR DESCRIPTION
## PR Objective

- [ ] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [x] Changing behavior or layout of website

## Description

This is an update to the alert banner on the top of the website to reflect the 0.13 release. To be merged and deployed once the release actually happens.
