### PR TITLE
Downloads page update for Terraform 0.13

### DIFF
--- a/content/source/downloads.html.erb
+++ b/content/source/downloads.html.erb
@@ -41,7 +41,7 @@ show_notification: false
       </p>
 
       <div class="alert alert-info" role="alert">
-        <p><strong>Note:</strong> When you upgrade to Terraform 0.12, your existing Terraform configurations might need syntax updates. You can make most of these updates automatically with the <code>terraform 0.12upgrade</code> command; for more information, see <a href="/upgrade-guides/0-12.html">Upgrading to Terraform 0.12</a>.</p>
+        <p><strong>Note:</strong> When you upgrade to Terraform 0.13, your existing Terraform configurations might need syntax updates. You can make most of these updates automatically with the <code>terraform 0.13upgrade</code> command; for more information, see <a href="/upgrade-guides/0-13.html">Upgrading to Terraform 0.13</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- [x] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

Small change to the notice / info box to modify language for 0.13 and `terraform 0.13upgrade` command.