### PR TITLE
update link on home page

### DIFF
--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -157,7 +157,7 @@ show_notification: true
                         </div>
                         <p class="g-type-body">Terraform makes it easy to re-use configurations for similar infrastructure, helping you
                             avoid mistakes and save time.</p>
-                        <a href="https://www.terraform.io/docs/providers/" class="button">View All Providers</a>
+                        <a href="https://registry.terraform.io/browse/providers" class="button">View All Providers</a>
                     </div>
                 </div>
                 <div >


### PR DESCRIPTION
changed "View all providers" link from https://www.terraform.io/docs/providers/ to https://registry.terraform.io/browse/providers

<!--

Hello! Thank you for submitting a docs PR to terraform.io! Feel free to delete
this message.

- For advice or edits from a tech writer or education engineer,
  please request review from the "hashicorp/terraform-education" GitHub team.

- When updating screenshots of a web UI, please try to capture
  the full width of the page, with the viewport size set to 1024px wide.

- If you're a HashiCorp employee with permission to merge to this repo,
  please get an approving review before merging your own PRs. (If you got
  review approval on the private fork, that's fine too; just announce it in a
  comment before merging!) When in doubt, ask in the #proj-terraform-docs channel.

- To learn more about how the website is built and deployed, how to preview your
  changes, which content lives where, and more, check out the README.md in the
  root of this repo.

-->

## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [ ] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [x] Changing behavior or layout of website

## Description

<!-- (Add whatever you'd like to say here.) -->
