### PR TITLE
Adding further context to Policies and Policy Sets docs

### DIFF
--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -20,11 +20,11 @@ Sentinel Policies are rules which are enforced on Terraform runs to validate tha
 [users]: ../users-teams-organizations/users.html
 [workspaces]: ../workspaces/index.html
 
-**Policies** are written using the Sentinel [language](https://docs.hashicorp.com/sentinel/concepts/language). Policies are the guardrails that prevent Terraform runs from performing dangerous actions. Upon evaluation, policies will adhere to a predefined [enforcement level](#enforcement-levels). Policies are either managed individually or as part of a versioned policy set. 
+**Policies** are written using the Sentinel [language](https://docs.hashicorp.com/sentinel/concepts/language). Policies are the guardrails that prevent Terraform runs from performing dangerous actions. Upon evaluation, policies will adhere to a predefined [enforcement level](#enforcement-levels). 
 
-Individual policies allow the policy to be edited directly in the Terraform UI, whereas versioned policy sets are defined as individual policy files and are stored in a supported VCS provider or uploaded via the Terraform API.
+Policies are managed as parts of versioned policy sets, which allow individual policy files to be stored in a supported VCS provider or uploaded via the Terraform Cloud API.
 
--> **Note:** Individually managed policies is a deprecated feature in Terraform Cloud and recommend versioned policy sets as the primary method of enforcing policies. 
+-> **Note:** It's also possible to manage policies and policy sets individually. However, this is a deprecated feature in Terraform Cloud, and we recommend always using versioned policy sets to manage policies. 
 
 **Policy sets** are groups of policies that can be enforced on [workspaces][]. A policy set can be enforced on designated workspaces, or to all workspaces in the organization.
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -20,7 +20,11 @@ Sentinel Policies are rules which are enforced on Terraform runs to validate tha
 [users]: ../users-teams-organizations/users.html
 [workspaces]: ../workspaces/index.html
 
-**Policies** consist of a Sentinel policy file and an enforcement level.
+**Policies** are written using the Sentinel [language](https://docs.hashicorp.com/sentinel/concepts/language). Policies are the guardrails that prevent Terraform runs from performing dangerous actions. Upon evaluation, policies will adhere to a predefined [enforcement level](#enforcement-levels). Policies are either managed individually or as part of a versioned policy set. 
+
+Individual policies allow the policy to be edited directly in the Terraform UI, whereas versioned policy sets are defined as individual policy files and are stored in a supported VCS provider or uploaded via the Terraform API.
+
+-> **Note:** Individually managed policies is a deprecated feature in Terraform Cloud and recommend versioned policy sets as the primary method of enforcing policies. 
 
 **Policy sets** are groups of policies that can be enforced on [workspaces][]. A policy set can be enforced on designated workspaces, or to all workspaces in the organization.
 


### PR DESCRIPTION
<!--

Hello! Thank you for submitting a docs PR to terraform.io! Feel free to delete
this message.

- For advice or edits from a tech writer or education engineer,
  please request review from the "hashicorp/terraform-education" GitHub team.

- When updating screenshots of a web UI, please try to capture
  the full width of the page, with the viewport size set to 1024px wide.

- If you're a HashiCorp employee with permission to merge to this repo,
  please get an approving review before merging your own PRs. (If you got
  review approval on the private fork, that's fine too; just announce it in a
  comment before merging!) When in doubt, ask in the #proj-terraform-docs channel.

- To learn more about how the website is built and deployed, how to preview your
  changes, which content lives where, and more, check out the README.md in the
  root of this repo.

-->

## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [x] Making some docs easier to understand

## Description

This PR expands the contents of the Sentinel documentation, in particular, the [Policy and Policy Sets](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#policies-and-policy-sets) section. This change will provide the reader with an understanding of the differences between individually managed policies and versioned policy sets. 

I have also explicitly calls out that individually managed policies via the UI are a deprecated feature and recommends the use of versioned policy sets instead.
