### PR TITLE
Extend/Resource/Import: Fix Code Block Escape Format

### DIFF
--- a/content/source/docs/extend/resources/import.html.md
+++ b/content/source/docs/extend/resources/import.html.md
@@ -63,15 +63,13 @@ func TestAccExampleThing_basic(t *testing.T) {
 
 In the resource documentation (e.g. `website/docs/r/example_thing.html.markdown`), add an `Import` documentation section at the bottom of the page:
 
-``````markdown
-## Import
-
-Service Thing can be imported using the id, e.g.
-
-```
-$ terraform import example_thing.example abc123
-```
-``````
+    ## Import
+    
+    Service Thing can be imported using the id, e.g.
+    
+    ```
+    $ terraform import example_thing.example abc123
+    ```
 
 ## Additional Information
 


### PR DESCRIPTION
## Before

https://www.terraform.io/docs/extend/resources/import.html#resource-documentation-implementation

<img width="1920" alt="Screenshot 2020-08-15 at 11 24 44" src="https://user-images.githubusercontent.com/892721/90308662-f822d500-dee9-11ea-904e-b2c968d034c6.png">

## After

https://github.com/hashicorp/terraform-website/blob/f2fe498f4500de35b1459ac29e8b0a9fad52d8ca/content/source/docs/extend/resources/import.html.md#resource-documentation-implementation

<img width="1920" alt="Screenshot 2020-08-15 at 11 16 11" src="https://user-images.githubusercontent.com/892721/90308540-f278bf80-dee8-11ea-8c67-97b96cbc3281.png">

## PR Objective

- [ ] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [x] Changing behavior or layout of website