### PR TITLE
Add registry link to nav, consolidate sign up and sign in buttons

### DIFF
--- a/content/source/layouts/_sidebar.erb
+++ b/content/source/layouts/_sidebar.erb
@@ -8,6 +8,7 @@
   <ul class="nav sidebar-nav">
     <li><a data-track='intro' href="/intro/index.html">Intro</a></li>
     <li><a data-track='learn' href="https://learn.hashicorp.com/terraform/">Learn</a></li>
+    <li><a data-track='registry' href="https://registry.terraform.io">Registry</a></li>
     <li><a data-track='community' href="/community.html">Community</a></li>
     <li><a data-track='enterprise' href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
   </ul>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -78,7 +78,7 @@
 
             <%
               docs_items = <<-EOT
-                <li><a data-track='docs-home' href="/docs/index.html">Docs Home</a></li>
+                <li><a data-track='docs' href="/docs/index.html">Docs Home</a></li>
                 <li><a data-track='docs-cli' href="/docs/cli-index.html">Terraform CLI</a></li>
                 <li><a data-track='docs-cloud' href="/docs/cloud/index.html">Terraform Cloud</a></li>
                 <li><a data-track='docs-ent' href="/docs/enterprise/index.html">Terraform Enterprise</a></li>
@@ -98,6 +98,7 @@
                     <ul class="dropdown">
                       <li><a data-track='intro' href="/intro/index.html">Intro</a></li>
                       <li><a data-track='learn' href="https://learn.hashicorp.com/terraform/">Tutorials</a></li>
+                      <li><a data-track='registry' href="https://registry.terraform.io">Registry</a></li>
                       <li><a data-track='community' href="/community.html">Community</a></li>
                       <li><a data-track='enterprise' href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
                     </ul>
@@ -109,8 +110,10 @@
                       <%= docs_items %>
                     </ul>
                   </li>
+                  <li class="hidden-sm"><a data-track='registry' href="https://registry.terraform.io">Registry</a></li>
                   <li class="hidden-sm"><a data-track='community' href="/community.html">Community</a></li>
                   <li class="hidden-sm"><a data-track='enterprise' href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
+                  
                   <li>
                     <a data-track='download' href="/downloads.html">
                       <%= inline_svg "download.svg" %> Download
@@ -121,17 +124,11 @@
                       <%= inline_svg "github.svg" %> GitHub
                     </a>
                   </li>
-                   <li id="terraform-overview-sign-in-link">
-                   <div>
-                    <a data-track='sign-in' href="https://app.terraform.io/session?utm_source=docs_banner">
-                      Sign In
-                    </a>
-                    </div>
-                  </li>
                    <li id="terraform-overview-sign-up-link" class="hidden-md hidden-sm">
                    <div>
-                    <a data-track='sign-up' href="https://app.terraform.io/signup/account?utm_source=docs_banner">
-                      Create Account
+                    <a data-track='cloud' href="https://app.terraform.io/session?utm_source=docs_banner">
+                      Terraform Cloud
+                      <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="css-i6dzq1" style="fill: none !important;margin-left: 6px;margin-top: -1px;margin-right: 0;"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
                     </a>
                     </div>
                   </li>


### PR DESCRIPTION
## PR Objective

- [x] Changing behavior or layout of website

## Description

This PR aims to improve two things in the navigation:

1. Link to the registry at the top level - it wasn't linked to before anywhere in the nav and is an important part of the Terraform ecosystem.
2. Consolidate and correct the behavior of the "sign up" and "sign in" buttons. These buttons directly imply that you can sign in to the current website, terraform.io, but in reality take you to the terraform cloud website instead. Additionally, the two buttons were taking up a lot of real estate in the nav bar, and according to analytics, the sign up button was getting very little traffic relative to any of the other links. We can both free up valuable real estate required to add the "registry" link, and make the behavior more clear by consolidating both buttons to a single button that makes it clear that the user would be heading over to terraform cloud. If they are signed in, it would bring them to the dashboard, and if not, they would arrive at the "sign in" page, which also has a clear link to sign up if you don't have an account.

Here's how the new navigation bar looks:

![](https://p176.p0.n0.cdn.getcloudapp.com/items/Jru6xOk0/Screen%20Shot%202020-08-21%20at%204.28.56%20PM.png?v=a02e9473760fce43222c6bdf07b210ec)

I have retained this structure in the responsive and mobile versions of the nav, and retained the UTM parameter on the terraform cloud external link.