### PR TITLE
Update docs to incl. newly implemented module functions

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -99,8 +99,9 @@ tfconfig/v2
         ├── name (string)
         ├── source (string)
         ├── config (block expression representation)
-        ├── count (expression representation) (not implemented)
-        ├── for_each (expression representation) (not implemented)
+        ├── count (expression representation)
+        ├── depends_on (expression representation)
+        ├── for_each (expression representation)
         └── version_constraint (string)
 ```
 
@@ -427,11 +428,10 @@ delimiter are omitted for the root module.
   representation](#block-expression-representation) for all parameter values
   sent to the module.
 * `count` - An [expression representation](#expression-representations) for the
-  `count` field (not currently in use).
+  `count` field.
+* `depends_on`: An [expression representation](#expression-representations) for the
+  `depends_on` field.
 * `for_each` - An [expression representation](#expression-representations) for
-  the `for_each` field (not currently in use).
+  the `for_each` field.
 * `version_constraint` - The string value found in the `version` field of the
   module declaration.
-
--> **NOTE:** As `count` and `for_each` are currently not implemented in modules,
-the `count` and `for_each` fields will always be blank.


### PR DESCRIPTION
<!--

Hello! Thank you for submitting a docs PR to terraform.io! Feel free to delete
this message.

- For advice or edits from a tech writer or education engineer,
  please request review from the "hashicorp/terraform-education" GitHub team.

- When updating screenshots of a web UI, please try to capture
  the full width of the page, with the viewport size set to 1024px wide.

- If you're a HashiCorp employee with permission to merge to this repo,
  please get an approving review before merging your own PRs. (If you got
  review approval on the private fork, that's fine too; just announce it in a
  comment before merging!) When in doubt, ask in the #proj-terraform-docs channel.

- To learn more about how the website is built and deployed, how to preview your
  changes, which content lives where, and more, check out the README.md in the
  root of this repo.

-->

## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [x] Adding/updating docs for new feature

## Description

Updated the documentation for the `tfconfig/v2` import to include the `for_each` and `depends_on` meta-arguments which are now supported on Terraform modules as part of the 0.13.x release.
