### PR TITLE
Cover exposure of sensitive variables in Sentinel mocks

### DIFF
--- a/content/source/docs/cloud/workspaces/variables.html.md
+++ b/content/source/docs/cloud/workspaces/variables.html.md
@@ -70,13 +70,13 @@ Terraform often needs cloud provider credentials and other sensitive information
 
 To protect these secrets, you can mark any any Terraform or environment variable as sensitive data by clicking its "Sensitive" checkbox (visible when editing).
 
-Marking a variable as sensitive prevents anybody (including you) from viewing its value in Terraform Cloud's UI or API.
+Marking a variable as sensitive prevents anybody (including you) from viewing its value in the variables section of the workspace in Terraform Cloud's UI or with its Variables API endpoint.
 
 Users with permission to read and write variables can set new values for sensitive variables.  No other attribute of a sensitive variable can be modified. To update other attributes, delete the variable and create a new variable to replace it.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-~> **Important:** Terraform runs will receive the full text of sensitive variables, and might print the value in logs and state files if the configuration pipes the value through to an output or a resource parameter. Take care when writing your configurations to avoid unnecessary credential disclosure. Whenever possible, use environment variables since these cannot end up in state files. (Environment variables can end up in log files if TF_LOG is set to TRACE.)
+~> **Important:** Terraform runs will receive the full text of sensitive variables, and might print the value in logs and state files if the configuration pipes the value through to an output or a resource parameter. Additionally, Sentinel mocks downloaded from runs will contain the sensitive values of Terraform (but not environment) variables. Take care when writing your configurations to avoid unnecessary credential disclosure. Whenever possible, use environment variables since these cannot end up in state files or in Sentinel mocks. (Environment variables can end up in log files if TF_LOG is set to TRACE.)
 
 ### Looking Up Variable Names
 


### PR DESCRIPTION
I updated the text related to sensitive variables to cover Sentinel mocks.
I also changed the old language "Marking a variable as sensitive prevents anybody (including you) from viewing its value in Terraform Cloud's UI or API." to "Marking a variable as sensitive prevents anybody (including you) from viewing its value in the variables section of the workspace in Terraform Cloud's UI or with its Variables API endpoint." which is more accurate.  The first was NOT accurate because people with the right permission CAN view sensitive Terraform variables in state files in the UI if they are passed to attributes of resources. Additionally, someone with full TFC API access could extract the state file and again see values of sensitive Terraform variables in that case.

<!--

Hello! Thank you for submitting a docs PR to terraform.io! Feel free to delete
this message.

- For advice or edits from a tech writer or education engineer,
  please request review from the "hashicorp/terraform-education" GitHub team.

- When updating screenshots of a web UI, please try to capture
  the full width of the page, with the viewport size set to 1024px wide.

- If you're a HashiCorp employee with permission to merge to this repo,
  please get an approving review before merging your own PRs. (If you got
  review approval on the private fork, that's fine too; just announce it in a
  comment before merging!) When in doubt, ask in the #proj-terraform-docs channel.

- To learn more about how the website is built and deployed, how to preview your
  changes, which content lives where, and more, check out the README.md in the
  root of this repo.

-->

## PR Objective

<!-- (Delete any that don't apply, add anything you want to.) -->

- [ ] Fixing inaccurate docs
- [ ] Making some docs easier to understand
- [ ] Adding/updating docs for new feature
- [ ] Changing behavior or layout of website

## Description

<!-- (Add whatever you'd like to say here.) -->
