### PR TITLE
Remove errant single quotes

### DIFF
--- a/content/source/docs/enterprise/admin/automated-recovery.html.md
+++ b/content/source/docs/enterprise/admin/automated-recovery.html.md
@@ -196,7 +196,7 @@ set -e -u -o pipefail
 
 path=absolute_path_to_directory_of_snapshots
 
-access="--store local --path '$path'"
+access="--store local --path $path"
 
 # jq is used by this script, so install it. For other Linux distros, either preinstall jq
 # and remove these lines, or change to the mechanism your distro uses to install jq.


### PR DESCRIPTION
## PR Objective

- [x] Fixing inaccurate docs

## Description

Fairly straightforward! The version of the Automated Recovery sample script that we provide had incorrect single quote, which would lead to a failure to interpolate the variable. This PR removes said single quotes.