### PR TITLE
Fix typo in acceptance testing docs

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -134,6 +134,7 @@ func TestAccExampleWidget_basic(t *testing.T) {
 func testAccPreCheck(t *testing.T) {
   if v := os.Getenv("EXAMPLE_KEY"); v == "" {
     t.Fatal("EXAMPLE_KEY must be set for acceptance tests")
+  }
   if v := os.Getenv("EXAMPLE_SECRET"); v == "" {
     t.Fatal("EXAMPLE_SECRET must be set for acceptance tests")
   }


### PR DESCRIPTION
Add missing curly brace to example code in the `TestCase` section of the acceptance testing documentation

## Labels

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
