### PR TITLE
Update Providers section of testcase docs

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -144,10 +144,10 @@ func testAccPreCheck(t *testing.T) {
 ### Providers 
 
 **Type:**
-`map[string]`[terraform.ResourceProvider](https://github.com/hashicorp/terraform-plugin-sdk/blob/9f0df37a8fdb2627ae32db6ceaf7f036d89b6768/terraform/resource_provider.go#L12-L172)  
+`map[string]`[\*schema.Provider](https://github.com/hashicorp/terraform-plugin-sdk/blob/a8e5eaf628dcbd66869b9512e81c3495cfac5722/helper/schema/provider.go#L40-L96)  
 **Required:** Yes  
 
-**Providers** is a map of `terraform.ResourceProvider` values with `string`
+**Providers** is a map of `*schema.Provider` values with `string`
 keys, representing the Providers that will be under test. Only the Providers
 included in this map will be loaded during the test, so any Provider included in
 a configuration file for testing must be represented in this map or the test
@@ -173,12 +173,12 @@ func TestAccExampleWidget_basic(t *testing.T) {
 // File: example/provider_test.go
 package example
 
-var testAccProviders map[string]terraform.ResourceProvider
+var testAccProviders map[string]*schema.Provider
 var testAccProvider *schema.Provider
 
 func init() {
   testAccProvider = Provider().(*schema.Provider)
-  testAccProviders = map[string]terraform.ResourceProvider{
+  testAccProviders = map[string]*schema.Provider{
     "example": testAccProvider,
   }
 }


### PR DESCRIPTION
The `terraform.ResourceProvider` no longer exists in v2 of the terraform-plugin-sdk and can therefore not be used anymore for the providers field.

Use `*schema.Provider` instead (as used by the [AWS plugin](https://github.com/terraform-providers/terraform-provider-aws/blob/4ac98ce9911f302cb7181db28d4a8772b5e67112/aws/provider_test.go#L34) for example).

## Labels

- [x] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
