### PR TITLE
Fix link to module_calls collection

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -115,7 +115,7 @@ The collections are:
   definitions across all modules in the configuration.
 * [`outputs`](#the-outputs-collection) - The configuration of all output
   definitions across all modules in the configuration.
-* [`module_calls`](#the-variables-collection) - The configuration of all module
+* [`module_calls`](#the-module_calls-collection) - The configuration of all module
   calls (individual [`module`](/docs/configuration/modules.html) blocks) across
   all modules in the configuration.
 


### PR DESCRIPTION
Link was pointing to variables collection, now will point to correct module calls collection

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
