### PR TITLE
Sentinel: Add details on updated provider_name field for TF 0.13

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -334,9 +334,9 @@ An element contains the following fields:
   where a provider offers a resource type whose name does not start with its own
   name, such as the `googlebeta` provider offering `google_compute_instance`.
 
--> Starting with Terraform 0.13, the `provider_name` field will contain the
-_full_ source address to the provider in the Terraform Registry. Example:
-`registry.terraform.io/hashicorp/null` for the null provider.
+    -> **Note:** Starting with Terraform 0.13, the `provider_name` field contains the
+    _full_ source address to the provider in the Terraform Registry. Example:
+    `registry.terraform.io/hashicorp/null` for the null provider.
 
 * `deposed` - An identifier used during replacement operations, and can be used
   to identify the exact resource being replaced in state.

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -333,6 +333,11 @@ An element contains the following fields:
   allows the provider to be interpreted unambiguously in the unusual situation
   where a provider offers a resource type whose name does not start with its own
   name, such as the `googlebeta` provider offering `google_compute_instance`.
+
+-> Starting with Terraform 0.13, the `provider_name` field will contain the
+_full_ source address to the provider in the Terraform Registry. Example:
+`registry.terraform.io/hashicorp/null` for the null provider.
+
 * `deposed` - An identifier used during replacement operations, and can be used
   to identify the exact resource being replaced in state.
 * `change` - The data describing the change that will be made to this resource.

--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -143,9 +143,9 @@ An element in the collection has the following values:
   where a provider offers a resource type whose name does not start with its own
   name, such as the `googlebeta` provider offering `google_compute_instance`.
 
--> Starting with Terraform 0.13, the `provider_name` field will contain the
-_full_ source address to the provider in the Terraform Registry. Example:
-`registry.terraform.io/hashicorp/null` for the null provider.
+    -> **Note:** Starting with Terraform 0.13, the `provider_name` field contains the
+    _full_ source address to the provider in the Terraform Registry. Example:
+    `registry.terraform.io/hashicorp/null` for the null provider.
 
 * `values` - An object (map) representation of the attribute values of the
   resource, whose structure depends on the resource type schema. When accessing

--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -142,6 +142,11 @@ An element in the collection has the following values:
   allows the provider to be interpreted unambiguously in the unusual situation
   where a provider offers a resource type whose name does not start with its own
   name, such as the `googlebeta` provider offering `google_compute_instance`.
+
+-> Starting with Terraform 0.13, the `provider_name` field will contain the
+_full_ source address to the provider in the Terraform Registry. Example:
+`registry.terraform.io/hashicorp/null` for the null provider.
+
 * `values` - An object (map) representation of the attribute values of the
   resource, whose structure depends on the resource type schema. When accessing
   proposed state through the [`planned_values`](./tfplan-v2.html#the-planned_values-collection)


### PR DESCRIPTION
Starting with Terraform 0.13, the provider_name field in the resource
collections in the tfplan/v2 and tfstate/v2 imports will contain the
fully qualified path to the resource in the Terraform Registry. Example:
registry.terraform.io/hashicorp/null for the null provider.

This change adds a note for this in the tfplan/v2 and tfstate/v2
documentation pages.
