### PR TITLE
Clarify overriding Sentinel policy

### DIFF
--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -17,7 +17,7 @@ Enforcement level details can be found in the [Managing Policies](./manage-polic
 
 All `hard mandatory` and `soft mandatory` policies must pass in order for the run to continue to the the "Confirm & Apply" state.
 
-If a `soft mandatory` policy fails, users with permission to manage policies will be presented with an "Override & Continue" button in the run. They have the ability to override the failed check and continue the execution of the run. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+If a `soft mandatory` policy fails, users with permission to manage policies will be presented with an "Override & Continue" button in the run. They have the ability to override the failed check and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 


### PR DESCRIPTION
A large customer was uncertain whether overriding a Sentinel policy only affected the current run or all future runs. I actually found the current language clear enough since it said "and continue the execution of the run". But I added sentence "This will not have any impact on future runs." to satisfy them.

## Labels
- [ ] inaccuracy
- [x ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
