### PR TITLE
Update all Learn crosslinks within terraform-website

### DIFF
--- a/content/source/docs/cloud/cost-estimation/index.html.md
+++ b/content/source/docs/cloud/cost-estimation/index.html.md
@@ -7,7 +7,7 @@ page_title: "Overview - Cost Estimation - Terraform Cloud and Terraform Enterpri
 
 -> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> **Hands-on:** Try the [Verify Costs in Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Control Costs with Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides cost estimates for many resources found in your Terraform configuration. For each resource an hourly and monthly cost is shown, along with the monthly delta. The total cost and delta of all estimable resources is also shown.
 

--- a/content/source/docs/cloud/cost-estimation/index.html.md
+++ b/content/source/docs/cloud/cost-estimation/index.html.md
@@ -7,7 +7,7 @@ page_title: "Overview - Cost Estimation - Terraform Cloud and Terraform Enterpri
 
 -> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on walkthrough, try the [Verify Costs in Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Verify Costs in Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides cost estimates for many resources found in your Terraform configuration. For each resource an hourly and monthly cost is shown, along with the monthly delta. The total cost and delta of all estimable resources is also shown.
 

--- a/content/source/docs/cloud/cost-estimation/index.html.md
+++ b/content/source/docs/cloud/cost-estimation/index.html.md
@@ -7,7 +7,7 @@ page_title: "Overview - Cost Estimation - Terraform Cloud and Terraform Enterpri
 
 -> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on tutorial, try the [Verify Costs in Policies](https://learn.hashicorp.com/terraform/cloud-getting-started/cost-estimation?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Verify Costs in Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides cost estimates for many resources found in your Terraform configuration. For each resource an hourly and monthly cost is shown, along with the monthly delta. The total cost and delta of all estimable resources is also shown.
 

--- a/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
@@ -19,9 +19,9 @@ Allow one individual (or a small group) in your engineering team to get familiar
 
 Write your first [Terraform Configuration file](https://learn.hashicorp.com/tutorials/terraform/aws-build?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
 
-## 3. Read the Getting Started Guide
+## 3. Follow the Getting Started Tutorials
 
-Follow the rest of the [Terraform getting started guide](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS). These pages will walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
+Follow the rest of the [Terraform: Get Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp Learn. These tutorials will walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
 
 ## 4. Implement a Real Infrastructure Project
 

--- a/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
@@ -13,15 +13,15 @@ Allow one individual (or a small group) in your engineering team to get familiar
 
 ## 1. Install Terraform
 
-[Follow the instructions here to install Terraform OSS](https://learn.hashicorp.com/terraform/getting-started/install).
+[Follow the instructions here to install Terraform OSS](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
 
 ## 2. Write Some Code
 
-Write your first [Terraform Configuration file](https://learn.hashicorp.com/terraform/getting-started/build).
+Write your first [Terraform Configuration file](https://learn.hashicorp.com/tutorials/terraform/aws-build?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
 
 ## 3. Read the Getting Started Guide
 
-Follow the rest of the [Terraform getting started guide](https://learn.hashicorp.com/terraform/getting-started/change). These pages will walk you through [changing](https://learn.hashicorp.com/terraform/getting-started/change) and [destroying](https://learn.hashicorp.com/terraform/getting-started/destroy) resources, working with [resource dependencies](https://learn.hashicorp.com/terraform/getting-started/dependencies), and more.
+Follow the rest of the [Terraform getting started guide](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS). These pages will walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
 
 ## 4. Implement a Real Infrastructure Project
 

--- a/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
@@ -13,7 +13,7 @@ Allow one individual (or a small group) in your engineering team to get familiar
 
 ## 1. Install Terraform
 
-[Follow the instructions here to install Terraform OSS](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
+[Follow the instructions here to install Terraform OSS](https://learn.hashicorp.com/tutorials/terraform/install-cli?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
 
 ## 2. Write Some Code
 

--- a/content/source/docs/cloud/index.html.md
+++ b/content/source/docs/cloud/index.html.md
@@ -33,5 +33,5 @@ The [Terraform Enterprise deployment and operation documentation](/docs/enterpri
 
 ## Where Should I Go First?
 
-- If you want to learn by doing, begin with [the Terraform Cloud Getting Started Guide](https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview) on learn.hashicorp.com.
+- If you want to learn by doing, begin with [the Terraform Cloud Getting Started Guide](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on learn.hashicorp.com.
 - If you want a high-level overview of nearly everything Terraform Cloud does, begin with [the overview of features](./overview.html).

--- a/content/source/docs/cloud/index.html.md
+++ b/content/source/docs/cloud/index.html.md
@@ -33,5 +33,5 @@ The [Terraform Enterprise deployment and operation documentation](/docs/enterpri
 
 ## Where Should I Go First?
 
-- If you want to learn by doing, begin with [the Terraform Cloud Getting Started Guide](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on learn.hashicorp.com.
+- If you want to learn by doing, begin with [the Terraform Cloud Getting Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on learn.hashicorp.com.
 - If you want a high-level overview of nearly everything Terraform Cloud does, begin with [the overview of features](./overview.html).

--- a/content/source/docs/cloud/index.html.md
+++ b/content/source/docs/cloud/index.html.md
@@ -33,5 +33,5 @@ The [Terraform Enterprise deployment and operation documentation](/docs/enterpri
 
 ## Where Should I Go First?
 
-- If you want to learn by doing, begin with [the Terraform Cloud Getting Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on learn.hashicorp.com.
+- If you want to learn by doing, begin with [the Terraform Cloud Getting Started collection](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on learn.hashicorp.com.
 - If you want a high-level overview of nearly everything Terraform Cloud does, begin with [the overview of features](./overview.html).

--- a/content/source/docs/cloud/migrate/index.html.md
+++ b/content/source/docs/cloud/migrate/index.html.md
@@ -15,11 +15,9 @@ page_title: "Migrating State from Local Terraform - Terraform Cloud and Terrafor
 
 # Migrating State from Local Terraform
 
-> For a hands-on tutorial, try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/terraform/state/tfc_migration?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate?in=terraform/state&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 If you already use Terraform to manage infrastructure, you're probably managing some resources that you want to transfer to Terraform Cloud. By migrating your Terraform [state][] to Terraform Cloud, you can continue managing that infrastructure without de-provisioning anything.
-
-These reference docs describe the process for migrating state. To practice using a hands-on, step-by-step example follow the [HashiCorp Learn guide](https://learn.hashicorp.com/terraform/tfc/tfc_migration?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
 
 ~> **Important:** These instructions are for migrating state in a basic working directory that only uses the `default` workspace. If you use multiple [workspaces][cli-workspaces] in one working directory, the instructions are different; see [Migrating State from Multiple Terraform Workspaces](./workspaces.html) instead.
 

--- a/content/source/docs/cloud/migrate/index.html.md
+++ b/content/source/docs/cloud/migrate/index.html.md
@@ -15,7 +15,7 @@ page_title: "Migrating State from Local Terraform - Terraform Cloud and Terrafor
 
 # Migrating State from Local Terraform
 
-> For a hands-on walkthrough, try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate?in=terraform/state&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate?in=terraform/state&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 If you already use Terraform to manage infrastructure, you're probably managing some resources that you want to transfer to Terraform Cloud. By migrating your Terraform [state][] to Terraform Cloud, you can continue managing that infrastructure without de-provisioning anything.
 

--- a/content/source/docs/cloud/overview.html.md
+++ b/content/source/docs/cloud/overview.html.md
@@ -14,7 +14,7 @@ page_title: "Overview of Features - Terraform Cloud and Terraform Enterprise"
 [terraform enterprise]: /docs/enterprise/index.html
 
 
-> For a hands-on tutorial, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/terraform/cloud-getting-started/signup?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud is a platform that performs Terraform runs to provision infrastructure, either on demand or in response to various events. Unlike a general-purpose continuous integration (CI) system, it is deeply integrated with Terraform's workflows and data, which allows it to make Terraform significantly more convenient and powerful.
 

--- a/content/source/docs/cloud/overview.html.md
+++ b/content/source/docs/cloud/overview.html.md
@@ -14,7 +14,7 @@ page_title: "Overview of Features - Terraform Cloud and Terraform Enterprise"
 [terraform enterprise]: /docs/enterprise/index.html
 
 
-> For a hands-on walkthrough, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud is a platform that performs Terraform runs to provision infrastructure, either on demand or in response to various events. Unlike a general-purpose continuous integration (CI) system, it is deeply integrated with Terraform's workflows and data, which allows it to make Terraform significantly more convenient and powerful.
 

--- a/content/source/docs/cloud/overview.html.md
+++ b/content/source/docs/cloud/overview.html.md
@@ -14,7 +14,7 @@ page_title: "Overview of Features - Terraform Cloud and Terraform Enterprise"
 [terraform enterprise]: /docs/enterprise/index.html
 
 
-> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Terraform Cloud is a platform that performs Terraform runs to provision infrastructure, either on demand or in response to various events. Unlike a general-purpose continuous integration (CI) system, it is deeply integrated with Terraform's workflows and data, which allows it to make Terraform significantly more convenient and powerful.
 

--- a/content/source/docs/cloud/registry/index.html.md
+++ b/content/source/docs/cloud/registry/index.html.md
@@ -5,7 +5,7 @@ page_title: "Private Module Registry - Terraform Cloud and Terraform Enterprise"
 
 # Private Module Registry
 
-> For a hands-on walkthrough, try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud's private module registry helps you share [Terraform modules](/docs/modules/index.html) across your organization. It includes support for module versioning, a searchable and filterable list of available modules, and a configuration designer to help you build new workspaces faster.
 

--- a/content/source/docs/cloud/registry/index.html.md
+++ b/content/source/docs/cloud/registry/index.html.md
@@ -5,7 +5,7 @@ page_title: "Private Module Registry - Terraform Cloud and Terraform Enterprise"
 
 # Private Module Registry
 
-> For a hands-on tutorial, try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/terraform/modules/private-modules?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud's private module registry helps you share [Terraform modules](/docs/modules/index.html) across your organization. It includes support for module versioning, a searchable and filterable list of available modules, and a configuration designer to help you build new workspaces faster.
 

--- a/content/source/docs/cloud/registry/publish.html.md
+++ b/content/source/docs/cloud/registry/publish.html.md
@@ -7,7 +7,7 @@ page_title: "Publishing Private Modules - Private Module Registry - Terraform Cl
 
 # Publishing Modules to the Terraform Cloud Private Module Registry
 
-> For a hands-on tutorial, try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/terraform/modules/private-modules?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud's private module registry lets you publish Terraform modules to be consumed by users across your organization. It works much like the public [Terraform Registry](/docs/registry/index.html), except that it uses your configured [VCS integrations][vcs] instead of requiring public GitHub repositories.
 

--- a/content/source/docs/cloud/registry/publish.html.md
+++ b/content/source/docs/cloud/registry/publish.html.md
@@ -7,7 +7,7 @@ page_title: "Publishing Private Modules - Private Module Registry - Terraform Cl
 
 # Publishing Modules to the Terraform Cloud Private Module Registry
 
-> For a hands-on walkthrough, try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud's private module registry lets you publish Terraform modules to be consumed by users across your organization. It works much like the public [Terraform Registry](/docs/registry/index.html), except that it uses your configured [VCS integrations][vcs] instead of requiring public GitHub repositories.
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -5,7 +5,7 @@ page_title: "Using Private Modules - Private Module Registry - Terraform Cloud a
 
 # Using Modules from the Terraform Cloud Private Module Registry
 
-> **Hands-on:** Try the [Use Terraform Modules](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Use Modules from the Registry](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 By design, Terraform Cloud's private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already familiar with the public registry, here are the main differences:
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -5,7 +5,7 @@ page_title: "Using Private Modules - Private Module Registry - Terraform Cloud a
 
 # Using Modules from the Terraform Cloud Private Module Registry
 
-> For a hands-on walkthrough, try the [Use Terraform Modules](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Use Terraform Modules](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 By design, Terraform Cloud's private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already familiar with the public registry, here are the main differences:
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -5,7 +5,7 @@ page_title: "Using Private Modules - Private Module Registry - Terraform Cloud a
 
 # Using Modules from the Terraform Cloud Private Module Registry
 
-> For a hands-on tutorial, try the [Use Terraform Modules](https://learn.hashicorp.com/terraform/modules/using-modules?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Use Terraform Modules](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 By design, Terraform Cloud's private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already familiar with the public registry, here are the main differences:
 

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -11,7 +11,7 @@ page_title: "CLI-driven Runs - Runs - Terraform Cloud and Terraform Enterprise"
 
 # The CLI-driven Run Workflow
 
-> For a hands-on walkthrough, try the [Authenticate the CLI with Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-login?in=terraform/0-13&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Authenticate the CLI with Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-login?in=terraform/0-13&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud has three workflows for managing Terraform runs.
 

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -11,7 +11,7 @@ page_title: "CLI-driven Runs - Runs - Terraform Cloud and Terraform Enterprise"
 
 # The CLI-driven Run Workflow
 
-> For a hands-on tutorial, try the [Authenticate the CLI with Terraform Cloud](https://learn.hashicorp.com/terraform/tfc/tfc_login?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Authenticate the CLI with Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-login?in=terraform/0-13&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud has three workflows for managing Terraform runs.
 

--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -5,7 +5,7 @@ page_title: "Terraform Runs and Remote Operations - Terraform Cloud and Terrafor
 
 # Terraform Runs and Remote Operations
 
-> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Terraform Cloud provides a central interface for running Terraform within a large collaborative organization. If you're accustomed to running Terraform from your workstation, the way Terraform Cloud manages runs can be unfamiliar.
 

--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -5,7 +5,7 @@ page_title: "Terraform Runs and Remote Operations - Terraform Cloud and Terrafor
 
 # Terraform Runs and Remote Operations
 
-> For a hands-on tutorial, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/terraform/cloud-getting-started/signup?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides a central interface for running Terraform within a large collaborative organization. If you're accustomed to running Terraform from your workstation, the way Terraform Cloud manages runs can be unfamiliar.
 

--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -5,7 +5,7 @@ page_title: "Terraform Runs and Remote Operations - Terraform Cloud and Terrafor
 
 # Terraform Runs and Remote Operations
 
-> For a hands-on walkthrough, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides a central interface for running Terraform within a large collaborative organization. If you're accustomed to running Terraform from your workstation, the way Terraform Cloud manages runs can be unfamiliar.
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -7,7 +7,7 @@ page_title: "Enforce and Override Policies - Sentinel - Terraform Cloud and Terr
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on tutorial, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/terraform/sentinel/sentinel-intro?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) track on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Once a policy is added to an organization it is enforced on all runs.
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -7,7 +7,7 @@ page_title: "Enforce and Override Policies - Sentinel - Terraform Cloud and Terr
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Once a policy is added to an organization it is enforced on all runs.
 

--- a/content/source/docs/cloud/sentinel/examples.html.md
+++ b/content/source/docs/cloud/sentinel/examples.html.md
@@ -7,7 +7,7 @@ page_title: "Example Policies - Policies - Terraform Cloud and Terraform Enterpr
 
 -> **Note:** Terraform policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on tutorial, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/terraform/sentinel/sentinel-intro?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) track on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 This page lists some example policies. These examples are not exhaustive, but they demonstrate some of the most common use cases of policies with Terraform Cloud. For more examples, see the [Governance section of the Terraform Guides repository](https://github.com/hashicorp/terraform-guides/tree/master/governance).
 

--- a/content/source/docs/cloud/sentinel/examples.html.md
+++ b/content/source/docs/cloud/sentinel/examples.html.md
@@ -7,7 +7,7 @@ page_title: "Example Policies - Policies - Terraform Cloud and Terraform Enterpr
 
 -> **Note:** Terraform policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 This page lists some example policies. These examples are not exhaustive, but they demonstrate some of the most common use cases of policies with Terraform Cloud. For more examples, see the [Governance section of the Terraform Guides repository](https://github.com/hashicorp/terraform-guides/tree/master/governance).
 

--- a/content/source/docs/cloud/sentinel/index.html.md
+++ b/content/source/docs/cloud/sentinel/index.html.md
@@ -7,7 +7,7 @@ page_title: "Sentinel - Terraform Cloud and Terraform Enterprise"
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 [Sentinel](https://www.hashicorp.com/sentinel) is an embedded policy-as-code
 framework integrated with the HashiCorp Enterprise products. It enables

--- a/content/source/docs/cloud/sentinel/index.html.md
+++ b/content/source/docs/cloud/sentinel/index.html.md
@@ -7,7 +7,7 @@ page_title: "Sentinel - Terraform Cloud and Terraform Enterprise"
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on tutorial, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/terraform/sentinel/sentinel-intro?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) track on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 [Sentinel](https://www.hashicorp.com/sentinel) is an embedded policy-as-code
 framework integrated with the HashiCorp Enterprise products. It enables

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -7,7 +7,7 @@ page_title: "Managing Sentinel Policies - Sentinel - Terraform Cloud and Terrafo
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Sentinel Policies are rules which are enforced on Terraform runs to validate that the plan and corresponding resources are in compliance with company policies.
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -7,7 +7,7 @@ page_title: "Managing Sentinel Policies - Sentinel - Terraform Cloud and Terrafo
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on tutorial, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/terraform/sentinel/sentinel-intro?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) track on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Sentinel Policies are rules which are enforced on Terraform runs to validate that the plan and corresponding resources are in compliance with company policies.
 
@@ -20,11 +20,11 @@ Sentinel Policies are rules which are enforced on Terraform runs to validate tha
 [users]: ../users-teams-organizations/users.html
 [workspaces]: ../workspaces/index.html
 
-**Policies** are written using the Sentinel [language](https://docs.hashicorp.com/sentinel/concepts/language). Policies are the guardrails that prevent Terraform runs from performing dangerous actions. Upon evaluation, policies will adhere to a predefined [enforcement level](#enforcement-levels). 
+**Policies** are written using the Sentinel [language](https://docs.hashicorp.com/sentinel/concepts/language). Policies are the guardrails that prevent Terraform runs from performing dangerous actions. Upon evaluation, policies will adhere to a predefined [enforcement level](#enforcement-levels).
 
 Policies are managed as parts of versioned policy sets, which allow individual policy files to be stored in a supported VCS provider or uploaded via the Terraform Cloud API.
 
--> **Note:** It's also possible to manage policies and policy sets individually. However, this is a deprecated feature in Terraform Cloud, and we recommend always using versioned policy sets to manage policies. 
+-> **Note:** It's also possible to manage policies and policy sets individually. However, this is a deprecated feature in Terraform Cloud, and we recommend always using versioned policy sets to manage policies.
 
 **Policy sets** are groups of policies that can be enforced on [workspaces][]. A policy set can be enforced on designated workspaces, or to all workspaces in the organization.
 

--- a/content/source/docs/cloud/users-teams-organizations/permissions.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/permissions.html.md
@@ -9,7 +9,7 @@ page_title: "Permissions - Terraform Cloud and Terraform Enterprise"
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-> For a hands-on walkthrough, try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud's access model is team-based. In order to perform an action within a Terraform Cloud organization, users must belong to a team that has been granted the appropriate permissions.
 

--- a/content/source/docs/cloud/users-teams-organizations/permissions.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/permissions.html.md
@@ -9,7 +9,7 @@ page_title: "Permissions - Terraform Cloud and Terraform Enterprise"
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-> For a hands-on tutorial, try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/terraform/tfc/tfc_permissions?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud's access model is team-based. In order to perform an action within a Terraform Cloud organization, users must belong to a team that has been granted the appropriate permissions.
 

--- a/content/source/docs/cloud/users-teams-organizations/teams.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/teams.html.md
@@ -11,7 +11,7 @@ page_title: "Teams - Terraform Cloud and Terraform Enterprise"
 
 -> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. Free organizations only include an owners team, which can include up to five members. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on walkthrough, try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Teams are groups of Terraform Cloud [users][] within an [organization][organizations]. To delegate provisioning work, the organization can grant workspace permissions to specific teams.
 

--- a/content/source/docs/cloud/users-teams-organizations/teams.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/teams.html.md
@@ -11,7 +11,7 @@ page_title: "Teams - Terraform Cloud and Terraform Enterprise"
 
 -> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. Free organizations only include an owners team, which can include up to five members. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
 
-> For a hands-on tutorial, try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/terraform/tfc/tfc_permissions?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Teams are groups of Terraform Cloud [users][] within an [organization][organizations]. To delegate provisioning work, the organization can grant workspace permissions to specific teams.
 

--- a/content/source/docs/cloud/workspaces/creating.html.md
+++ b/content/source/docs/cloud/workspaces/creating.html.md
@@ -5,7 +5,7 @@ page_title: "Creating Workspaces - Workspaces - Terraform Cloud and Terraform En
 
 # Creating Workspaces
 
-> For a hands-on walkthrough, try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Workspaces organize infrastructure into meaningful groups. Create new workspaces whenever you need to manage a new collection of infrastructure resources.
 

--- a/content/source/docs/cloud/workspaces/creating.html.md
+++ b/content/source/docs/cloud/workspaces/creating.html.md
@@ -5,7 +5,7 @@ page_title: "Creating Workspaces - Workspaces - Terraform Cloud and Terraform En
 
 # Creating Workspaces
 
-> For a hands-on introduction, try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/terraform/cloud-getting-started/signup) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Workspaces organize infrastructure into meaningful groups. Create new workspaces whenever you need to manage a new collection of infrastructure resources.
 

--- a/content/source/docs/cloud/workspaces/index.html.md
+++ b/content/source/docs/cloud/workspaces/index.html.md
@@ -5,7 +5,7 @@ page_title: "Workspaces - Terraform Cloud and Terraform Enterprise"
 
 # Workspaces
 
-> For a hands-on tutorial, try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/terraform/cloud-getting-started/signup?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) track on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Workspaces are how Terraform Cloud organizes infrastructure.
 

--- a/content/source/docs/cloud/workspaces/index.html.md
+++ b/content/source/docs/cloud/workspaces/index.html.md
@@ -5,7 +5,7 @@ page_title: "Workspaces - Terraform Cloud and Terraform Enterprise"
 
 # Workspaces
 
-> For a hands-on walkthrough, try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
 Workspaces are how Terraform Cloud organizes infrastructure.
 

--- a/content/source/docs/cloud/workspaces/run-triggers.html.md
+++ b/content/source/docs/cloud/workspaces/run-triggers.html.md
@@ -5,7 +5,7 @@ page_title: "Run Triggers - Workspaces - Terraform Cloud and Terraform Enterpris
 
 # Run Triggers
 
-> For a hands-on tutorial, try the [Connect Workspaces with Run Triggers](https://learn.hashicorp.com/terraform/tfc/tfc_run_triggers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide on HashiCorp Learn.
+> For a hands-on walkthrough, try the [Connect Workspaces with Run Triggers](https://learn.hashicorp.com/tutorials/terraform/cloud-run-triggers?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, known as "source workspaces". These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces. You can connect your workspace to up to 20 source workspaces.
 

--- a/content/source/docs/cloud/workspaces/run-triggers.html.md
+++ b/content/source/docs/cloud/workspaces/run-triggers.html.md
@@ -5,7 +5,7 @@ page_title: "Run Triggers - Workspaces - Terraform Cloud and Terraform Enterpris
 
 # Run Triggers
 
-> For a hands-on walkthrough, try the [Connect Workspaces with Run Triggers](https://learn.hashicorp.com/tutorials/terraform/cloud-run-triggers?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Connect Workspaces with Run Triggers](https://learn.hashicorp.com/tutorials/terraform/cloud-run-triggers?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
 Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, known as "source workspaces". These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces. You can connect your workspace to up to 20 source workspaces.
 

--- a/content/source/docs/enterprise/install/config.html.md
+++ b/content/source/docs/enterprise/install/config.html.md
@@ -55,5 +55,5 @@ You have successfully configured the installation and configuration steps that
 are specific to Terraform Enterprise! You can now configure SMTP
 (`https://<TFE HOSTNAME>/app/admin/smtp/`), Twilio (`https://<TFE HOSTNAME>/app/admin/twillio`),
 SAML (`https://<TFE HOSTNAME>/app/admin/saml`), or follow the
-[Get Started - Terraform Cloud](https://learn.hashicorp.com/terraform/cloud-getting-started/signup)
-track on HashiCorp Learn to start using the software.
+[Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+collection on HashiCorp Learn to start using the software.

--- a/content/source/docs/extend/community/contributing.html.md
+++ b/content/source/docs/extend/community/contributing.html.md
@@ -29,7 +29,7 @@ guidance specific to Go.
 - Infrastructure as Code. If this is a new term for you, check out
 [Infrastructure as Code](https://en.wikipedia.org/wiki/Infrastructure_as_Code)
 on Wikipedia for a brief introduction. Our [Getting Started
-guide](https://learn.hashicorp.com/terraform/getting-started/install) is a great way to get started as
+collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) is a great way to get started as
 well.
 
 ## HashiCorp vs. Community Providers

--- a/content/source/docs/extend/index.html.md
+++ b/content/source/docs/extend/index.html.md
@@ -39,7 +39,7 @@ components of Terraform (Core vs. Plugins) and the basics of how they interact.
 
 Learn about Terraform plugins that you can develop using the Terraform Plugin SDK (currently only Providers).
 
-## [Call APIs with Terraform Providers Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+## [Call APIs with Terraform Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
 
 A collection of step by step tutorials for writing, compiling, and executing an
 example Terraform Provider.

--- a/content/source/docs/extend/index.html.md
+++ b/content/source/docs/extend/index.html.md
@@ -28,7 +28,7 @@ Terraform.
 
 Below is a brief description of each section. The content is organized from
 simplest to most complex — developers new to writing code for Terraform should
-start at the top. 
+start at the top.
 
 ## [How Terraform Works](/docs/extend/how-terraform-works.html)
 
@@ -39,10 +39,10 @@ components of Terraform (Core vs. Plugins) and the basics of how they interact.
 
 Learn about Terraform plugins that you can develop using the Terraform Plugin SDK (currently only Providers).
 
-## [Writing Custom Providers](https://learn.hashicorp.com/terraform/providers/setup-implement-read)
+## [Call APIs with Terraform Providers Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
 
-A step by step guide for writing, compiling, and executing an example Terraform
-Provider. 
+A collection of step by step tutorials for writing, compiling, and executing an
+example Terraform Provider.
 
 ## [HashiCorp Provider Design Principles](/docs/extend/hashicorp-provider-design-principles.html)
 
@@ -81,4 +81,4 @@ they apply to Terraform plugin development.
 ## [Community](/docs/extend/community/index.html)
 
 Terraform is a mature project with a growing community. There are active,
-dedicated people willing to help you through various mediums. 
+dedicated people willing to help you through various mediums.

--- a/content/source/docs/extend/resources/index.html.md
+++ b/content/source/docs/extend/resources/index.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Resources
 
-A key component to Terraform Provider development is defining the creation, read, update, and deletion functionality of a resource to map those API operations into the Terraform lifecycle. While the basic aspects of developing Terraform resources have already been covered in [Call APIs with Terraform Providers Learn collection](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Schemas](/docs/extend/schemas/), this section covers more advanced features of resource development.
+A key component to Terraform Provider development is defining the creation, read, update, and deletion functionality of a resource to map those API operations into the Terraform lifecycle. While the basic aspects of developing Terraform resources have already been covered in the [Call APIs with Terraform Providers Learn collection](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Schemas](/docs/extend/schemas/), this section covers more advanced features of resource development.
 
 ## Import
 

--- a/content/source/docs/extend/resources/index.html.md
+++ b/content/source/docs/extend/resources/index.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Resources
 
-A key component to Terraform Provider development is defining the creation, read, update, and deletion functionality of a resource to map those API operations into the Terraform lifecycle. While the basic aspects of developing Terraform resources have already been covered in [Writing Custom Providers/Call APIs with Terraform Providers Learn Track](https://learn.hashicorp.com/terraform/providers/setup-implement-read) and [Schemas](/docs/extend/schemas/), this section covers more advanced features of resource development.
+A key component to Terraform Provider development is defining the creation, read, update, and deletion functionality of a resource to map those API operations into the Terraform lifecycle. While the basic aspects of developing Terraform resources have already been covered in [Call APIs with Terraform Providers Learn collection](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Schemas](/docs/extend/schemas/), this section covers more advanced features of resource development.
 
 ## Import
 
@@ -24,6 +24,6 @@ Terraform tracks the state of provisioned resources in its state file, and compa
 
 ## State Migrations
 
-Resources define the data types and API interactions required to create, update, and destroy infrastructure with a cloud vendor, while the [Terraform state](/docs/state/index.html) stores mapping and metadata information for those remote objects. 
+Resources define the data types and API interactions required to create, update, and destroy infrastructure with a cloud vendor, while the [Terraform state](/docs/state/index.html) stores mapping and metadata information for those remote objects.
 
 When resource implementations change (due to bug fixes, improvements, or changes to the backend APIs Terraform interacts with), they can sometimes become incompatible with existing state. When this happens, a migration is needed for resources provisioned in the wild with old schema configurations. Terraform resources support migrating state values in these scenarios via [State Migration](/docs/extend/resources/state-migration.html).

--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -312,7 +312,7 @@ Different VCS providers handle forks differently, but a fork is usually owned by
 
 Terraform Cloud makes extensive use of VCS repos, and assumes that forks of a trusted repo are not necessarily trusted. As such, Terraform Cloud avoids evaluating any code from external forks, which prevents Terraform Cloud from running [speculative plans][] for [pull requests][] from forks.
 
-On [Terraform Enterprise][], [speculative plans][] on [pull requests][] from forks can be enabled by an administrator. 
+On [Terraform Enterprise][], [speculative plans][] on [pull requests][] from forks can be enabled by an administrator.
 
 ## Git
 
@@ -731,7 +731,7 @@ The process of using Terraform to make real infrastructure match the desired sta
 
 In Terraform Cloud, runs are performed in a series of stages ([plan][], [policy check][], and [apply][]), though not every stage occurs in every run. Terraform Cloud saves information about historical runs.
 
-- [Learn Terraform: Getting Started](https://learn.hashicorp.com/terraform/getting-started/install)
+- [Learn Terraform: Get Started](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
 - [Terraform Cloud docs: About Runs](/docs/cloud/run/index.html)
 
 ## Run Triggers

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -40,7 +40,7 @@ Documentation for Terraform's core functionality, including:
 
 -> New users can start here.
 
-Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
+Interactive tutorials to teach you how to use Terraform's features. Begin with the [Get Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS), then continue with task-specific tutorials or go directly to the [Terraform CLI docs](/docs/cli-index.html).
 
 ### [Guides and Whitepapers ➜](/guides/index.html)
 
@@ -52,7 +52,7 @@ Detailed descriptions of various Terraform workflows, both general and specific.
 - [The long-term process of evolving provisioning practices in a large organization](/docs/cloud/guides/recommended-practices/index.html)
 - [Tasks for upgrading to major new Terraform versions](/upgrade-guides/index.html)
 
-This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the guides at [Learn Terraform](https://learn.hashicorp.com/terraform/?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)), but to explain best practices and show how the different pieces of a workflow fit together.
+This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the tutorials at [Learn Terraform](https://learn.hashicorp.com/terraform/?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)), but to explain best practices and show how the different pieces of a workflow fit together.
 
 </div>
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -36,7 +36,7 @@ Documentation for Terraform's core functionality, including:
 
 ...and much more.
 
-### [Learn Terraform ➜](https://learn.hashicorp.com/terraform/?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) (external site)
+### [Learn Terraform ➜](https://learn.hashicorp.com/terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) (external site)
 
 -> New users can start here.
 
@@ -52,7 +52,7 @@ Detailed descriptions of various Terraform workflows, both general and specific.
 - [The long-term process of evolving provisioning practices in a large organization](/docs/cloud/guides/recommended-practices/index.html)
 - [Tasks for upgrading to major new Terraform versions](/upgrade-guides/index.html)
 
-This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the tutorials at [Learn Terraform](https://learn.hashicorp.com/terraform/?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)), but to explain best practices and show how the different pieces of a workflow fit together.
+This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the tutorials at [Learn Terraform](https://learn.hashicorp.com/terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)), but to explain best practices and show how the different pieces of a workflow fit together.
 
 </div>
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -36,11 +36,11 @@ Documentation for Terraform's core functionality, including:
 
 ...and much more.
 
-### [Learn Terraform ➜](https://learn.hashicorp.com/terraform/) (external site)
+### [Learn Terraform ➜](https://learn.hashicorp.com/terraform/?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) (external site)
 
 -> New users can start here.
 
-Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/terraform/getting-started/install), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
+Interactive guides to teach you how to use Terraform's features. Begin with the [Getting Started guide](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS), then continue with task-specific advanced guides or go directly to the [Terraform CLI docs](/docs/cli-index.html).
 
 ### [Guides and Whitepapers ➜](/guides/index.html)
 
@@ -52,7 +52,7 @@ Detailed descriptions of various Terraform workflows, both general and specific.
 - [The long-term process of evolving provisioning practices in a large organization](/docs/cloud/guides/recommended-practices/index.html)
 - [Tasks for upgrading to major new Terraform versions](/upgrade-guides/index.html)
 
-This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the guides at [Learn Terraform](https://learn.hashicorp.com/terraform/)), but to explain best practices and show how the different pieces of a workflow fit together.
+This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the guides at [Learn Terraform](https://learn.hashicorp.com/terraform/?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)), but to explain best practices and show how the different pieces of a workflow fit together.
 
 </div>
 
@@ -78,9 +78,9 @@ Terraform Enterprise is an on-premise distribution of Terraform Cloud. It offers
 
 Documentation about the [Terraform Registry](https://registry.terraform.io/), a web service for distributing Terraform modules. Includes information about publishing, finding, and using modules.
 
-### [Terraform GitHub Actions ➜](https://learn.hashicorp.com/tutorials/terraform/github-actions)
+### [Terraform GitHub Actions ➜](https://learn.hashicorp.com/tutorials/terraform/github-actions?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
 
-Documentation about the Terraform GitHub Actions. [GitHub Actions](https://developer.github.com/actions) is GitHub's service for running commands in reaction to events in a Git repository, and HashiCorp publishes several actions for validating repositories that contain Terraform configurations.
+Tutorials about using Terraform with GitHub Actions. [GitHub Actions](https://developer.github.com/actions) is GitHub's service for running commands in reaction to events in a Git repository, and HashiCorp publishes a helper action for running Terraform commands against repositories that contain Terraform configurations.
 
 ### [Extending Terraform ➜](/docs/extend/index.html)
 

--- a/content/source/downloads.html.erb
+++ b/content/source/downloads.html.erb
@@ -86,9 +86,9 @@ show_notification: false
         <a href='https://app.terraform.io/signup/account?utm_source=terraform_io_download'>Sign up for Terraform Cloud</a>
       </div>
       <ul>
-        <li><a href='https://learn.hashicorp.com/collections/terraform/aws-get-started'>Get started with Terraform and AWS</a></li>
-        <li><a href='https://learn.hashicorp.com/collections/terraform/azure-get-started'>Get started with Terraform and Microsoft Azure</a></li>
-        <li><a href='https://learn.hashicorp.com/collections/terraform/gcp-get-started'>Get started with Terraform and Google Cloud</a></li>
+        <li><a href='https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=terraform_io_download'>Get started with Terraform and AWS</a></li>
+        <li><a href='https://learn.hashicorp.com/collections/terraform/azure-get-started?utm_source=terraform_io_download'>Get started with Terraform and Microsoft Azure</a></li>
+        <li><a href='https://learn.hashicorp.com/collections/terraform/gcp-get-started?utm_source=terraform_io_download'>Get started with Terraform and Google Cloud</a></li>
       </ul>
     </div>
   </div>

--- a/content/source/layouts/_cloud_content.erb
+++ b/content/source/layouts/_cloud_content.erb
@@ -15,7 +15,7 @@
       </li>
 
       <li>
-        <a href="https://learn.hashicorp.com/terraform/cloud-getting-started/signup">Getting Started <span class="glyphicon glyphicon-new-window"></span></a>
+        <a href="https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS">Getting Started <span class="glyphicon glyphicon-new-window"></span></a>
       </li>
 
       <li>
@@ -275,7 +275,7 @@
       <li>
         <a href="/docs/cloud/integrations/kubernetes/index.html">Kubernetes Integration</a>
       </li>
-      
+
       <li>
         <a href="/docs/cloud/api/index.html">API</a>
         <ul class="nav">

--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -11,7 +11,7 @@
     "Introduction to Terraform" => "/intro/index.html",
     "Guides and Whitepapers" => "/guides/index.html",
     "Terraform Registry" => "/docs/registry/index.html",
-    "Terraform GitHub Actions" => "https://learn.hashicorp.com/tutorials/terraform/github-actions",
+    "Terraform GitHub Actions" => "https://learn.hashicorp.com/tutorials/terraform/github-actions?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS",
     "Extending Terraform" => "/docs/extend/index.html"
   }
 -%>

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -11,7 +11,7 @@
       </li>
       <li<%= sidebar_current("docs-extend-writing-custom-providers") %>>
         <!-- possibly make this "Guides" and collect some? -->
-        <a href="https://learn.hashicorp.com/terraform/providers/setup-implement-read">Writing Custom Providers <span class="glyphicon glyphicon-new-window"></span></a>
+        <a href="https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS">Writing Custom Providers <span class="glyphicon glyphicon-new-window"></span></a>
       </li>
       <li<%= sidebar_current("docs-extend-hashicorp-provider-design-principles") %>>
         <a href="/docs/extend/hashicorp-provider-design-principles.html">HashiCorp Provider Design Principles</a>


### PR DESCRIPTION
- Use new collections-aware tutorial URLs instead of relying on redirects.
- Top-level collection links have real destinations now (instead of anchors).
- UTM tag all the things.