### PR TITLE
Fix broken link in recommended practices doc

### DIFF
--- a/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
@@ -27,7 +27,7 @@ Follow the rest of the [Terraform: Get Started collection](https://learn.hashico
 
 Choose a small real-life project and implement it with Terraform. Look at your organization’s list of upcoming projects, and designate one to be a Terraform proof-of-concept. Alternately, you can choose some existing infrastructure to re-implement with Terraform.
 
-The key is to choose a project with limited scope and clear boundaries, such as provisioning infrastructure for a new application on AWS. This helps keep your team from getting overwhelmed with features and possibilities. You can also look at some [example projects](https://github.com/hashicorp/terraform/tree/master/examples/) to get a feel for your options. (The [AWS two-tier example](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/two-tier) is often a good start.)
+The key is to choose a project with limited scope and clear boundaries, such as provisioning infrastructure for a new application on AWS. This helps keep your team from getting overwhelmed with features and possibilities. You can also look at some [example AWS projects](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples) to get a feel for your options. (The [AWS two-tier example](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/two-tier) is often a good start.)
 
 Your goal here is to build a small but reliable core of expertise with Terraform, and demonstrate its benefits to others in the organization.
 


### PR DESCRIPTION
The examples were moved to terraform providers aws repository, so the documentation here points at a broken link.


## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
