### PR TITLE
Remove extra text and heading from Enterprise index

### DIFF
--- a/content/source/docs/enterprise/index.html.md
+++ b/content/source/docs/enterprise/index.html.md
@@ -5,10 +5,6 @@ page_title: "Terraform Enterprise"
 
 # Terraform Enterprise
 
-This is the documentation for Terraform Enterprise.
-
-## About Terraform Cloud and Terraform Enterprise
-
 Terraform Enterprise is our self-hosted distribution of Terraform Cloud. It offers enterprises a private instance of the Terraform Cloud application, with no resource limits and with additional enterprise-grade architectural features like audit logging and SAML single sign-on.
 
 [Terraform Cloud](https://www.hashicorp.com/products/terraform/) is an application that helps teams use Terraform together. It manages Terraform runs in a consistent and reliable environment, and includes easy access to shared state and secret data, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more.


### PR DESCRIPTION
The first line and first header of the Terraform Enterprise docs are a little bit misleading. @swarnap got thrown by them and since they don't add much information I'd like to take them out.

## Labels

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
