### PR TITLE
Site behavior: Add GA tracking segment for 404 referrers

### DIFF
--- a/content/source/404.html.md
+++ b/content/source/404.html.md
@@ -1,5 +1,5 @@
 ---
-layout: "inner"
+layout: "404"
 page_title: "Not Found"
 noindex: true
 description: |-

--- a/content/source/layouts/404.erb
+++ b/content/source/layouts/404.erb
@@ -1,0 +1,20 @@
+<% wrap_layout :inner do %>
+    <%= yield %>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (
+                typeof window !== 'undefined' &&
+                typeof window.analytics !== 'undefined' &&
+                typeof window.analytics.track === 'function' &&
+                typeof window.document.referrer === 'string' &&
+                typeof window.location.href === 'string'
+            ) {
+                window.analytics.track(window.location.href, {
+                    category: '404 Response',
+                    label: window.document.referrer || 'No Referrer',
+                });
+            }
+        });
+    </script>
+<% end %>


### PR DESCRIPTION
Copied largely from
https://github.com/hashicorp/nomad/blob/master/website/pages/not-found/index.jsx#L13

This should track where links that 404 are coming from, which will hopefully help reduce the risk of moving pages in the Terraform docs. (We already redirect, but this is an extra safety net.)