### PR TITLE
Styles: Make code spans usable in sidebar navs

### DIFF
--- a/content/source/assets/stylesheets/_docs.scss
+++ b/content/source/assets/stylesheets/_docs.scss
@@ -20,6 +20,15 @@
     a { display: inline; }
   }
 
+  // Code spans in nav links shouldn't get bootstrap default code span styles;
+  // make them just inherit everything.
+  code {
+    padding: unset;
+    color: unset;
+    background-color: unset;
+    border-radius: unset;
+  }
+
   // hide an outdated implementation of expand/collapse link
   a.subnav-toggle {
     display: none;


### PR DESCRIPTION
This is in preparation for https://github.com/hashicorp/terraform/pull/26723, which will use code spans to style certain sidebar nav items (mostly `terraform` command pages). 

Without this, they were getting some goofy Bootstrap defaults. With it, they
look like normal links in a different font.

BEFORE: 😑

![image](https://user-images.githubusercontent.com/484309/97381347-21ff5d00-1886-11eb-925a-d0c132374b19.png)

AFTER: 😄

![image](https://user-images.githubusercontent.com/484309/97381416-4824fd00-1886-11eb-9801-ddacfad15eb5.png)