### PR TITLE
Adding documentation explaining blob storage authentication

### DIFF
--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -40,11 +40,11 @@ There are three kinds of token available:
 - [Team tokens](../users-teams-organizations/api-tokens.html#team-api-tokens) — each team can have one API token at a time. This is intended for performing plans and applies via a CI/CD pipeline.
 - [Organization tokens](../users-teams-organizations/api-tokens.html#organization-api-tokens) — each organization can have one API token at a time. This is intended for automating the management of teams, team membership, and workspaces. The organization token cannot perform plans and applies.
 
-### Archivist (blob storage) Authentication
+### Blob Storage Authentication
 
-Terraform Cloud relies on a blob storage service called Archivist for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
+Terraform Cloud relies on a Hashicorp-developed blob storage service for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
 
-Unlike the Terraform Cloud's API, Archivist does not require that a bearer token be submitted with each request. Instead, Archivist includes a securely generated secret in the URLs which are valid for 25 hours.
+Unlike the Terraform Cloud's API, this service does not require that a bearer token be submitted with each request. Instead, it includes a securely generated secret in the URLs which are valid for 25 hours.
 
 For example, the [state versions api](./state-versions.html) returns a field named `hosted-state-download`, which is a URL of this form:
 `https://archivist.terraform.io/v1/object/<secret value>`

--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -44,12 +44,12 @@ There are three kinds of token available:
 
 Terraform Cloud relies on a blob storage service called Archivist for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
 
-Unlike the Terraform Cloud's API, Archivist does not require that a bearer token be submitted with each request. Instead, Archivist URLS contain a Vault token that is used for authentication and authorization, and is valid for 25 hours.
+Unlike the Terraform Cloud's API, Archivist does not require that a bearer token be submitted with each request. Instead, Archivist uses secret URLs which are valid for 25 hours.
 
 For example, the [state versions api](./state-versions.html) returns a field named `hosted-state-download`, which is a URL of this form:
-`https://archivist.terraform.io/v1/object/<this long string is an encoded vault token>`
+`https://archivist.terraform.io/v1/object/<secret value>`
 
-It is important to treat these URLS themselves as secrets. They should not be logged, or shared with untrusted parties.
+It is important to treat these URLs themselves as secrets. They should not be logged, or shared with untrusted parties.
 
 ## Feature Entitlements
 

--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -44,7 +44,7 @@ There are three kinds of token available:
 
 Terraform Cloud relies on a HashiCorp-developed blob storage service for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
 
-Unlike the Terraform Cloud's API, this service does not require that a bearer token be submitted with each request. Instead, it includes a securely generated secret in the URLs which are valid for 25 hours.
+Unlike the Terraform Cloud API, this service does not require that a bearer token be submitted with each request. Instead, each URL includes a securely generated secret and is only valid for 25 hours.
 
 For example, the [state versions api](./state-versions.html) returns a field named `hosted-state-download`, which is a URL of this form:
 `https://archivist.terraform.io/v1/object/<secret value>`

--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -40,6 +40,17 @@ There are three kinds of token available:
 - [Team tokens](../users-teams-organizations/api-tokens.html#team-api-tokens) — each team can have one API token at a time. This is intended for performing plans and applies via a CI/CD pipeline.
 - [Organization tokens](../users-teams-organizations/api-tokens.html#organization-api-tokens) — each organization can have one API token at a time. This is intended for automating the management of teams, team membership, and workspaces. The organization token cannot perform plans and applies.
 
+### Archivist (blob storage) Authentication
+
+Terraform Cloud relies on a blob storage service called Archivist for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
+
+Unlike the Terraform Cloud's API, Archivist does not require that a bearer token be submitted with each request. Instead, Archivist URLS contain a Vault token that is used for authentication and authorization, and is valid for 25 hours.
+
+For example, the [state versions api](./state-versions.html) returns a field named `hosted-state-download`, which is a URL of this form:
+`https://archivist.terraform.io/v1/object/<this long string is an encoded vault token>`
+
+It is important to treat these URLS themselves as secrets. They should not be logged, or shared with untrusted parties.
+
 ## Feature Entitlements
 
 Terraform Cloud is available at multiple pricing tiers (including free), which offer different feature sets.

--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -44,12 +44,12 @@ There are three kinds of token available:
 
 Terraform Cloud relies on a blob storage service called Archivist for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
 
-Unlike the Terraform Cloud's API, Archivist does not require that a bearer token be submitted with each request. Instead, Archivist uses secret URLs which are valid for 25 hours.
+Unlike the Terraform Cloud's API, Archivist does not require that a bearer token be submitted with each request. Instead, Archivist includes a securely generated secret in the URLs which are valid for 25 hours.
 
 For example, the [state versions api](./state-versions.html) returns a field named `hosted-state-download`, which is a URL of this form:
 `https://archivist.terraform.io/v1/object/<secret value>`
 
-It is important to treat these URLs themselves as secrets. They should not be logged, or shared with untrusted parties.
+It is important to treat these URLs themselves as secrets. They should not be logged, nor shared with untrusted parties.
 
 ## Feature Entitlements
 

--- a/content/source/docs/cloud/api/index.html.md
+++ b/content/source/docs/cloud/api/index.html.md
@@ -42,14 +42,14 @@ There are three kinds of token available:
 
 ### Blob Storage Authentication
 
-Terraform Cloud relies on a Hashicorp-developed blob storage service for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
+Terraform Cloud relies on a HashiCorp-developed blob storage service for storing statefiles and multiple other pieces of customer data, all of which are documented on our [data security page](../architectural-details/data-security.html).
 
 Unlike the Terraform Cloud's API, this service does not require that a bearer token be submitted with each request. Instead, it includes a securely generated secret in the URLs which are valid for 25 hours.
 
 For example, the [state versions api](./state-versions.html) returns a field named `hosted-state-download`, which is a URL of this form:
 `https://archivist.terraform.io/v1/object/<secret value>`
 
-It is important to treat these URLs themselves as secrets. They should not be logged, nor shared with untrusted parties.
+This is a broadly accepted pattern for secure access. It is important to treat these URLs themselves as secrets. They should not be logged, nor shared with untrusted parties.
 
 ## Feature Entitlements
 


### PR DESCRIPTION
This change adds an explanation of TFC's blob-storage service, which uses a separate mechanism for authentication and authorization.

This change was already approved in a private review