### PR TITLE
Adding new attributes for Sentinel tfrun import

### DIFF
--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -16,8 +16,10 @@ This import currently consists of run attributes, as well as namespaces for the 
 
 ```
 tfrun
+├── id (string)
 ├── created_at (string)
 ├── message (string)
+├── commit_sha (string)
 ├── speculative (boolean)
 ├── is_destroy (boolean)
 ├── variables (map of keys)
@@ -25,6 +27,7 @@ tfrun
 ├── organization
 │   └── name (string)
 ├── workspace
+│   ├── id (string)
 │   ├── name (string)
 │   ├── description (string)
 │   ├── auto_apply (bool)
@@ -54,6 +57,12 @@ to only enforce the policy on non-development workspaces is more appropriate.
 
 The **root namespace** contains data associated with the current run.
 
+### Value: `id`
+
+* **Value Type:** String.
+
+Specifies the ID that is associated with the current Terraform run.
+
 ### Value: `created_at`
 
 * **Value Type:** String.
@@ -66,9 +75,15 @@ Users can use the `time` import to [load](https://docs.hashicorp.com/sentinel/im
 
 * **Value Type:** String.
 
-Specifies the message that is associated with the run.
+Specifies the message that is associated with the Terraform run.
 
 The default value is *"Queued manually via the Terraform Enterprise API"*.
+
+### Value: `commit_sha`
+
+* **Value Type:** String.
+
+Specifies the checksum hash (SHA) that identifies the commit
 
 ### Value: `speculative`
 
@@ -109,7 +124,6 @@ import "tfrun"
 main = (length(tfrun.target_addrs) else 0) == 0
 ```
 
-
 ## Namespace: organization
 
 The **organization namespace** contains data associated with the current run's Terraform Cloud [organization](../../users-teams-organizations/organizations.html).
@@ -124,13 +138,19 @@ Specifies the name assigned to the Terraform Cloud organization.
 
 The **workspace namespace** contains data associated with the current run's workspace.
 
+### Value: `id`
+
+* **Value Type:** String.
+
+Specifies the ID that is associated with the Terraform workspace.
+
 ### Value: `name`
 
 * **Value Type:** String.
 
 The name of the workspace, which can only include letters, numbers, `-`, and `_`.
 
-As an example, in a workspace named `app-dev-us-east` the following policy would evaluate to `true`:
+As an example, in a workspace named `app-us-east-dev` the following policy would evaluate to `true`:
 
 ```
 # Enforces production rules on all non-development workspaces
@@ -138,15 +158,8 @@ As an example, in a workspace named `app-dev-us-east` the following policy would
 import "tfrun"
 import "strings"
 
-# (Actual policy logic omitted)
-meets_production_policy = rule { ... }
-
 main = rule {
-    if strings.has_suffix(tfrun.workspace.name, "-dev") {
-        true
-    } else
-        meets_production_policy
-    }
+    strings.has_suffix(tfrun.workspace.name, "-dev")
 }
 ```
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -83,7 +83,7 @@ The default value is *"Queued manually via the Terraform Enterprise API"*.
 
 * **Value Type:** String.
 
-Specifies the checksum hash (SHA) that identifies the commit
+Specifies the checksum hash (SHA) that identifies the commit.
 
 ### Value: `speculative`
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -158,8 +158,10 @@ As an example, in a workspace named `app-us-east-dev` the following policy would
 import "tfrun"
 import "strings"
 
-main = rule {
-    strings.has_suffix(tfrun.workspace.name, "-dev")
+evaluate_production_policy = rule { false }
+
+main = rule when strings.has_suffix(tfrun.workspace.name, "-dev") is false {
+    evaluate_production_policy
 }
 ```
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -158,7 +158,8 @@ As an example, in a workspace named `app-us-east-dev` the following policy would
 import "tfrun"
 import "strings"
 
-evaluate_production_policy = rule { false }
+# (Actual policy logic omitted)
+evaluate_production_policy = rule { ... }
 
 main = rule when strings.has_suffix(tfrun.workspace.name, "-dev") is false {
     evaluate_production_policy


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

This PR updates the documentation for the Sentinel tfrun import to include newly added attributes, namely run id, commit sha and workspace id. It also fixes an inaccuracy in the workspace policy example. 

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
