### PR TITLE
Layout: Add outbound link to registry in Docs menu

### DIFF
--- a/content/source/assets/stylesheets/_global.scss
+++ b/content/source/assets/stylesheets/_global.scss
@@ -29,3 +29,10 @@ body {
 .sidebar .sidebar-nav li a {
   line-height: 18px;
 }
+
+.sidebar .sidebar-nav li a .hack-outbound-svg {
+  fill: none !important;
+  path {
+    stroke: $sidebar-link-color !important;
+  }
+}

--- a/content/source/assets/stylesheets/_header.scss
+++ b/content/source/assets/stylesheets/_header.scss
@@ -62,6 +62,13 @@
           svg {
             fill: $header-link-color-hover;
           }
+
+          .hack-outbound-svg {
+            fill: none !important;
+            path {
+              stroke: $header-link-color-hover !important;
+            }
+          }
         }
       }
 
@@ -88,6 +95,13 @@
         width: 14px;
         height: 14px;
         margin-right: 3px;
+      }
+
+      .hack-outbound-svg {
+        fill: none !important;
+        path {
+          stroke: $header-link-color !important;
+        }
       }
 
       &:hover > ul {

--- a/content/source/assets/stylesheets/_home.scss
+++ b/content/source/assets/stylesheets/_home.scss
@@ -32,6 +32,13 @@
             svg {
               fill: $home-header-link-color-hover;
             }
+
+            .hack-outbound-svg {
+              fill: none !important;
+              path {
+                stroke: $home-header-link-color-hover !important;
+              }
+            }
           }
         }
 
@@ -43,6 +50,13 @@
 
         svg {
           fill: $home-header-link-color;
+        }
+
+        .hack-outbound-svg {
+          fill: none !important;
+          path {
+            stroke: $home-header-link-color !important;
+          }
         }
 
         ul {

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -55,7 +55,7 @@
 
   <body id="<%= body_id_for(current_page) %>" class="<%= body_classes_for(current_page) %>">
     <%= partial("layouts/alert_banner", locals: {show: false, theme: 'terraform', url:"https://www.hashicorp.com/webinars/provision-infrastructure-using-cloud-development-kit-for-terraform/", tag:"Live Webinar", text:"Write an infrastructure application in TypeScript and Python using CDK for Terraform", cta:"Register Now"}) %>
-  
+
     <header class="hashiStackMenuRoot hashiStackMenu">
             <nav class="nav g-container">
               <a class="logoLink" href="https://www.hashicorp.com">
@@ -258,6 +258,12 @@
                 <li><a data-track='docs-cloud' href="/docs/cloud/index.html">Terraform Cloud</a></li>
                 <li><a data-track='docs-ent' href="/docs/enterprise/index.html">Terraform Enterprise</a></li>
                 <li><a data-track='docs-providers' href="/docs/providers/index.html">Providers</a></li>
+                <li>
+                  <a data-track='docs-registry-outbound' href="https://registry.terraform.io">
+                    Terraform Registry
+                    #{inline_svg("outbound-link.svg", class: "hack-outbound-svg")}
+                  </a>
+                </li>
                 <li><a data-track='docs-glossary' href="/docs/glossary.html">Glossary</a></li>
                 <li><a data-track='docs-guides' href="/guides/index.html">Guides and Whitepapers</a></li>
                 <li><a data-track='docs-registry' href="/docs/registry/index.html">Registry</a></li>


### PR DESCRIPTION
This proposal could really use a better alternative to the CSS hackery that fixes the colors of the outbound link icon, so I'm filing it as a draft in the hopes that someone can suggest something. 😅

Context: 

- You can't see it in this PR, but we're in the process of renaming the current "Registry" link in the docs menu to "Publishing Modules & Providers" (because it goes to the docs about publishing modules and providers on the registry). So that won't be a name conflict. 
- Similar idea as https://github.com/hashicorp/terraform-website/pull/1417, except the link is going in the docs menu. That's not really the correct place for it, but it's temporarily expedient until we can get some kind of consensus about what to do with the massive TFC links on the far right. 
- I got that "outbound link" SVG from @BrandonRomano, and I think it came from a collection of similar icons on our Figma. 
- The whole problem here is that the "download", "github", and "menu dropdown thingie" SVGs in the header all get their visible shapes from a fill property, but the outbound link SVG uses a stroke property, which we need to override to match the colors on both the homepage and the rest of the site. I couldn't see a way to do that when using an img tag, so I used the inline SVG helper, and that brings us to where we are today. 

It looks fine, I just hate the code.

![Screen Shot 2020-11-11 at 3 07 38 PM](https://user-images.githubusercontent.com/484309/98874746-b396cf00-242f-11eb-8281-534c13922715.png) ![Screen Shot 2020-11-11 at 3 07 50 PM](https://user-images.githubusercontent.com/484309/98874751-b5609280-242f-11eb-984d-d02d86122dc3.png)
