### PR TITLE
Fix changed Cost Estimation value in API docs

### DIFF
--- a/content/source/docs/cloud/api/organizations.html.md
+++ b/content/source/docs/cloud/api/organizations.html.md
@@ -54,7 +54,7 @@ curl \
       "type": "organizations",
       "attributes": {
         "name": "hashicorp",
-        "cost-estimation-enabled": false,
+        "cost-estimation-enabled": true,
         "created-at": "2017-09-07T14:34:40.492Z",
         "email": "user@example.com",
         "session-timeout": null,
@@ -114,7 +114,7 @@ curl \
     "type": "organizations",
     "attributes": {
       "name": "hashicorp",
-      "cost-estimation-enabled": false,
+      "cost-estimation-enabled": true,
       "created-at": "2017-09-07T14:34:40.492Z",
       "email": "user@example.com",
       "session-timeout": null,
@@ -165,7 +165,7 @@ Key path                                   | Type    | Default   | Description
 `data.attributes.session-timeout`          | integer |    20160  | Session timeout after inactivity (minutes)
 `data.attributes.session-remember`         | integer |    20160  | Session expiration (minutes)
 `data.attributes.collaborator-auth-policy` | string  | password  | Authentication policy (`password` or `two_factor_mandatory`)
-`data.attributes.cost-estimation-enabled`  | boolean | false     | Whether or not the cost estimation feature is enabled for all workspaces in the organization
+`data.attributes.cost-estimation-enabled`  | boolean | true      | Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 `data.attributes.owners-team-saml-role-id` | string  | (nothing) | **Optional.** **SAML only** The name of the ["owners" team](/docs/enterprise/saml/team-membership.html#managing-membership-of-the-owners-team)
 
 ### Sample Payload
@@ -202,7 +202,7 @@ curl \
     "type": "organizations",
     "attributes": {
       "name": "hashicorp",
-      "cost-estimation-enabled": false,
+      "cost-estimation-enabled": true,
       "created-at": "2017-09-07T14:34:40.492Z",
       "email": "user@example.com",
       "session-timeout": null,
@@ -255,7 +255,7 @@ Key path                                   | Type    | Default   | Description
 `data.attributes.session-timeout`          | integer |    20160  | Session timeout after inactivity (minutes)
 `data.attributes.session-remember`         | integer |    20160  | Session expiration (minutes)
 `data.attributes.collaborator-auth-policy` | string  | password  | Authentication policy (`password` or `two_factor_mandatory`)
-`data.attributes.cost-estimation-enabled`  | boolean | false     | Whether or not the cost estimation feature is enabled for all workspaces in the organization
+`data.attributes.cost-estimation-enabled`  | boolean | true      | Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 `data.attributes.owners-team-saml-role-id` | string  | (nothing) | **Optional.** **SAML only** The name of the ["owners" team](/docs/enterprise/saml/team-membership.html#managing-membership-of-the-owners-team)
 
 ### Sample Payload
@@ -291,7 +291,7 @@ curl \
     "type": "organizations",
     "attributes": {
       "name": "hashicorp",
-      "cost-estimation-enabled": false,
+      "cost-estimation-enabled": true,
       "created-at": "2017-09-07T14:34:40.492Z",
       "email": "admin@example.com",
       "session-timeout": null,


### PR DESCRIPTION
We recently made a change where Cost Estimation is now enabled by default in organizations; this has the added caveat that on Terraform Cloud, the organization must also be entitled to use Cost Estimation. On Terraform Cloud, it is always enabled.


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
