### PR TITLE
TF Core: add symlink to `language.erb` layout

### DIFF
--- a/content/source/layouts/language.erb
+++ b/content/source/layouts/language.erb
@@ -1,0 +1,1 @@
+../../../ext/terraform/website/layouts/language.erb


### PR DESCRIPTION
This commit is a preparation for changes to docs files in the
hashicorp/terraform repo (see
https://github.com/hashicorp/terraform/pull/26723), and is required before the
rearranged docs will build. The rearranged docs are expected to ship with
Terraform 0.14.

We also need a symlink to the /docs/cli directory, but that was already merged
in 3bb903908 because Martin needed to ship some docs about the native package
repositories.

This commit can be merged before the updated docs are released with no ill effect.
