### PR TITLE
redirect removed examples pages

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -570,3 +570,10 @@
 /docs/providers/google/d/google_storage_transfer_project_service_account.html   /docs/providers/google/d/storage_transfer_project_service_account.html
 /docs/providers/google/d/datasource_tpu_tensorflow_versions.html                /docs/providers/google/d/tpu_tensorflow_versions.html
 /docs/registry/support.html                                                     /docs/registry/index.html#getting-help
+
+# Redirect removed terraform examples to learn.hashicorp.com
+/intro/examples/aws.html        https://learn.hashicorp.com/terraform
+/intro/examples/consul.html     https://learn.hashicorp.com/terraform
+/intro/examples/count           https://learn.hashicorp.com/terraform
+/intro/examples/cross-provider  https://learn.hashicorp.com/terraform
+/intro/examples/                https://learn.hashicorp.com/terraform


### PR DESCRIPTION
The examples section of terraform's website had pages which were
pointing directly to examples in the terraform repository. Those
examples were very out of date and I removed them without realizing that
they were references on the website.

There is better content on learn.hashicorp.com, so we decided to remove
the Examples section entirely and replace with a general redirect to
learn.


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
