### PR TITLE
Mention overriding soft-mandatory policies in CLI

### DIFF
--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -212,9 +212,6 @@ Do you want to override the soft failed policy check?
 
   Enter a value: override
 ```
-If you do override, you will then be prompted to apply the run. 
-
-Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
 
 ```
 $ terraform apply

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -182,7 +182,14 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 ## Sentinel Policies
 
-If the specified workspace uses Sentinel policies, those policies will run against all speculative plans and remote applies in that workspace. The policy output will be available in the terminal. Soft mandatory checks can be overridden by users with the [Manage Policies](docs/cloud/users-teams-organizations/permissions.html#manage-policies) permission by typing "override" in response to the prompt. (Note that "yes" will not work.)
+If the specified workspace uses Sentinel policies, those policies will run against all speculative plans and remote applies in that workspace. Policy output is shown in the terminal. 
+
+Failed policies can pause or prevent an apply, depending on the enforcement level:
+
+- Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
+- Soft mandatory checks can be overridden by users with permission to [manage policies](docs/cloud/users-teams-organizations/permissions.html#manage-policies). If your account can override a failed check, Terraform will prompt you to type "override" to confirm. (Note that typing "yes" will not work.) If you override the check, you will be prompted to apply the run (unless auto-apply is enabled).
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 ```
 $ terraform apply

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -220,32 +220,6 @@ Do you want to override the soft failed policy check?
   Enter a value: override
 ```
 
-```
-$ terraform apply
-
-[...]
-
-Plan: 1 to add, 0 to change, 1 to destroy.
-
-------------------------------------------------------------------------
-
-Organization policy check:
-
-Sentinel Result: false
-
-Sentinel evaluated to false because one or more Sentinel policies evaluated
-to false. This false was not due to an undefined value or runtime error.
-
-1 policies evaluated.
-## Policy 1: my-policy.sentinel (hard-mandatory)
-
-Result: false
-
-FALSE - my-policy.sentinel:1:1 - Rule "main"
-
-Error: Organization policy check hard failed.
-```
-
 ## Targeted Plan and Apply
 
 -> **Version note:** Targeting support was added client-side in Terraform v0.12.26 and also requires server-side support that may not be available for all Terraform Enterprise deployments yet.

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -182,7 +182,39 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 ## Sentinel Policies
 
-If the specified workspace uses Sentinel policies, those policies will run against all speculative plans and remote applies in that workspace. The policy output will be available in the terminal. Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
+If the specified workspace uses Sentinel policies, those policies will run against all speculative plans and remote applies in that workspace. The policy output will be available in the terminal. Soft mandatory checks can be overridden by users with the [Manage Policies](docs/cloud/users-teams-organizations/permissions.html#manage-policies) permission by typing "override" in response to the prompt. (Note that "yes" will not work.)
+
+```
+$ terraform apply
+
+[...]
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+------------------------------------------------------------------------
+
+Organization policy check:
+
+Sentinel Result: false
+
+Sentinel evaluated to false because one or more Sentinel policies evaluated
+to false. This false was not due to an undefined value or runtime error.
+
+1 policies evaluated.
+## Policy 1: my-policy.sentinel (soft-mandatory)
+
+Result: false
+
+FALSE - my-policy.sentinel:1:1 - Rule "main"
+
+Do you want to override the soft failed policy check?
+  Only 'override' will be accepted to override.
+
+  Enter a value: override
+```
+If you do override, you will then be prompted to apply the run. 
+
+Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
 
 ```
 $ terraform apply


### PR DESCRIPTION
Users can override soft-mandatory Sentinel policies when using the Terraform CLI with the remote backend. They are shown the following:
```
Do you want to override the soft failed policy check?
  Only 'override' will be accepted to override.

  Enter a value:
```

They must type "override" to override.  Note that "yes" will not work.


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
