### PR TITLE
Updating verbiage for sizing tables

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -110,7 +110,7 @@ Terraform Enterprise application as well as the Terraform plans and applies.
 * At least 10GB of disk space on the root volume
 * At least 40GB of disk space for the Docker data directory (defaults to `/var/lib/docker`)
 * At least 8GB of system memory
-* At least 2 CPU cores
+* At least 4 CPU cores
 
 ### Network Requirements
 

--- a/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
@@ -37,32 +37,32 @@ or “Burstable CPU” in AWS terms, such as T-series instances.
 
 ### Terraform Enterprise Server (EC2 via Auto Scaling Group)
 
-| Type        | CPU      | Memory       | Disk | AWS Instance Types    |
-|-------------|----------|--------------|------|-----------------------|
-| Minimum     | 2 core   | 8 GB RAM     | 50GB | m5.large              |
-| Recommended | 4-8 core | 16-32 GB RAM | 50GB | m5.xlarge, m5.2xlarge |
+| Type    | CPU    | Memory    | Disk | AWS Instance Types |
+|---------|--------|-----------|------|--------------------|
+| Minimum | 4 core | 16 GB RAM | 50GB | m5.xlarge          |
+| Scaled  | 8 core | 32 GB RAM | 50GB | m5.2xlarge         |
 
 #### Hardware Sizing Considerations
 
 - The minimum size would be appropriate for most initial production
   deployments, or for development/testing environments.
 
-- The recommended size is for production environments where there is a
+- The scaled size is for production environments where there is a
   consistent high workload in the form of concurrent Terraform runs.
 
 ### PostgreSQL Database (RDS Multi-AZ)
 
-| Type        | CPU      | Memory       | Storage | AWS Instance Types          |
-|-------------|----------|--------------|---------|-----------------------------|
-| Minimum     | 2 core   | 8 GB RAM     | 50GB    | db.m4.large                 |
-| Recommended | 4-8 core | 16-32 GB RAM | 50GB    | db.m4.xlarge, db.m4.2xlarge |
+| Type    | CPU    | Memory    | Storage | AWS Instance Types |
+|---------|--------|-----------|---------|--------------------|
+| Minimum | 4 core | 16 GB RAM | 50GB    | db.m4.xlarge       |
+| Scaled  | 8 core | 32 GB RAM | 50GB    | db.m4.2xlarge      |
 
 #### Hardware Sizing Considerations
 
 - The minimum size would be appropriate for most initial production
   deployments, or for development/testing environments.
 
-- The recommended size is for production environments where there is a
+- The scaled size is for production environments where there is a
   consistent high workload in the form of concurrent Terraform runs.
 
 ### Object Storage (S3)

--- a/content/source/docs/enterprise/before-installing/reference-architecture/azure.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/azure.md
@@ -44,10 +44,10 @@ instances.
 
 ### Terraform Enterprise Servers (Azure VMs)
 
-| Type        | CPU      | Memory       | Disk | Azure VM Sizes                     |
-| ----------- | -------- | ------------ | ---- | ---------------------------------- |
-| Minimum     | 2 core   | 8 GB RAM     | 50GB | Standard\_D2\_v3                   |
-| Recommended | 4-8 core | 16-32 GB RAM | 50GB | Standard\_D4\_v3, Standard\_D8\_v3 |
+| Type    | CPU    | Memory    | Disk | Azure VM Sizes   |
+|---------|--------|-----------|------|------------------|
+| Minimum | 4 core | 16 GB RAM | 50GB | Standard\_D4\_v3 |
+| Scaled  | 8 core | 32 GB RAM | 50GB | Standard\_D8\_v3 |
 
 #### Hardware Sizing Considerations
 
@@ -60,21 +60,21 @@ instances.
 - The minimum size would be appropriate for most initial production
   deployments or for development/testing environments.
 
-- The recommended size is for production environments where there is a
+- The scaled size is for production environments where there is a
   consistently high workload in the form of concurrent Terraform runs.
 
 ### PostgreSQL Database (Azure Database for PostgreSQL)
 
-| Type        | CPU      | Memory      | Storage | Azure DB Sizes                                     |
-| ----------- | -------- | ----------- | ------- | -------------------------------------------------- |
-| Minimum     | 2 core   | 4 GB RAM    | 50GB    | General Purpose 2 vCores                           |
-| Recommended | 4-8 core | 8-16 GB RAM | 50GB    | General Purpose 4 vCores, General Purpose 8 vCores |
+| Type    | CPU    | Memory    | Storage | Azure DB Sizes |
+|---------|--------|-----------|---------|----------------|
+| Minimum | 4 core | 8 GB RAM  | 50GB    | GP_Gen5_4      |
+| Scaled  | 8 core | 16 GB RAM | 50GB    | GP_Gen5_8      |
 
 #### Hardware Sizing Considerations
 
 - The minimum size would be appropriate for most initial production
   deployments or for development/testing environments.
-- The recommended size is for production environments where there is
+- The scaled size is for production environments where there is
   a consistent high workload in the form of concurrent Terraform
   runs.
   - Be aware that a 4 vCPU database has a maximum capacity of 1Tb.  For organizations which require long-term logging for audit, larger databases may be required.  The 8 vCPU database has a maximum of 1.5Tb.

--- a/content/source/docs/enterprise/before-installing/reference-architecture/gcp.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/gcp.md
@@ -37,10 +37,10 @@ or “Shared-core machine types” in GCP terms, such as f1-series and g1-series
 
 ### Terraform Enterprise Server (Compute Engine VM via Regional Managed Instance Group)
 
-| Type        | CPU      | Memory       | Disk        | GCP Machine Types              |
-|-------------|----------|--------------|-------------|--------------------------------|
-| Minimum     | 2 core   | 7.5 GB RAM   | 50GB/200GB* | n1-standard-2                 |
-| Recommended | 4-8 core | 15-30 GB RAM | 50GB/200GB* | n1-standard-4, n1-standard-8   |
+| Type    | CPU    | Memory    | Disk        | GCP Machine Types |
+|---------|--------|-----------|-------------|-------------------|
+| Minimum | 4 core | 15 GB RAM | 50GB/200GB* | n1-standard-4     |
+| Scaled  | 8 core | 30 GB RAM | 50GB/200GB* | n1-standard-8     |
 
 #### Hardware Sizing Considerations
 
@@ -53,22 +53,22 @@ or “Shared-core machine types” in GCP terms, such as f1-series and g1-series
 - The minimum size would be appropriate for most initial production
   deployments, or for development/testing environments.
 
-- The recommended size is for production environments where there is a
+- The scaled size is for production environments where there is a
   consistent high workload in the form of concurrent Terraform runs.
 
 ### PostgreSQL Database (Cloud SQL PostgreSQL Production)
 
-| Type        | CPU      | Memory       | Storage | GCP Machine Types            |
-|-------------|----------|--------------|---------|------------------------------|
-| Minimum     | 2 core   | 8 GB RAM     | 50GB    | Custom PostgreSQL Production |
-| Recommended | 4-8 core | 16-32 GB RAM | 50GB    | Custom PostgreSQL Production |
+| Type    | CPU    | Memory    | Storage | GCP Machine Types            |
+|---------|--------|-----------|---------|------------------------------|
+| Minimum | 4 core | 16 GB RAM | 50GB    | Custom PostgreSQL Production |
+| Scaled  | 8 core | 32 GB RAM | 50GB    | Custom PostgreSQL Production |
 
 #### Hardware Sizing Considerations
 
 - The minimum size would be appropriate for most initial production
   deployments, or for development/testing environments.
 
-- The recommended size is for production environments where there is a
+- The scaled size is for production environments where there is a
   consistent high workload in the form of concurrent Terraform runs.
 
 ### Object Storage (Cloud Storage)

--- a/content/source/docs/enterprise/before-installing/reference-architecture/vmware.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/vmware.md
@@ -48,19 +48,19 @@ the internal database or Vault may result in serious performance issues.
 
 ### Terraform Enterprise Servers
 
-| Type        | CPU Sockets | Total Cores\* | Memory       | Disk |
-| ----------- | ----------- | ------------- | ------------ | ---- |
-| Minimum     | 2           | 2             | 8 GB RAM     | 40GB |
-| Recommended | 2           | 4             | 16-32 GB RAM | 40GB |
+| Type    | CPU Sockets | Total Cores\* | Memory    | Disk |
+|---------|-------------|---------------|-----------|------|
+| Minimum | 2           | 4             | 16 GB RAM | 40GB |
+| Scaled  | 2           | 8             | 32 GB RAM | 40GB |
 
--> **Note:** Per VMWare’s recommendation, always allocate the least amount of CPU necessary. HashiCorp recommends starting with 2 CPUs and increasing if necessary.
+-> **Note:** Per VMWare’s recommendation, always allocate the least amount of CPU necessary. HashiCorp recommends starting with 4 CPUs and increasing if necessary.
 
 #### Hardware Sizing Considerations
 
 - The minimum size would be appropriate for most initial production
   deployments, or for development/testing environments.
 
-- The recommended size is for production environments where there is
+- The scaled size is for production environments where there is
   a consistent high workload in the form of concurrent terraform
   runs.
 
@@ -245,5 +245,5 @@ and is not covered in this document. We do recommend regular database snapshots.
 
 | Type        | CPU Sockets | Total Cores | Memory       | Storage |
 | ----------- | ----------- | ----------- | ------------ | ------- |
-| Minimum     | 2           | 2 core      | 8 GB RAM     | 50GB    |
-| Recommended | 2           | 4-8 core    | 16-32 GB RAM | 50GB    |
+| Demo        | 2           | 2 core      | 8 GB RAM     | 50GB    |
+| Production  | 2           | 4-8 core    | 16-32 GB RAM | 50GB    |

--- a/content/source/docs/enterprise/system-overview/capacity.html.md
+++ b/content/source/docs/enterprise/system-overview/capacity.html.md
@@ -48,7 +48,7 @@ The required CPU resources for an individual Terraform run vary considerably, bu
 factor than memory due to Terraform mostly waiting on IO from APIs to return.
 
 Our rule of thumb is 10 Terraform runs per CPU core, with 2 CPU cores allocated for the base Terraform Enterprise services.
-So an 8-core instance with 16 GB of memory could comfortably run 20 Terraform runs, if the runs are allocated the default
+So a 4-core instance with 16 GB of memory could comfortably run 20 Terraform runs, if the runs are allocated the default
 512 MB each.
 
 ## Disk


### PR DESCRIPTION
Clarifying the sizing tables to account for the change in default memory allocated to each run. Each run is now given 512MB of memory rather than 256MB of memory. As such, the minimum instance sizes must increase.

## Labels

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
