### PR TITLE
TFE Pre-Install Checklist: Document S3 API permissions

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -162,6 +162,26 @@ At a minimum, Terraform Enterprise requires the following S3 permissions:
 }
 ```
 
+#### KMS Policy
+
+At a minimum, Terraform Enterprise will require the following permissions if the objects in the bucket are to be encrypted via resources in AWS's KMS:
+
+```
+{
+    "Effect": "Allow",
+    "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:DescribeKey",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*"
+    ],
+    "Resource": [
+        "<KMS_KEY_ARN>"
+    ]
+}
+```
+
 ### SELinux
 
 SELinux is supported when Terraform Enterprise runs in _External Services_ mode and only the default SELinux policies provided by RedHat are used. Terraform Enterprise v201812-1 or later is required for this support.

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -141,7 +141,7 @@ Terraform Enterprise's instance profile serves as default credentials for Terraf
 
 The instance profile of Terraform Enterprise's instance is the operator's responsibility. If you plan to specify any non-default permissions for Terraform Enterprise's instance profile, be aware that Terraform runs might use those permissions and plan accordingly.
 
-#### AWS S3 IAM Profile
+#### S3 IAM Policy
 
 Terraform Enterprise's usage of S3 requires these permissions:
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -143,7 +143,7 @@ The instance profile of Terraform Enterprise's instance is the operator's respon
 
 #### S3 IAM Policy
 
-Terraform Enterprise's usage of S3 requires these permissions:
+At a minimum, Terraform Enterprise requires the following S3 permissions:
 
 ```
 {

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -141,7 +141,7 @@ Terraform Enterprise's instance profile serves as default credentials for Terraf
 
 The instance profile of Terraform Enterprise's instance is the operator's responsibility. If you plan to specify any non-default permissions for Terraform Enterprise's instance profile, be aware that Terraform runs might use those permissions and plan accordingly.
 
-#### S3 IAM Policy
+#### S3 Policy
 
 At a minimum, Terraform Enterprise requires the following S3 permissions:
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -141,6 +141,27 @@ Terraform Enterprise's instance profile serves as default credentials for Terraf
 
 The instance profile of Terraform Enterprise's instance is the operator's responsibility. If you plan to specify any non-default permissions for Terraform Enterprise's instance profile, be aware that Terraform runs might use those permissions and plan accordingly.
 
+#### AWS S3 IAM Profile
+
+Terraform Enterprise's usage of S3 requires these permissions:
+
+```
+{
+    "Effect": "Allow",
+    "Action": [
+        "s3:PutObject",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:GetBucketLocation"
+    ],
+    "Resource": [
+        "<BUCKET_ARN>",
+        "<BUCKET_ARN>/*"
+    ]
+}
+```
+
 ### SELinux
 
 SELinux is supported when Terraform Enterprise runs in _External Services_ mode and only the default SELinux policies provided by RedHat are used. Terraform Enterprise v201812-1 or later is required for this support.


### PR DESCRIPTION
Given that any customer would have to attempt multiple times in a sad AWS feedback loop or go code digging in order to get this permission set generated, we should go ahead and document these permissions publicly somewhere. I had to do this myself for a customer ticket.

The permission set was taken from [internal resources](https://github.com/hashicorp/is-terraform-aws-tfe-standalone/blob/master/templates/tfe-instance-role-policy.json#L30-L49)

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [X] clarification
- [X] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
