### PR TITLE
Fix agents page title

### DIFF
--- a/content/source/docs/cloud/agents/index.html.md
+++ b/content/source/docs/cloud/agents/index.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "cloud"
-page_title: "Terraform Cloud Agents - Workspaces - Terraform Cloud and Terraform Enterprise"
+page_title: "Terraform Cloud Agents - Terraform Cloud and Terraform Enterprise"
 ---
 
 # Terraform Cloud Agents


### PR DESCRIPTION
The agents page was moved out from underneath Workspaces, so this title is wrong.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
