### PR TITLE
0.14 release task: ship language and cli docs

### DIFF
--- a/content/source/docs/cloud/guides/recommended-practices/index.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/index.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Index - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 # Terraform Recommended Practices

--- a/content/source/docs/cloud/guides/recommended-practices/part1.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part1.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 1: Overview of Our Recommended Workflow - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 

--- a/content/source/docs/cloud/guides/recommended-practices/part2.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part2.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 2: Evaluating Your Current Provisioning Practices - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 

--- a/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.1.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 3.1: From Manual Changes to Semi-Automation - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 # Part 3.1: How to Move from Manual Changes to Semi-Automation

--- a/content/source/docs/cloud/guides/recommended-practices/part3.2.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.2.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 3.2: From Semi-Automation to Infrastructure as Code - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 # Part 3.2: How to Move from Semi-Automation to Infrastructure as Code

--- a/content/source/docs/cloud/guides/recommended-practices/part3.3.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.3.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 3.3: From Infrastructure as Code to Collaborative Infrastructure as Code - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 # Part 3.3: How to Move from Infrastructure as Code to Collaborative Infrastructure as Code

--- a/content/source/docs/cloud/guides/recommended-practices/part3.4.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.4.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 3.4: Advanced Workflow Improvements - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 # Part 3.4: Advanced Improvements to Collaborative Infrastructure as Code

--- a/content/source/docs/cloud/guides/recommended-practices/part3.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.html.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Part 3: How to Evolve Your Provisioning Practices - Terraform Recommended Practices"
-layout: "guides"
+layout: "intro"
 ---
 
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -24,17 +24,21 @@ We've divided the Terraform docs into several sections to make it easier to find
 
 A broad overview of what Terraform is and why people use it.
 
-### [Terraform CLI ➜](/docs/cli-index.html)
+### [Terraform Glossary ➜](/docs/glossary.html)
+
+Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
+
+### [Terraform Language ➜](/docs/configuration/index.html)
 
 -> Intermediate and advanced users spend most of their time here.
 
-Documentation for Terraform's core functionality, including:
+Documentation for Terraform's configuration language.
 
-- [Terraform's configuration language](/docs/configuration/index.html)
-- [The `terraform` binary and its subcommands](/docs/commands/index.html)
-- [The main Terraform providers](/docs/providers/index.html)
+The Terraform language is Terraform's primary user interface. This section is relevant to all users of Terraform, including Terraform Cloud and Terraform Enterprise users.
 
-...and much more.
+### [Terraform CLI ➜](/docs/cli-index.html)
+
+Documentation for Terraform's command-line workflows, including docs for [the `terraform` binary and its subcommands](/docs/commands/index.html).
 
 ### [Learn Terraform ➜](https://learn.hashicorp.com/terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) (external site)
 
@@ -42,25 +46,9 @@ Documentation for Terraform's core functionality, including:
 
 Interactive tutorials to teach you how to use Terraform's features. Begin with the [Get Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS), then continue with task-specific tutorials or go directly to the [Terraform CLI docs](/docs/cli-index.html).
 
-### [Guides and Whitepapers ➜](/guides/index.html)
-
--> Intermediate users can go here for a deeper understanding of what's possible with Terraform.
-
-Detailed descriptions of various Terraform workflows, both general and specific. This includes things like:
-
-- [The end-to-end loop of making infrastructure changes with Terraform](/guides/core-workflow.html)
-- [The long-term process of evolving provisioning practices in a large organization](/docs/cloud/guides/recommended-practices/index.html)
-- [Tasks for upgrading to major new Terraform versions](/upgrade-guides/index.html)
-
-This section is devoted to overviews and explanations of complex systems; the goal isn't to teach you how to accomplish a particular task (like the tutorials at [Learn Terraform](https://learn.hashicorp.com/terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)), but to explain best practices and show how the different pieces of a workflow fit together.
-
 </div>
 
 <div class="col-md-6 col-sm-12">
-
-### [Terraform Glossary ➜](/docs/glossary.html)
-
-Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
 
 ### [Terraform Cloud ➜](/docs/cloud/index.html)
 
@@ -77,10 +65,6 @@ Terraform Enterprise is an on-premise distribution of Terraform Cloud. It offers
 ### [Publishing Providers and Modules ➜](/docs/registry/index.html)
 
 Documentation about publishing Terraform providers and modules on the [Terraform Registry](https://registry.terraform.io/).
-
-### [Terraform GitHub Actions ➜](https://learn.hashicorp.com/tutorials/terraform/github-actions?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
-
-Tutorials about using Terraform with GitHub Actions. [GitHub Actions](https://developer.github.com/actions) is GitHub's service for running commands in reaction to events in a Git repository, and HashiCorp publishes a helper action for running Terraform commands against repositories that contain Terraform configurations.
 
 ### [Extending Terraform ➜](/docs/extend/index.html)
 

--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -3,15 +3,14 @@
   skip ||= ""
   header ||= "Other Docs"
   other_docs = {
+    "Terraform Language" => "/docs/configuration/index.html",
     "Terraform CLI" => "/docs/cli-index.html",
     "Terraform Cloud" => "/docs/cloud/index.html",
     "Terraform Enterprise" => "/docs/enterprise/index.html",
     "Provider References" => "/docs/providers/index.html",
     "Terraform Glossary" => "/docs/glossary.html",
     "Introduction to Terraform" => "/intro/index.html",
-    "Guides and Whitepapers" => "/guides/index.html",
     "Publishing Providers and Modules" => "/docs/registry/index.html",
-    "Terraform GitHub Actions" => "https://learn.hashicorp.com/tutorials/terraform/github-actions?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS",
     "Extending Terraform" => "/docs/extend/index.html"
   }
 -%>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -253,15 +253,14 @@
 
             <%
               docs_items = <<-EOT
-                <li><a data-track='docs-home' href="/docs/index.html">Docs Home</a></li>
+                <li><a data-track='docs-home' href="/docs/index.html">About the Docs</a></li>
+                <li><a data-track='docs-language' href="/docs/configuration/index.html">Terraform Language</a></li>
                 <li><a data-track='docs-cli' href="/docs/cli-index.html">Terraform CLI</a></li>
                 <li><a data-track='docs-cloud' href="/docs/cloud/index.html">Terraform Cloud</a></li>
                 <li><a data-track='docs-ent' href="/docs/enterprise/index.html">Terraform Enterprise</a></li>
                 <li><a data-track='docs-providers' href="/docs/providers/index.html">Providers</a></li>
                 <li><a data-track='docs-glossary' href="/docs/glossary.html">Glossary</a></li>
-                <li><a data-track='docs-guides' href="/guides/index.html">Guides and Whitepapers</a></li>
                 <li><a data-track='docs-registry' href="/docs/registry/index.html">Publishing Providers &amp; Modules</a></li>
-                <li><a data-track='docs-gh-actions' href="https://learn.hashicorp.com/tutorials/terraform/github-actions">GitHub Actions</a></li>
                 <li><a data-track='docs-extending' href="/docs/extend/index.html">Extending Terraform</a></li>
               EOT
             %>


### PR DESCRIPTION
**Draft status: This should be merged immediately after Terraform 0.14 is shipped. It's marked as a draft to prevent early merge.**

This PR adjusts several nav elements to accommodate the newly split Terraform Language and Terraform CLI docs, which will go live on 0.14 ship day. 

- Merging this early won't break the site, but will result in confusing/broken top-level navs. 
- Same deal for merging it late.

So, it basically needs to be merged right after the release CI process finishes, but it's not like we're trying to escape a rolling boulder of doom. Within the same hour should be fine. 