### PR TITLE
Post-0.14 release task: Remove symlinks to deleted sidebar navs

### DIFF
--- a/content/source/layouts/backend-types.erb
+++ b/content/source/layouts/backend-types.erb
@@ -1,1 +1,0 @@
-../../../ext/terraform/website/layouts/backend-types.erb

--- a/content/source/layouts/commands-providers.erb
+++ b/content/source/layouts/commands-providers.erb
@@ -1,1 +1,0 @@
-../../../ext/terraform/website/layouts/commands-providers.erb

--- a/content/source/layouts/commands-state.erb
+++ b/content/source/layouts/commands-state.erb
@@ -1,1 +1,0 @@
-../../../ext/terraform/website/layouts/commands-state.erb

--- a/content/source/layouts/commands-workspace.erb
+++ b/content/source/layouts/commands-workspace.erb
@@ -1,1 +1,0 @@
-../../../ext/terraform/website/layouts/commands-workspace.erb

--- a/content/source/layouts/functions.erb
+++ b/content/source/layouts/functions.erb
@@ -1,1 +1,0 @@
-../../../ext/terraform/website/layouts/functions.erb

--- a/content/source/layouts/guides.erb
+++ b/content/source/layouts/guides.erb
@@ -1,1 +1,0 @@
-../../../ext/terraform/website/layouts/guides.erb


### PR DESCRIPTION
**Status: Good to go.**

This PR has no reader-visible effect; it's just an internal cleanup. 

This depends on changes to hashicorp/terraform that happened for the 0.14 launch. 

During the TF-153 work, I removed several nav sidebars from the Terraform docs. These aren't referenced by any pages anymore, and the symlinks will point to nowhere. So we can safely delete them once those changes are part of what we ship to the live site. 