### PR TITLE
redirect /intro/examples/* to learn

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -245,7 +245,7 @@
 # /docs/cloud/free/index.html                             https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview
 # /docs/cloud/free/overview.html                          https://learn.hashicorp.com/collections/terraform/cloud-get-started
 # /intro/examples/index.html                              https://learn.hashicorp.com/terraform
-# /intro/examples/aws.html                                https://learn.hashicorp.com/terraform
+# /intro/examples/aws.html                                https://learn.hashicorp.com/collections/terraform/aws-get-started
 # /intro/examples/consul.html                             https://learn.hashicorp.com/tutorials/consul/terraform-consul-provider
 # /intro/examples/count.html                              https://learn.hashicorp.com/tutorials/terraform/count
 # /intro/examples/cross-provider.html                     https://learn.hashicorp.com/terraform

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -246,7 +246,7 @@
 # /docs/cloud/free/overview.html                          https://learn.hashicorp.com/collections/terraform/cloud-get-started
 # /intro/examples/index.html                              https://learn.hashicorp.com/terraform
 # /intro/examples/aws.html                                https://learn.hashicorp.com/terraform
-# /intro/examples/consul.html                             https://learn.hashicorp.com/terraform
+# /intro/examples/consul.html                             https://learn.hashicorp.com/tutorials/consul/terraform-consul-provider
 # /intro/examples/count.html                              https://learn.hashicorp.com/terraform
 # /intro/examples/cross-provider.html                     https://learn.hashicorp.com/terraform
 

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -243,7 +243,7 @@
 # /docs/providers/aws/guides/iam-policy-documents.html    https://learn.hashicorp.com/terraform/aws/iam-policy
 # /docs/providers/aws/guides/serverless-with-aws-lambda-and-api-gateway.html    https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
 # /docs/cloud/free/index.html                             https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview
-# /docs/cloud/free/overview.html                          https://learn.hashicorp.com/terraform/cloud-gettingstarted/
+# /docs/cloud/free/overview.html                          https://learn.hashicorp.com/collections/terraform/cloud-get-started
 # /intro/examples/index.html                              https://learn.hashicorp.com/terraform
 # /intro/examples/aws.html                                https://learn.hashicorp.com/terraform
 # /intro/examples/consul.html                             https://learn.hashicorp.com/terraform

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -247,7 +247,7 @@
 # /intro/examples/index.html                              https://learn.hashicorp.com/terraform
 # /intro/examples/aws.html                                https://learn.hashicorp.com/terraform
 # /intro/examples/consul.html                             https://learn.hashicorp.com/tutorials/consul/terraform-consul-provider
-# /intro/examples/count.html                              https://learn.hashicorp.com/terraform
+# /intro/examples/count.html                              https://learn.hashicorp.com/tutorials/terraform/count
 # /intro/examples/cross-provider.html                     https://learn.hashicorp.com/terraform
 
 # Most Terraform v0.11 config language doc pages were updated in-place by

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -243,7 +243,12 @@
 # /docs/providers/aws/guides/iam-policy-documents.html    https://learn.hashicorp.com/terraform/aws/iam-policy
 # /docs/providers/aws/guides/serverless-with-aws-lambda-and-api-gateway.html    https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
 # /docs/cloud/free/index.html                             https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview
-# /docs/cloud/free/overview.html                          https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview
+# /docs/cloud/free/overview.html                          https://learn.hashicorp.com/terraform/cloud-gettingstarted/
+# /intro/examples/index.html                              https://learn.hashicorp.com/terraform
+# /intro/examples/aws.html                                https://learn.hashicorp.com/terraform
+# /intro/examples/consul.html                             https://learn.hashicorp.com/terraform
+# /intro/examples/count.html                              https://learn.hashicorp.com/terraform
+# /intro/examples/cross-provider.html                     https://learn.hashicorp.com/terraform
 
 # Most Terraform v0.11 config language doc pages were updated in-place by
 # 0.12 versions, but there is no new equivalent to interpolation.html. We


### PR DESCRIPTION
this is per request from @mildwonkey via helpdesk. 

```
The terraform core team is removing some pages from terraform's website and would like redirect the urls to 
learn.hashicorp.com.

...

Everything under https://www.terraform.io/intro/examples/index.html should redirect to https://learn.hashicorp.com/terraform

That includes:

/intro/examples/index.html
/intro/examples/aws.html
/intro/examples/consul.html
/intro/examples/count.html
/intro/examples/cross-provider.html
```

<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
