### PR TITLE
downloads: Generalize the earlier note about Terraform 0.13

### DIFF
--- a/content/source/downloads.html.erb
+++ b/content/source/downloads.html.erb
@@ -41,7 +41,7 @@ show_notification: false
       </p>
 
       <div class="alert alert-info" role="alert">
-        <p><strong>Note:</strong> When you upgrade to Terraform 0.13, your existing Terraform configurations might need syntax updates. You can make most of these updates automatically with the <code>terraform 0.13upgrade</code> command; for more information, see <a href="/upgrade-guides/0-13.html">Upgrading to Terraform 0.13</a>.</p>
+        <p><strong>Note:</strong> If you're upgrading from an older version of Terraform then there may be some extra notes or upgrade steps. Please refer to the <a href="/upgrade-guides/index.html">Upgrade Guides</a> to learn more.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
There aren't any _mandatory_ upgrade steps for Terraform 0.14 but we still generally advise reviewing the upgrade guides for any relevant notes, so this just generalizes the message to refer to upgrade guides in a version-agnostic way.
