### PR TITLE
Fix persistent nasty bug with navigating to anchor links

### DIFF
--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -51,7 +51,6 @@ document.addEventListener("turbolinks:load", function() {
         if (e.target == this) {
             $(this).toggleClass("active");
         }
-        e.stopPropagation();
     });
     // If the subnav header doesn't link to a different page, use it as a toggle.
     docsSidebar.find("a[href^='#']").on("click", function(e) {

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -188,21 +188,20 @@ document.addEventListener("turbolinks:load", function() {
         });
         // Attach event listeners:
         // Trigger opens and closes.
-        $('#inner-quicknav #inner-quicknav-trigger').on('click', function(e) {
-            $(this).siblings('ul').toggleClass('active');
-            e.stopPropagation();
-        });
-        // Clicking inside the quick-nav doesn't close it.
-        quickNav.on('click', function(e) {
-            e.stopPropagation();
-        });
-        // Jumping to a section means you're done with the quick-nav.
-        quickNav.find('li a').on('click', function() {
-            quickNav.removeClass('active');
-        });
-        // Clicking outside the quick-nav closes it.
-        $('body').on('click', function() {
-            quickNav.removeClass('active');
+        $('body').on('click', function(e) {
+            var $target = $(e.target);
+            if ($target.is('#inner-quicknav #inner-quicknav-trigger')) {
+                // clicking trigger toggles quick-nav.
+                quickNav.toggleClass('active');
+            } else if ($target.is('#inner-quicknav > ul.dropdown li a')) {
+                // Jumping to a section means you're done with quick-nav.
+                quickNav.removeClass('active');
+            } else if ($target.closest(quickNav).length > 0) {
+                // Do nothing, clicking inside quick-nav doesn't close it.
+            } else {
+                // Clicking outside quick-nav closes it.
+                quickNav.removeClass('active');
+            }
         });
     }
 

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -12,8 +12,9 @@
 //= require terraform-overview/hashi-tabbed-content
 
 
-// Be less hurky-jerky when clicking in-same-page anchor links, and just let the
-// browser handle it.
+// TURBOLINKS SETUP/WORKAROUNDS:
+// Let the browser handle anchor links that go to the same page, instead of
+// doing a full turbolinks visit.
 document.addEventListener("turbolinks:click", function(e) {
     var here = document.location;
     var dest = new URL(e.data.url);
@@ -26,27 +27,52 @@ document.addEventListener("turbolinks:click", function(e) {
     }
 });
 
-// When doing a turbolinks visit, handle all the layout changes BEFORE we allow
-// turbolinks to consider itself finished. It calls Element.scrollIntoView() to
-// handle anchor links, and the browser handles that scrolling async without any
-// way to spy on it; if we're modifying the height of the page WHILE the browser
-// is trying to scroll somewhere specific, we clip through the floor and launch
-// ourselves out into the skybox. Anyway, by doing this on the new body element
-// before turbolinks tries to shim it into place, we're finished long before it
-// decides where it's scrolling.
-document.addEventListener("turbolinks:before-render", function(e) {
-    setUpUIFeatures(e.data.newBody);
-});
-
-// Except, the first time we load a page, it's not considered a turbolinks
-// visit! So we need to have a special case handler for initial page load.
+// Initial page load is not considered a turbolinks visit.
 document.addEventListener("DOMContentLoaded", function(_e) {
-    setUpUIFeatures(document.body);
+    setUpPage(document.body);
 });
 
-// Modify the page layout, and set up terraform.io UI features
-function setUpUIFeatures(bodyElement) {
+// Setup can affect the height of the page, so on Turbolinks visits we do it
+// BEFORE replacing the body and (maybe) calling Element.scrollIntoView().
+document.addEventListener("turbolinks:before-render", function(e) {
+    setUpPage(e.data.newBody);
+});
+
+// A few helpful constants:
+var selQuickNav = '#inner-quicknav > ul.dropdown';
+var selDocsSidenavs = '#docs-sidebar ul.nav.docs-sidenav';
+var sidebarControlsHTML =
+    '<div id="sidebar-controls">' +
+        '<div id="sidebar-filter" style="display: none;">' +
+            '<span class="glyphicon glyphicon-search"></span>' +
+            '<label for="sidebar-filter-field" class="sr-only sr-only-focusable">Filter page titles in sidebar navigation</label>' +
+            '<input type="search" id="sidebar-filter-field" class="form-control" name="sidebar-filter-field" role="search" placeholder="Filter page titles" />' +
+            '<button id="filter-close" class="glyphicon glyphicon-remove-circle" title="Reset filter"><span class="sr-only sr-only-focusable">Reset sidebar filter</span></button>' +
+        '</div>' +
+        '<div id="sidebar-buttons">' +
+            '<button id="toggle-button">Expand all</button>' +
+            ' | ' +
+            '<button id="filter-button" title="Shortcut: type the / key">Filter</button>' +
+        '</div>' +
+    '</div>';
+var quickNavHTML =
+    '<div id="inner-quicknav">' +
+        '<span id="inner-quicknav-trigger">' +
+            'Jump to Section' +
+            '<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg>' +
+        '</span>' +
+        '<ul class="dropdown"></ul>' +
+    '</div>';
+
+// Modify the page layout, set up sidebar nav, set up quick-nav. This is
+// idempotent, and might hit a page additional times on back/forward nav.
+function setUpPage(bodyElement) {
     "use strict";
+
+    // Do jQuery selections only within the provided body element
+    var local$ = function(selector) {
+        return $(selector, bodyElement);
+    };
 
     // SIDEBAR STUFF:
     // - "subNavs" are <li> elements with a nested <ul> as a direct child.
@@ -54,205 +80,195 @@ function setUpUIFeatures(bodyElement) {
     // - Subnavs are collapsed (<ul> hidden) or expanded (<ul> visible).
     // - Collapse/expand is managed by the "active" class on the <li>.
 
-    // Move the header (if any) into the grid container so we can make things line up nicely.
-    var sidebarHeaderGrid = $("#sidebar-header-grid", bodyElement);
-    var sidebarHeader = $("#docs-sidebar", bodyElement).find("h1,h2,h3,h4,h5,h6").not("#otherdocs").first();
+    // Move sidebar header (if any) into the grid container so we can make things line up nicely.
+    var sidebarHeaderGrid = local$("#sidebar-header-grid");
+    var sidebarHeader = local$("#docs-sidebar").find("h1,h2,h3,h4,h5,h6").not("#otherdocs").first();
     sidebarHeaderGrid.append(sidebarHeader);
 
-    // Collapse most subnavs, but reveal any that contain the
-    // current page. The a.current-page class is added during build by
-    // layouts/inner.erb.
-    var docsSidebar = $("#docs-sidebar ul.nav.docs-sidenav", bodyElement);
-    var subNavs = docsSidebar.find("ul").addClass("nav-hidden").parent("li");
-        // we leave the nav-hidden class alone after this.
-    function resetActiveSubnavs() {
-        subNavs.removeClass("active");
-        // Activate current page, locked-open navs, and all their ancestors:
-        docsSidebar.find("li").has(".current-page, .nav-visible").addClass("active");
-        // Activate auto-expand navs, but leave their ancestors alone:
-        docsSidebar.find(".nav-auto-expand").parent("li").addClass("active");
-        // Colored links for current page and its ancestors
-        docsSidebar.find("li").has(".current-page").addClass("current");
-    }
-    resetActiveSubnavs();
+    var docsSideNavs = local$(selDocsSidenavs);
 
-    // CSS class that adds toggle controls:
-    subNavs.addClass("has-subnav");
-    // Toggle subnav expansion when clicking an area that isn't claimed by the
-    // header or content (usually the :before pseudo-element)
-    subNavs.on("click", function(e) {
-        if (e.target == this) {
-            $(this).toggleClass("active");
-        }
-    });
-    // If the subnav header doesn't link to a different page, use it as a toggle.
-    docsSidebar.find("a[href^='#']").on("click", function(e) {
-        e.preventDefault();
-        $(this).parent("li").trigger("click");
-    });
+    // Calculate all the classes we'll need later:
+    docsSideNavs.find("ul").addClass("nav-hidden");
+        // (Doing this late so the navs aren't hidden from non-JS users.)
+    // Colored links for current page and its ancestors. (a.current-page
+    // is calculated during build by layouts/inner.erb.)
+    docsSideNavs.find("li").has(".current-page").addClass("current");
+    // The optional .nav-visible class locks open a section and all of its ancestors.
+    docsSideNavs.find('li').has('.nav-visible').addClass('nav-visible');
+    // Add toggle controls:
+    docsSideNavs.find("li").has("ul").addClass("has-subnav");
+
+    // Reveal appropriate sections for current page:
+    // Activate current page, locked-open navs, and all their ancestors:
+    docsSideNavs.find('.current, .nav-visible').addClass('active');
+    // Activate auto-expand navs, but leave their ancestors alone:
+    docsSideNavs.find('.nav-auto-expand').parent('li').addClass('active');
+    // We're specifically NOT removing .active from anything that happens to be
+    // open already, for better behavior on back/forward navs.
 
     // If this is a Very Large Sidebar, add extra controls to expand/collapse
     // and filter it.
-    var sidebarLinks = docsSidebar.find("a");
-    if (sidebarLinks.length > 30) {
-        if ($("#sidebar-controls", bodyElement).length === 0) { // then add it!
-            var sidebarControlsHTML =
-                '<div id="sidebar-controls">' +
-                    '<div id="sidebar-filter">' +
-                        '<span class="glyphicon glyphicon-search"></span>' +
-                        '<label for="sidebar-filter-field" class="sr-only sr-only-focusable">Filter page titles in sidebar navigation</label>' +
-                        '<input type="search" id="sidebar-filter-field" class="form-control" name="sidebar-filter-field" role="search" placeholder="Filter page titles" />' +
-                        '<button id="filter-close" class="glyphicon glyphicon-remove-circle" title="Reset filter"><span class="sr-only sr-only-focusable">Reset sidebar filter</span></button>' +
-                    '</div>' +
-                    '<div id="sidebar-buttons">' +
-                        '<button id="toggle-button">Expand all</button>' +
-                        ' | ' +
-                        '<button id="filter-button" title="Shortcut: type the / key">Filter</button>' +
-                    '</div>' +
-                '</div>';
+    if (local$("#sidebar-controls").length === 0) {
+        var sidebarLinks = docsSideNavs.find("a");
+        if (sidebarLinks.length > 30) {
             sidebarHeaderGrid.append(sidebarControlsHTML);
         }
-
-        var filterDiv = $("div#sidebar-filter", bodyElement);
-        var buttonsDiv = $("div#sidebar-buttons", bodyElement);
-        var subnavToggle = $("#sidebar-controls #toggle-button", bodyElement);
-        var filterField = $("#sidebar-controls input#sidebar-filter-field", bodyElement);
-        var filterButton = $("#filter-button", bodyElement);
-
-        filterDiv.hide();
-
-        filterButton.on("click", function(e) {
-            buttonsDiv.hide();
-            filterDiv.show();
-            filterField.focus();
-        });
-
-        // Filter field's close button: defer to reset button.
-        $("#filter-close", bodyElement).on("click", function(e) {
-            subnavToggle.trigger("reset");
-        });
-
-        // Expand/reset button behavior:
-        subnavToggle.on({
-            "taint": function(e) {
-                $(this).html("Reset");
-            },
-            "reset": function(e) {
-                filterField.val("");
-                filterField.trigger("blur");
-                sidebarLinks.parent("li").show();
-                resetActiveSubnavs();
-                $(this).html("Expand all");
-                buttonsDiv.show();
-                filterDiv.hide();
-            },
-            "click": function(e) {
-                e.preventDefault();
-                if ($(this).text() === "Expand all") {
-                    subNavs.addClass("active");
-                    $(this).trigger("taint");
-                } else {
-                    $(this).trigger("reset");
-                }
-            }
-        });
-
-        // Filter as you type. This alters three things:
-        // - "active" class on subnavs
-        // - direct show/hide of <li>s
-        // - state of subnavToggle button
-        // We rely on subnavToggle's "reset" event to clean up when done.
-        filterField.on('keyup', function(e) {
-            if (e.keyCode === 27) { // escape key
-                subnavToggle.trigger("reset");
-            } else {
-                subnavToggle.trigger("taint");
-                var filterRegexp = new RegExp(filterField.val(), 'i');
-                var matchingLinks = sidebarLinks.filter(function(index) {
-                    return $(this).text().match(filterRegexp);
-                });
-                sidebarLinks.parent('li').hide();
-                subNavs.removeClass('active'); // cleans up partial as-you-type searches
-                // make matches and their parents visible and expanded:
-                matchingLinks.parents('li').show().filter(subNavs).addClass('active');
-                // make direct children visible (if your search caught a subnav directly):
-                matchingLinks.parent('li').find('li').show();
-            }
-        });
-        // Type slash to focus sidebar filter:
-        $(bodyElement).keydown(function(e) {
-            // 191 = / (forward slash) key
-            if (e.keyCode !== 191) {
-                return;
-            }
-            var focusedElementType = $(document.activeElement).get(0).tagName.toLowerCase();
-            if (focusedElementType !== "textarea" && focusedElementType !== "input") {
-                e.preventDefault();
-                filterButton.trigger("click");
-            }
-        });
     }
 
-
-    // Move the main title into the grid container, so we can make things line up nicely.
-    var innerHeaderGrid = $('#inner-header-grid', bodyElement);
-    innerHeaderGrid.append( $("#inner h1", bodyElement).first() );
+    // MAIN BODY STUFF:
+    // Move main title into the grid container, so we can make things line up nicely.
+    var innerHeaderGrid = local$('#inner-header-grid');
+    innerHeaderGrid.append( local$("#inner h1").first() );
 
     // On docs/content pages, add a hierarchical quick nav menu if there are
     // more than two H2/H3/H4 headers.
-    var headers = $('#inner', bodyElement).find('h2, h3, h4');
-    if (headers.length > 2 && $("div#inner-quicknav", bodyElement).length === 0) {
-        // Build the quick-nav HTML:
-        innerHeaderGrid.append(
-            '<div id="inner-quicknav">' +
-                '<span id="inner-quicknav-trigger">' +
-                    'Jump to Section' +
-                    '<svg width="9" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z" fill-rule="evenodd"/></svg>' +
-                '</span>' +
-                '<ul class="dropdown"></ul>' +
-            '</div>'
-        );
-        var quickNav = $('#inner-quicknav > ul.dropdown', bodyElement);
-        headers.each(function(index, element) {
-            var level = element.nodeName.toLowerCase();
-            var header_text = $(element).text();
-            var header_id = $(element).attr('id');
-            quickNav.append('<li class="level-' + level + '"><a href="#' + header_id + '">' + header_text + '</a></li>');
+    if (local$("div#inner-quicknav").length === 0) {
+        var headers = local$('#inner').find('h2, h3, h4');
+        if (headers.length > 2) {
+            // Build the quick-nav HTML:
+            innerHeaderGrid.append(quickNavHTML);
+            var quickNav = local$(selQuickNav);
+            headers.each(function(index, element) {
+                var a = document.createElement('a');
+                a.setAttribute('href', '#' + element.id);
+                a.textContent = element.innerText;
+
+                var li = document.createElement('li');
+                li.className = 'level-' + element.nodeName.toLowerCase();
+                li.append(a);
+
+                quickNav.append(li);
+            });
+        }
+    }
+}
+
+// This doesn't have any state of its own, it's just a place to collect all the
+// ways we can change the state of the whole nav sidebar at once.
+var sidebarController = {
+    reset: function() {
+        $('#sidebar-filter-field').trigger("blur").val("");
+        $(selDocsSidenavs).find("li").show();
+        this.expandDefaults();
+        $('#toggle-button').html("Expand all");
+        $('#sidebar-buttons').show();
+        $('#sidebar-filter').hide();
+    },
+    expandAll: function() {
+        this.enableReset();
+        $(selDocsSidenavs).find('li').addClass('active');
+    },
+    expandDefaults: function() {
+        var docsSideNavs = $(selDocsSidenavs);
+        // Reset everything to inactive. .has-subnav is added during setup.
+        docsSideNavs.find('.has-subnav').removeClass("active");
+        // Activate current page, locked-open navs, and all their ancestors. (These
+        // classes propagate to ancestors during setup.)
+        docsSideNavs.find('.current, .nav-visible').addClass('active');
+        // Activate auto-expand navs, but leave their ancestors alone:
+        docsSideNavs.find('.nav-auto-expand').parent('li').addClass('active');
+    },
+    enableReset: function() {
+        $('#toggle-button').html("Reset");
+    },
+    showFilter: function() {
+        this.enableReset();
+        $('#sidebar-buttons').hide();
+        $('#sidebar-filter').show();
+        $('#sidebar-filter-field').focus();
+    },
+    // Filter as you type. This alters three things:
+    // - "active" class on subnavs
+    // - direct show/hide of <li>s
+    // - state of #toggle-button
+    performFilter: function() {
+        var filterRegexp = new RegExp($('#sidebar-filter-field').val(), 'i');
+        var sidebarLinks = $(selDocsSidenavs).find('a');
+        var matchingLinks = sidebarLinks.filter(function(index) {
+            return $(this).text().match(filterRegexp);
         });
-        // Attach event listeners:
-        // Trigger opens and closes.
-        $(bodyElement).on('click', function(e) {
-            var $target = $(e.target);
-            if ($target.is('#inner-quicknav #inner-quicknav-trigger')) {
-                // clicking trigger toggles quick-nav.
-                quickNav.toggleClass('active');
-            } else if ($target.is('#inner-quicknav > ul.dropdown li a')) {
-                // Jumping to a section means you're done with quick-nav.
-                quickNav.removeClass('active');
-            } else if ($target.closest(quickNav).length > 0) {
-                // Do nothing, clicking inside quick-nav doesn't close it.
-            } else {
-                // Clicking outside quick-nav closes it.
-                quickNav.removeClass('active');
-            }
-        });
+        sidebarLinks.parent('li').hide();
+        $(selDocsSidenavs).find('li').removeClass('active'); // cleans up partial as-you-type searches
+        // make matches and their parents visible and expanded:
+        matchingLinks.parents('li').show().addClass('active');
+        // make direct children visible (if your search caught a subnav directly):
+        matchingLinks.parent('li').find('li').show();
+    },
+};
+
+// These event handlers only need to be set up once, and get re-used when
+// navigating via turbolinks.
+$(document).on('click', function(e) {
+    var target = $(e.target);
+    var quickNav = $(selQuickNav);
+    var learnCta = target.parents(".download").find(".learn-cta");
+
+    // SIDEBAR/MISC STUFF:
+    if ( target.is('.has-subnav') ) {
+        // toggle arrow toggles its subnav.
+        target.toggleClass('active');
+    } else if ( target.is(".has-subnav > a[href^='#']") ) {
+        // links that don't go anywhere act as toggle controls.
+        e.preventDefault();
+        target.parent().toggleClass('active');
+    } else if ( target.is('#filter-button') ) {
+        sidebarController.showFilter();
+    } else if ( target.is('#filter-close') ) {
+        sidebarController.reset();
+    } else if ( target.is('#toggle-button') ) {
+        // the expand/reset button
+        if ( $('#toggle-button').text() === "Expand all" ) {
+            sidebarController.expandAll();
+        } else {
+            sidebarController.reset();
+        }
+    } else if ( target.is('section.downloads .details a') ) {
+        // Learn CTAs on downloads page
+        // Terminate early if user is downloading same OS different arch
+        if ( ! learnCta.hasClass("show") ) {
+            // When downloading first time or for an additional OS: show
+            // the relevant CTA (hiding others)
+            $("section.downloads .learn-cta").removeClass("show");
+            learnCta.addClass("show");
+        }
     }
 
-    // Downloads CTA
-    var $downloadLinks = $("section.downloads .details a", bodyElement);
-    var $learnCtas = $("section.downloads .learn-cta", bodyElement);
-    $downloadLinks.on("click", function () {
-        var $learnCta = $(this).parents(".download").find(".learn-cta");
+    // QUICK-NAV STUFF: (not mutually exclusive w/ sidebar stuff, due to the final 'else')
+    if (target.closest('#inner-quicknav-trigger').length > 0) {
+        // clicking trigger (or its svg child) toggles quick-nav.
+        quickNav.toggleClass('active');
+    } else if (target.is('#inner-quicknav > ul.dropdown li a')) {
+        // Jumping to a section means you're done with quick-nav.
+        quickNav.removeClass('active');
+    } else if (target.closest(quickNav).length > 0) {
+        // clicking inside quick-nav doesn't close it.
+        // Do nothing.
+    } else {
+        // Clicking outside quick-nav closes it.
+        quickNav.removeClass('active');
+    }
+});
 
-        // Terminate early if user is downloading same OS different arch
-        if ($learnCta.hasClass("show")) return;
+// Typing in the filter field filters the sidebar; escape key quits.
+$(document).on('keyup', function(e) {
+    if ( e.target === document.getElementById('sidebar-filter-field') ) {
+        if (e.keyCode === 27) { // escape key
+            sidebarController.reset();
+        } else {
+            sidebarController.performFilter();
+        }
+    }
+});
 
-        // When downloading first first time or for an additional OS
-        $learnCtas.each(function () {
-        $(this).removeClass("show");
-        });
-
-        $learnCta.addClass("show");
-    });
-
-}
+// Type slash to start filtering the sidebar.
+$(document).on('keydown', function(e) {
+    // 191 = / (forward slash) key
+    if (e.keyCode !== 191) {
+        return;
+    }
+    var focusedElementType = document.activeElement.tagName;
+    if (focusedElementType !== "TEXTAREA" && focusedElementType !== "INPUT") {
+        e.preventDefault();
+        sidebarController.showFilter();
+    }
+});

--- a/content/source/assets/javascripts/application.js
+++ b/content/source/assets/javascripts/application.js
@@ -12,6 +12,20 @@
 //= require terraform-overview/hashi-tabbed-content
 
 
+// Be less hurky-jerky when clicking in-same-page anchor links, and just let the
+// browser handle it.
+document.addEventListener("turbolinks:click", function(e) {
+    var here = document.location;
+    var dest = new URL(e.data.url);
+    if ( here.origin === dest.origin
+      && here.pathname === dest.pathname
+      && here.search === dest.search )
+    {
+        // cancel the turbolinks visit. Doesn't affect "real" click event.
+        e.preventDefault();
+    }
+});
+
 // When doing a turbolinks visit, handle all the layout changes BEFORE we allow
 // turbolinks to consider itself finished. It calls Element.scrollIntoView() to
 // handle anchor links, and the browser handles that scrolling async without any


### PR DESCRIPTION
Or, How I Learned to Stop Worrying and Love the Turbolinks.

Turbolinks changes the lifecycle of a normal web page in completely bizarre ways, and I didn't have a good handle on it when I originally implemented some of our features. That had some wild knock-on effects, the most visible of which was that navigating to an in-page anchor was outrageously unreliable. 

Petros reminded me of that earlier today, and I resolved to finally figure out what the heck. So the upshot is: 

- It's not safe to modify the page's layout in any meaningful way within a `turbolinks:load` event handler. The docs encourage you to do that, but it's a TRAP. There's a point earlier in the process where it's safe to move things around, but then you also need to register separate handlers for initial page load and for turbolinks transitions. 
    - So I did that. That fixed the anchor link problem.
- I was accidentally exempting some links from turbolinks behavior, so links from the sidebar felt slower than links from body text. 
- Added a _deliberate_ exemption for anchor links within the same page; turbolinks doesn't need to interact with those at all, the browser can just handle it. This makes anchor links somewhat more resilient, but mostly just saves some wasted HTTP calls. 
- The whole point of turbolinks is to re-use all the work you did when initially setting up a page, rather than throwing it out and starting fresh. So I refactored the JS to not re-create all my event handlers on every page transition.

Anyway, everything should feel a bit less janky now. 