### PR TITLE
Fix audit trail API pagination parameters

### DIFF
--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -38,6 +38,8 @@ The audit trails API exposes a stream of audit events, which describe changes to
 
 ### Query Parameters
 
+[These are standard URL query parameters](../index.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
 | Parameter | Description                                                                                                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `since`   | **Optional.** Returns only audit trails created after this date (UTC and in [ISO8601 Format](https://www.iso.org/iso-8601-date-and-time-format.html) - YYYY-MM-DDTHH:MM:SS.SSSZ) |

--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -41,7 +41,8 @@ The audit trails API exposes a stream of audit events, which describe changes to
 | Parameter | Description                                                                                                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `since`   | **Optional.** Returns only audit trails created after this date (UTC and in [ISO8601 Format](https://www.iso.org/iso-8601-date-and-time-format.html) - YYYY-MM-DDTHH:MM:SS.SSSZ) |
-| `page`    | **Optional.** If omitted, the endpoint will return the first page.                                                                                                               |
+`page[number]`      | **Optional.** If omitted, the endpoint will return the first page.
+`page[size]`        | **Optional.** If omitted, the endpoint will return 1000 audit events per page.                                                                                                             |
 
 ### Sample Request
 
@@ -49,7 +50,7 @@ The audit trails API exposes a stream of audit events, which describe changes to
 $ curl \
   --header "Authorization: Bearer $TOKEN" \
   --request GET \
-  https://app.terraform.io/api/v2/organization/audit-trail?page=1&since=2020-05-30T17:52:46.000Z
+  https://app.terraform.io/api/v2/organization/audit-trail?page[number]=1&since=2020-05-30T17:52:46.000Z
 ```
 
 ### Sample Response

--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -50,7 +50,7 @@ The audit trails API exposes a stream of audit events, which describe changes to
 $ curl \
   --header "Authorization: Bearer $TOKEN" \
   --request GET \
-  https://app.terraform.io/api/v2/organization/audit-trail?page[number]=1&since=2020-05-30T17:52:46.000Z
+  "https://app.terraform.io/api/v2/organization/audit-trail?page[number]=1&since=2020-05-30T17:52:46.000Z"
 ```
 
 ### Sample Response


### PR DESCRIPTION
API supports the normal pagination parameters `page[size]`/`page[number]`, not `page`. `since` is fine