### PR TITLE
Include back medium nav buttons, adjust a footer link

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -290,6 +290,44 @@
                       <%= docs_items %>
                     </ul>
                   </li>
+                  <li class="visible-sm">
+                    <span>
+                      <a href="/index.html">Info</a>
+                      <svg
+                        width="9"
+                        height="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.811 1.067a.612.612 0 0 0 0-.884.655.655 0 0 0-.908 0L4.5 3.491 1.097.183a.655.655 0 0 0-.909 0 .615.615 0 0 0 0 .884l3.857 3.75a.655.655 0 0 0 .91 0l3.856-3.75z"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                    <ul class="dropdown">
+                      <li>
+                        <a
+                          data-track="registry"
+                          href="https://registry.terraform.io/"
+                        >
+                          Registry
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          data-track="learn"
+                          href="https://learn.hashicorp.com/terraform/?utm_source=terraform_io"
+                        >
+                          Tutorials
+                        </a>
+                      </li>
+                      <li>
+                        <a data-track="community" href="/community.html">
+                          Community
+                        </a>
+                      </li>
+                    </ul>
+                  </li>
                   <li class="hidden-sm"><a data-track='community' href="/community.html">Community</a></li>
                   <li>
                     <a data-track='github' href="https://github.com/hashicorp/terraform">
@@ -327,7 +365,7 @@
         <div class="row">
           <div class="col-xs-12">
             <ul class="footer-links nav navbar-nav">
-              <li><a href="/intro/index.html">Intro</a></li>
+              <li><a href="/">Overview</a></li>
               <li><a href="/docs/index.html">Docs</a></li>
               <li><a href="/docs/extend/index.html">Extend</a></li>
               <li><a href="https://www.hashicorp.com/privacy">Privacy</a></li>


### PR DESCRIPTION
Ensure that all of the nav links appear at medium size within the Info dropdown.

![CleanShot 2020-12-11 at 10 09 49@2x](https://user-images.githubusercontent.com/2105067/101939519-f3211a00-3b99-11eb-8faa-df43f4c38fd8.png)

Additionally, this PR includes one tiny footer adjustment to align with the nav.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
