### PR TITLE
Fix testAccCheckExampleResourceExists in example codes

### DIFF
--- a/content/source/docs/extend/best-practices/testing.html.md
+++ b/content/source/docs/extend/best-practices/testing.html.md
@@ -159,8 +159,11 @@ func testAccCheckExampleResourceExists(n string, widget *example.Widget) resourc
 
 		// If no error, assign the response Widget attribute to the widget pointer
 		*widget = *resp.Widget
+		if *widget == nil {
+			return fmt.Errorf("Widget (%s) not found", rs.Primary.ID)
+		}
 
-		return fmt.Errorf("Widget (%s) not found", rs.Primary.ID)
+		return nil
 	}
 }
 

--- a/content/source/docs/extend/best-practices/testing.html.md
+++ b/content/source/docs/extend/best-practices/testing.html.md
@@ -157,11 +157,12 @@ func testAccCheckExampleResourceExists(n string, widget *example.Widget) resourc
 			return err
 		}
 
-		// If no error, assign the response Widget attribute to the widget pointer
-		*widget = *resp.Widget
-		if *widget == nil {
+		if resp.Widget == nil {
 			return fmt.Errorf("Widget (%s) not found", rs.Primary.ID)
 		}
+
+		// assign the response Widget attribute to the widget pointer
+		*widget = *resp.Widget
 
 		return nil
 	}


### PR DESCRIPTION
Hi, I am implementing my terraform provider while referencing community's docs. I appreciate helpful documents, but, I found strange code in below page.

- https://www.terraform.io/docs/extend/best-practices/testing.html#basic-test-to-verify-attributes

The strange code is below function.

```go
// testAccCheckExampleResourceExists queries the API and retrieves the matching Widget.
func testAccCheckExampleResourceExists(n string, widget *example.Widget) resource.TestCheckFunc {
    return func(s *terraform.State) error {
        // find the corresponding state object
        rs, ok := s.RootModule().Resources[n]
        if !ok {
            return fmt.Errorf("Not found: %s", n)
        }

        // retrieve the configured client from the test setup
        conn := testAccProvider.Meta().(*ExampleClient)
        resp, err := conn.DescribeWidget(&example.DescribeWidgetsInput{
            WidgetIdentifier: rs.Primary.ID,
        })

        if err != nil {
            return err
        }

        // If no error, assign the response Widget attribute to the widget pointer
        *widget = *resp.Widget

        return fmt.Errorf("Widget (%s) not found", rs.Primary.ID)
    }
}
```

`testAccCheckExampleResourceExists` is TestCheckFunc, bud it method always returns `error`.
I believe that `testAccCheckExampleResourceExists` returns nil if there is `widget`.
I would appreciate it if you could check this changes.


Regards,

<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
