### PR TITLE
Updating unknown values changes section to incl. interpolated values

### DIFF
--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -172,7 +172,7 @@ following exceptions:
 
 Unknown values within `applied` in the
 [resource namespace](./import/tfplan.html#namespace-resources-data-sources)
-no longer return interpolated values, or the magic UUID (defined as
+no longer return values with interpolation sequences, or the magic UUID (defined as
 `74D93920-ED26-11E3-AC10-0800200C9A66` in Terraform 0.11 or earlier). Instead,
 unknown values are now returned as `undefined`.
 

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -172,7 +172,7 @@ following exceptions:
 
 Unknown values within `applied` in the
 [resource namespace](./import/tfplan.html#namespace-resources-data-sources)
-no longer return the magic UUID value (defined as
+no longer return interpolated values, or the magic UUID (defined as
 `74D93920-ED26-11E3-AC10-0800200C9A66` in Terraform 0.11 or earlier). Instead,
 unknown values are now returned as `undefined`.
 
@@ -184,6 +184,7 @@ within the [diff
 namespace](./import/tfplan.html#namespace-resource-diff)
 to validate whether or not a value is unknown before looking for it in
 `applied`.
+
 
 ### Changes Affecting Resources Being Destroyed but not Re-created
 


### PR DESCRIPTION
This PR includes a minor change to the [Using Sentinel with Terraform 0.12](https://www.terraform.io/docs/cloud/sentinel/sentinel-tf-012.html) section to call out that when a Terraform value is computed, we will no longer provide an interpolated value. This was the default behavior prior to Terraform 0.12.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
