### PR TITLE
CircleCI: Reconfigure Slack notifications with orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+orbs:
+  # Slack orb v. 3 uses a webhook URL for auth. If upgrading to v. 4+, we'll need a token instead.
+  slack: circleci/slack@3.4.2
+
 references:
   images:
     middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
@@ -25,10 +29,18 @@ jobs:
 
       - run: make website-test
 
+      - slack/status:
+          success_message: ":white_check_mark: Finished link check for branch. :meow_yay: No broken links!"
+          failure_message: ":broken_image: Found broken links when checking branch."
+
   website-build-and-upload:
     docker:
       - image: *MIDDLEMAN_IMAGE
     steps:
+      - slack/notify:
+          message: ":terraform-loading: Starting build/deploy for terraform.io..."
+          color: "#ECB942"
+
       - checkout
 
       # pull and update git submodules
@@ -58,6 +70,10 @@ jobs:
           working_directory: content
           command: ./scripts/upload.sh
 
+      - slack/status:
+          success_message: ":terraformda: Successfully deployed to terraform.io."
+          failure_message: ":boom: Failed to deploy terraform.io! Urgent attention needed! <!here>"
+
   website-warm-cache-check-links:
     docker:
       - image: *MIDDLEMAN_IMAGE
@@ -67,6 +83,9 @@ jobs:
           name: Warm cache and check for broken links
           command: wget --delete-after --level inf --no-directories --no-host-directories --no-verbose --page-requisites --recursive --spider "https://www.terraform.io/"
 
+      - slack/status:
+          success_message: ":white_check_mark: Finished warming cache for terraform.io. :meow_yay: No broken links!"
+          failure_message: ":broken_image: Found broken links while warming cache for terraform.io. For details, check job log and :command:-F for 'broken'."
 
 workflows:
   linkcheck:


### PR DESCRIPTION
Circle's built-in Slack notifications (which are apparently deprecated anyhow)
only notify once at the end of the workflow, so we don't get the benefit from
splitting the deploy linkcheck jobs -- it's always just one cryptic red block in
our channel.

But the Slack orb is more configurable, and lets us give more informative
messages on a per-job basis! In fact, we can even do _multiple_  messages per
job, which will be nice for letting people know that their deploy is WIP.

## Considerations:

I'll need to use the Circle API to delete the legacy Slack configs, because they disabled the UI for that. I'm pretty sure I have the necessary permissions, I'll just go ahead and do it once this PR is approved. 

## Screenz:

The old notifications: (note that for this one, the deploy succeeded but the whole notification is red because of broken links.) 

![Screen Shot 2020-12-14 at 4 43 24 PM](https://user-images.githubusercontent.com/484309/102155376-4f9d6700-3e30-11eb-9cd4-1139e4d63ed1.png)

Testing the new notifications: (I tweaked some of the text after taking this screenshot, and added an `@here` mention to the deploy failure since it's a fairly dire circumstance that deserves broad notice.)

![Screen Shot 2020-12-14 at 4 42 47 PM](https://user-images.githubusercontent.com/484309/102155577-ab67f000-3e30-11eb-9dcd-e9377d1c98a1.png)