### PR TITLE
Circle configs: Fix broken YAML indentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,9 @@ workflows:
     # run on branches and PRs; ignore master, since the cache warming also checks links.
     jobs:
       - website-test:
-        filters:
-          branches:
-            ignore: master
+          filters:
+            branches:
+              ignore: master
   website-deploy:
     # only run on main branch
     jobs:


### PR DESCRIPTION
This kept the filter from blocking that job on the master branch.
