### PR TITLE
Circle configs: replace wget with linkcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ references:
   images:
     middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
     ubuntu: &UBUNTU_IMAGE ubuntu-1604:201903-01
+    # We rely on dart-lang/sdk commit 7e7c01e804179782f884b174706ed0c80fb2ef71
+    # -- earliest viable container version is 2.11.0-182.0.dev
+    dart: &DART docker.mirror.hashicorp.services/google/dart:2.12.0-133.2.beta
 
   cache:
     rubygem: &RUBYGEM_CACHE_KEY static-site-gems-v1-{{ checksum "content/Gemfile.lock" }}
@@ -76,16 +79,21 @@ jobs:
 
   website-warm-cache-check-links:
     docker:
-      - image: *MIDDLEMAN_IMAGE
+      - image: *DART
     steps:
-      # Don't need gems or anything
+      # TODO: This should be in the container, but we want to get the kinks
+      # worked out before committing to the overhead. Also the install takes 3s.
+      - run:
+          name: install filiph/linkcheck
+          command: pub global activate linkcheck
+
       - run:
           name: Warm cache and check for broken links
-          command: wget --delete-after --level inf --no-directories --no-host-directories --no-verbose --page-requisites --recursive --spider "https://www.terraform.io/"
+          command: /root/.pub-cache/bin/linkcheck https://www.terraform.io/
 
       - slack/status:
           success_message: ":white_check_mark: Finished warming cache for terraform.io. :meow_yay: No broken links!"
-          failure_message: ":broken_image: Found broken links while warming cache for terraform.io. For details, check job log and :command:-F for 'broken'."
+          failure_message: ":broken_image: Found broken links while warming cache for terraform.io. For details, check job log."
 
 workflows:
   linkcheck:

--- a/content/source/layouts/_sidebar.erb
+++ b/content/source/layouts/_sidebar.erb
@@ -9,7 +9,7 @@
     <li><a data-track='overview' href="/">Overview</a></li>
     <li><a data-track='registry' href="https://registry.terraform.io">Registry</a></li>
     <li><a data-track='learn' href="https://learn.hashicorp.com/terraform/">Tutorials</a></li>
-    <li><a data-track='community' href="/community.html">Community</a></li>
+    <li><a data-track='community' href="/community">Community</a></li>
     <li><a data-track='github' href="https://github.com/hashicorp/terraform">GitHub</a></li>
     <li><a data-track='download-cli' href="/downloads.html">Download CLI</a></li>
   </ul>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -292,7 +292,7 @@
                   </li>
                   <li class="visible-sm">
                     <span>
-                      <a href="/index.html">Info</a>
+                      <a href="/">Info</a>
                       <svg
                         width="9"
                         height="5"
@@ -322,13 +322,13 @@
                         </a>
                       </li>
                       <li>
-                        <a data-track="community" href="/community.html">
+                        <a data-track="community" href="/community">
                           Community
                         </a>
                       </li>
                     </ul>
                   </li>
-                  <li class="hidden-sm"><a data-track='community' href="/community.html">Community</a></li>
+                  <li class="hidden-sm"><a data-track='community' href="/community">Community</a></li>
                   <li>
                     <a data-track='github' href="https://github.com/hashicorp/terraform">
                       GitHub


### PR DESCRIPTION
(This commit also updates a couple links in the site header navs. Just a no-op to skip an unnecessary redirect.)

After deploys for terraform.io, we've been using `wget` in spider mode to
simultaneously warm up the Fastly cache and report on any broken links. It's
okay at the cache thing, but its reporting of broken links is abysmal -- most
notably, it doesn't tell you what pages the broken links CAME from, only the
failed destination URL.

[filiph/linkcheck](https://github.com/filiph/linkcheck) (Dart) gives much better
reporting, and still visits every page on the site to warm the cache.

We need to use a beta version of the Dart SDK for running it, because we need a
recent fix for recognizing 308 codes (sent by Vercel, currently just for the
marketing pages) as redirects. Details are in the yaml file.

We considered some other options:

- [linkchecker](https://github.com/linkchecker/linkchecker) (Python) gives
  similar quality of results, but is an order of magnitude slower.
- muffet (Go) (and our wrapper around it) can't be configured to stay within a
  single site, so we get noise from external hosts that don't want to be
  spidered. (Yeah, it doesn't recurse into external sites, but at the frequency
  we're running this task, I don't even really want to hit the top-level links.)