### PR TITLE
Fix redirecting tfe provider links in glossary

### DIFF
--- a/content/source/docs/glossary.html.md
+++ b/content/source/docs/glossary.html.md
@@ -105,7 +105,7 @@ Terraform relies on cloud service provider APIs to manage resources; each servic
 Terraform Cloud also offers its own API, for managing resources like team membership, policies, and workspaces. That API, in turn, is used by the `tfe` Terraform provider, so you can use Terraform to manage the system that runs Terraform for you.
 
 - [Terraform Cloud docs: API](/docs/cloud/api/index.html)
-- [Terraform providers: `tfe`](/docs/providers/tfe/index.html)
+- [Terraform providers: `tfe`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs)
 
 ## Apply (noun)
 
@@ -902,7 +902,7 @@ A particular version of the `terraform` binary available for use in Terraform Cl
 
 A Terraform provider that manages Terraform Cloud. Allows you to manage Terraform Cloud using a Terraform [configuration][].
 
-- [Provider docs: tfe](/docs/providers/tfe/index.html)
+- [Provider docs: tfe](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs)
 
 ## (API) Token
 


### PR DESCRIPTION
I caught all these in the TFC/TFE/Extend docs, but missed the glossary. 

With that, I think I've updated ALLLLL of the redirecting or bad-anchor links in content and navs, in this repo, terraform core, and terraform-website-next. (There's a PR up over there for the last few.) 

...WITH ONE BIG EXCEPTION, in the provider docs index pages. Because there's another thing in progress with those, so I don't want to mess with them out of band. 