### PR TITLE
Redirect provider category indexes to main provider docs page

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -588,3 +588,14 @@
 # /intro/examples/count           https://learn.hashicorp.com/terraform
 # /intro/examples/cross-provider  https://learn.hashicorp.com/terraform
 # /intro/examples/                https://learn.hashicorp.com/terraform
+
+# Removing the lists of provider docs
+/docs/providers/type/cloud-index.html          /docs/providers/index.html
+/docs/providers/type/community-index.html      /docs/providers/index.html
+/docs/providers/type/database-index.html       /docs/providers/index.html
+/docs/providers/type/infra-index.html          /docs/providers/index.html
+/docs/providers/type/major-index.html          /docs/providers/index.html
+/docs/providers/type/misc-index.html           /docs/providers/index.html
+/docs/providers/type/monitor-index.html        /docs/providers/index.html
+/docs/providers/type/network-index.html        /docs/providers/index.html
+/docs/providers/type/vcs-index.html            /docs/providers/index.html

--- a/content/scripts/testdata/incoming-links.txt
+++ b/content/scripts/testdata/incoming-links.txt
@@ -259,10 +259,6 @@
 /docs/providers/statuscake/index.html
 /docs/providers/terraform/d/remote_state.html
 /docs/providers/terraform/index.html
-/docs/providers/type/cloud-index.html
-/docs/providers/type/community-index.html
-/docs/providers/type/major-index.html
-/docs/providers/type/network-index.html
 /docs/providers/ultradns/index.html
 /docs/provisioners/chef.html
 /docs/provisioners/connection.html


### PR DESCRIPTION
I recently deleted the category indexes from terraform core, and shrank the main
provider docs page to match the current situation, with just a list of ten
temporary legacy providers and an explanation of docs in the registry.