### PR TITLE
Improved PR link checking, finally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,24 +17,42 @@ references:
 
 jobs:
   website-test:
-    machine:
-      image: *UBUNTU_IMAGE
+    docker:
+      - image: *MIDDLEMAN_IMAGE
     steps:
       - checkout
 
-      - run:
-          name: gem and bundle install
-          command: |
-            gem install bundler -v '1.17.3' --no-document
-            bundle _1.17.3_ install --jobs=3 --retry=3
-
       - run: make sync
 
-      - run: make website-test
+      # restores gem cache
+      - restore_cache:
+          key: *RUBYGEM_CACHE_KEY
 
-      - slack/status:
-          success_message: ":white_check_mark: Finished link check for branch. :meow_yay: No broken links!"
-          failure_message: ":broken_image: Found broken links when checking branch."
+      - run:
+          name: install gems
+          working_directory: content
+          command: bundle check || bundle install --path vendor/bundle --retry=3
+
+      # saves gem cache if we have changed the Gemfile
+      - save_cache:
+          key: *RUBYGEM_CACHE_KEY
+          paths:
+            - content/vendor/bundle
+
+      - run:
+          name: run middleman in background
+          working_directory: content
+          background: true
+          command: bundle exec middleman server
+
+      - run:
+          name: wait for server to start
+          command: until curl -sS http://localhost:4567/ > /dev/null; do sleep 1; done
+
+      - run:
+          name: check links in changed pages
+          working_directory: content
+          command: git diff --name-only --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
 
   website-build-and-upload:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ references:
     rubygem: &RUBYGEM_CACHE_KEY static-site-gems-v1-{{ checksum "content/Gemfile.lock" }}
 
 jobs:
-  website-test:
+  website-link-check:
     docker:
       - image: *MIDDLEMAN_IMAGE
     steps:
@@ -114,10 +114,10 @@ jobs:
           failure_message: ":broken_image: Found broken links while warming cache for terraform.io. For details, check job log."
 
 workflows:
-  linkcheck:
+  website-test:
     # run on branches and PRs; ignore master, since the cache warming also checks links.
     jobs:
-      - website-test:
+      - website-link-check:
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,15 @@ jobs:
       - run:
           name: check links in changed pages
           working_directory: content
-          command: git diff --name-only --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
+          command: git diff --name-only -z --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
+            # --name-only: Return a list of affected files but don't show the changes.
+            # -z: Make that a null-separated list (instead of newline-separated), and
+            #     DON'T mangle non-ASCII characters.
+            # --diff-filter=AMRCT: Only list files that were added, modified, renamed,
+            #     copied, or had their type changed (file, symlink, etc.). In
+            #     particular, we don't want to check deleted files.
+            # $(git merge-base HEAD origin/master)..HEAD: Only consider files that have
+            #     changed since this branch diverged from master.
 
   website-build-and-upload:
     docker:

--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+require 'nokogiri'
+require 'open-uri'
+
+# Takes a list of source files to check, piped to STDIN.
+# from content directory:
+# git diff --name-only --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
+
+# content/source/ for terraform-website, website/ for terraform
+site_root_paths = %r[^(content/source/|website/)]
+# middleman mostly accepts any combination of those extensions
+page_extensions = /(\.(html|markdown|md))+$/
+
+ARGF.set_encoding('utf-8')
+input = ARGF.read
+input_files = input.split("\n")
+input_files.reject! {|f| f !~ site_root_paths || f !~ page_extensions}
+
+puts "Checking URLs in the following pages:"
+input_files.each {|input_file|
+  puts "- #{input_file}"
+}
+
+errors = {}
+
+input_files.each {|input_file|
+  errors[input_file] = []
+  input_url = input_file.sub(site_root_paths, 'http://localhost:4567/').sub(page_extensions, '.html')
+
+  begin
+    page_html = open(input_url)
+  rescue
+    errors[input_file] << "Couldn't open page at all; something's extra-wrong."
+    next
+  end
+
+  page = Nokogiri::HTML(page_html)
+
+  links = page.css('#inner a').map {|a|
+    next if a.attributes['href'].nil?
+    a.attributes['href'].value
+  }.compact
+
+  links.each {|link|
+    link_url = URI.join(input_url, link) # Automatically handles relative vs. absolute vs. abs+protocol stuff
+
+    begin
+      link_html = open(link_url)
+    rescue OpenURI::HTTPError => e
+      error_code = e.io.status.join(' ')
+      errors[input_file] << "  - Broken link: #{link} [#{error_code}] \n    (checked URL: #{link_url})"
+      next
+    end
+
+    anchor = link_url.fragment
+    if (anchor)
+      link_page = Nokogiri::HTML(link_html)
+
+      # anchor fragments can contain characters that are illegal in #id selectors (like '.'),
+      # so we need to use an attribute selector with a quoted value instead.
+      if ( link_page.css("[id='#{anchor}']", "a[name='#{anchor}']").length == 0 )
+        errors[input_file] << "  - Missing anchor: #{link} \n    (checked URL: #{link_url})"
+      end
+    end
+  }
+}
+
+errors.reject! {|file, problems| problems.empty?}
+
+puts "\n\nResults:"
+
+if (errors.empty?)
+  puts "=== No broken links! ==="
+else
+  puts "=== Found broken links! ===\nFix before merging... or if they're not really broken, explain why.\n\n"
+  errors.each {|file, problems|
+    puts file
+    puts problems.join("\n")
+    puts ""
+  }
+  exit 1
+end

--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -1,83 +1,131 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'nokogiri'
-require 'open-uri'
+require 'net/http'
+require 'erb'
 
-# Takes a list of source files to check, piped to STDIN.
-# from content directory:
-# git diff --name-only --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
+# Takes a list of source files to check on STDIN, and checks against a webserver
+# at localhost:4567. File list can be separated with nulls or newlines. You
+# usually want null-separated, because Git commands can do strange things to
+# file names with non-ASCII characters unless you pass -z.
 
-# content/source/ for terraform-website, website/ for terraform
-site_root_paths = %r[^(content/source/|website/)]
-# middleman mostly accepts any combination of those extensions
+# Suggested use (from "content" directory):
+# git diff --name-only -z --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD \
+#   | bundle exec ./scripts/check-pr-links.rb
+
+# Only checking files in website content.
+# Main content dir is "content/source/" for terraform-website, "website/" for terraform.
+site_root_paths = %r{^(content/source/|website/)}
+# Only checking files that get turned into web pages, which usually have some
+# combination of these extensions (like ".html.md")
 page_extensions = /(\.(html|markdown|md))+$/
 
 ARGF.set_encoding('utf-8')
 input = ARGF.read
-input_files = input.split("\n")
-input_files.reject! {|f| f !~ site_root_paths || f !~ page_extensions}
+input_files = input.split(/\x00|\n/)
+input_files.reject! { |f| f !~ site_root_paths || f !~ page_extensions }
 
-puts "Checking URLs in the following pages:"
-input_files.each {|input_file|
+puts 'Checking URLs in the following pages:'
+input_files.each do |input_file|
   puts "- #{input_file}"
-}
+end
 
 errors = {}
 
-input_files.each {|input_file|
-  errors[input_file] = []
-  input_url = input_file.sub(site_root_paths, 'http://localhost:4567/').sub(page_extensions, '.html')
+# takes a `URI` object, returns [ok, html-or-error]
+def check_link(url)
+  response = Net::HTTP.get_response(url)
 
-  begin
-    page_html = open(input_url)
-  rescue
-    errors[input_file] << "Couldn't open page at all; something's extra-wrong."
+  # Only 200s are "ok"; if it successfully redirects, you should still fix it anyway.
+  if response.code == '200'
+    [true, response.body]
+  else
+    [false, "[#{response.code} #{response.message.strip}] #{url}"]
+  end
+rescue StandardError => e
+  # HTTP errors aren't exceptions, so this is a network problem: bad hostname,
+  # host is timing out, or whole network is hosed. These can be SLOW, and I
+  # don't want the job to look stuck. So in addition to reporting the error in
+  # its proper time, log to the console NOW so the user knows what's up.
+  exception_message = "[#{e.class} - #{e.message.strip}] #{url}"
+  puts "!! Got a network error: #{exception_message}"
+  puts '   Probably a bad hostname or a server timeout, but might be network trouble.'
+  [false, exception_message]
+end
+
+# returns boolean
+def check_anchor(html, anchor)
+  page = Nokogiri::HTML(html)
+  # anchor fragments can contain characters that are illegal in #id selectors (like '.'),
+  # so we need to use an attribute selector with a quoted value instead.
+  !page.css("[id='#{anchor}']", "a[name='#{anchor}']").empty?
+rescue StandardError
+  # Nokogiri throws errors on totally invalid selectors, so in the event that we
+  # get some bizarro anchor that escapes the quoting or something in that
+  # interpolation, just report it as a broken link instead of exploding the
+  # whole run.
+  false
+end
+
+# Returns array of link destination strings, which is probably a mix of relative
+# and absolute paths, URLs, and bare #anchors that resolve to the same page.
+# Notably, we only check within the page content area (#inner); that's because
+# for PR checks we desperately want to avoid irrelevant alerts, and the content
+# area is always relevant.
+def find_links(html)
+  page = Nokogiri::HTML(html)
+  page.css('#inner a').reject { |a| a.attributes['href'].nil? }.map { |a| a.attributes['href'].value }
+end
+
+input_files.each do |input_file|
+  errors[input_file] = []
+  # Ruby has no stdlib equivalent of `encodeURI()`. There are several things like
+  # `encodeURIComponent()`, and ERB::Util.url_encode is the one that properly
+  # escapes spaces as %20.
+  url_string = input_file.split('/').map { |s| ERB::Util.url_encode(s) }.join('/')
+  url_string.sub!(site_root_paths, 'http://localhost:4567/')
+  url_string.sub!(page_extensions, '.html')
+  input_url = URI(url_string)
+
+  ok, result = check_link(input_url)
+
+  unless ok
+    errors[input_file] << "  - Couldn't open page at all; something's extra-wrong.\n    #{result}"
     next
   end
 
-  page = Nokogiri::HTML(page_html)
+  find_links(result).each do |link|
+    # The URI class can just handle path traversal math for us, yay.
+    link_url = URI.join(input_url, link)
+    link_ok, link_result = check_link(link_url)
 
-  links = page.css('#inner a').map {|a|
-    next if a.attributes['href'].nil?
-    a.attributes['href'].value
-  }.compact
-
-  links.each {|link|
-    link_url = URI.join(input_url, link) # Automatically handles relative vs. absolute vs. abs+protocol stuff
-
-    begin
-      link_html = open(link_url)
-    rescue OpenURI::HTTPError => e
-      error_code = e.io.status.join(' ')
-      errors[input_file] << "  - Broken link: #{link} [#{error_code}] \n    (checked URL: #{link_url})"
+    unless link_ok
+      errors[input_file] << "  - Broken link: #{link}\n    #{link_result}"
       next
     end
 
     anchor = link_url.fragment
-    if (anchor && link_html)
-      link_page = Nokogiri::HTML(link_html)
+    next unless anchor
 
-      # anchor fragments can contain characters that are illegal in #id selectors (like '.'),
-      # so we need to use an attribute selector with a quoted value instead.
-      if ( link_page.css("[id='#{anchor}']", "a[name='#{anchor}']").length == 0 )
-        errors[input_file] << "  - Missing anchor: #{link} \n    (checked URL: #{link_url})"
-      end
+    unless check_anchor(link_result, anchor)
+      errors[input_file] << "  - Missing anchor: #{link} \n    (checked URL: #{link_url})"
     end
-  }
-}
+  end
+end
 
-errors.reject! {|file, problems| problems.empty?}
+errors.reject! { |_file, problems| problems.empty? }
 
 puts "\n\nResults:"
 
-if (errors.empty?)
-  puts "=== No broken links! ==="
+if errors.empty?
+  puts '=== No broken links! ==='
 else
   puts "=== Found broken links! ===\nFix before merging... or if they're not really broken, explain why.\n\n"
-  errors.each {|file, problems|
+  errors.each do |file, problems|
     puts file
     puts problems.join("\n")
-    puts ""
-  }
+    puts ''
+  end
   exit 1
 end

--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -121,7 +121,9 @@ puts "\n\nResults:"
 if errors.empty?
   puts '=== No broken links! ==='
 else
-  puts "=== Found broken links! ===\nFix before merging... or if they're not really broken, explain why.\n\n"
+  puts "=== Found broken links! ==="
+  puts "Fix before merging... or if they're not really broken, explain why."
+  puts "(NOTE: This script reports false positives for Vercel app routes like /cloud. Sorry!)\n\n"
   errors.each do |file, problems|
     puts file
     puts problems.join("\n")

--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -54,7 +54,7 @@ input_files.each {|input_file|
     end
 
     anchor = link_url.fragment
-    if (anchor)
+    if (anchor && link_html)
       link_page = Nokogiri::HTML(link_html)
 
       # anchor fragments can contain characters that are illegal in #id selectors (like '.'),


### PR DESCRIPTION
Well, I think I've figured out how to make our pull request checks usable: 

- Use Git to figure out which files were changed. 
- Spin up a preview server. 
- Translate the changed file paths to page URLs.
- Grab each changed page and use Nokogiri to find all the links _in the docs content area_ (ignoring other areas of the page like the top nav and sidebar nav). 
- Check every link and report HTTP errors.
- For links that include an `#anchor`, use Nokogiri to make sure the destination page actually includes that anchor. 

## For reviewers

I need at least two reviewers: 

- A Ruby reviewer
- A CircleCI (with funky Git + Bash stuff) reviewer

If you only want to review one part, go ahead and treat the other as a black box. 

I also need the CircleCI reviewer to take a look at the similar-but-more-complicated companion PR in the Terraform core repo: 

- https://github.com/hashicorp/terraform/pull/27404

## Screenshot

The output in Circle ends up looking like this, if you have broken links: 

![Screenshot_2021-01-04 Step - website-test (1942) - hashicorp terraform-website](https://user-images.githubusercontent.com/484309/103601645-ec4aa600-4ebe-11eb-80b0-8ddc437d888d.png)

## The big old commit message

I already wrote all the explanations up for posterity, so I'll just paste it in here. 

CI: Add more trustworthy link checking for pull requests (details below)

This commit adds a Ruby script and a CircleCI workflow for checking links in
*only the changed files* on a branch. The goal is to give a clear signal if you
introduce new broken links in a PR, with a minimum of false positives or (real)
problems that are unrelated to your changes.

DETAILS AND CAVEATS:

- We rely on Git to decide which files we're checking, and we calculate it
  differently in by repo:

    - In terraform-website, we compare against the most recent common ancestor
      of the PR branch and master.

    - In terraform core, not everything merges to master (due to long-lived
      branches like v0.14), so we need to figure out which branch you're
      probably PRing to first.

- This only checks links in the *content area* of docs pages. It doesn't check
  nav sidebars or the top/bottom navs.

- No special handling for the new Vercel routes, so links to those from content
  will be false positives. Probably revisiting this later, but should be OK for
  an MVP since most docs content doesn't link heavily to the marketing pages.

- We don't implement redirects... but you should update those links to their
  new destinations anyway.

- There are some easy optimization targets in the script that I didn't bother
  reaching for; caching, basically. Easy to add later, but right now the script
  time is WAY overshadowed by container pull and checkout time, so who cares.

CONTEXT AND REASONING:

We do a global, spidering link check for terraform.io whenever we deploy the
site. But a global link check sucks for pull requests:

- It catches links that have *nothing to do* with your PR, and which you, the PR
  author, might not have the power to do anything about.

- Since it has to use a one-off build of the site to check changed pages that
  aren't live yet, we either get false positives due to not implementing prod
  behaviors (redirects, new routes for marketing content) or have to
  re-implement those behaviors in a different stack.

- Does lots of pointless extra work.

So our current PR link checking is useless, mostly due to the "someone else did
that" issue and the false positives for top nav items and redirects -- it's
always red and never actionable, so we just ignore it.

After investigating a bunch of alternatives, it turned out that the easiest
fix was to just write my own link checker script from semi-scratch in Ruby. I
realize that sounds outrageous, but:

- If you have a decent URL library and HTML parsing/scraping library, there's
  not much left to write. I got the prototype working in an afternoon.
  Re-implementing when we switch to Next shouldn't be much worse; if anything,
  the JS platform's tools should be better.

- Adding Nokogiri to your dependencies is a legendary recipe for pain, but we
  already HAD it because of Middleman, so no extra overhead.

- On the other hand, getting any OTHER language ecosystem into our existing
  Middleman container would require rearchitecting that container from the
  ground up.

- It might have been possible to run the site build in one container and an
  off-the-shelf link checker in a second container, but networking two
  containers together in a CI job seems quite complicated.

- It might have been possible to use Vercel or Netlify to do PR previews, ping
  their API to wait for the preview to come up, then run a link checker in a
  single container. This still might be a reasonable approach for the future,
  but required more platform investment (which was hard to justify for Middleman
  stuff).

- None of the off-the-shelf link checkers I investigated (about five or six of
  them) met my requirements for PR checks (accept a list of pages to check,
  scrape their links but don't spider any further than one level, check for
  broken anchors as well as 404s, etc.), so they would have required some
  additional tooling anyway, probably at a similar level of effort/complexity as
  this new script.
