### PR TITLE
Add private registry port to network-requirements

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -24,6 +24,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 
 * **2003:** Graphite (Carbon) feeding port (monitoring, metrics)
 * **2004:** Graphite (Carbon) feeding port (monitoring, metrics)
+* **3121:** TFE private registry
 * **4150-4151, 4160-4161, 4170-4171:** Replicated NSQD (messaging platform daemon for internal communication)
 * **5432:** PostgreSQL
 * **5672:** RabbitMQ TFE worker coordination


### PR DESCRIPTION
The private registry services listens on 3121 and needs ingress from the TFE server.

## Labels

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
