### PR TITLE
Fix name of behavior functions in docs

### DIFF
--- a/content/source/docs/extend/schemas/schema-behaviors.html.md
+++ b/content/source/docs/extend/schemas/schema-behaviors.html.md
@@ -294,7 +294,7 @@ provider "example" {
 ### StateFunc
 **Data structure:** [SchemaStateFunc](https://github.com/hashicorp/terraform-plugin-sdk/blob/9f0df37a8fdb2627ae32db6ceaf7f036d89b6768/helper/schema/schema.go#L306-L308)    
 
-`SchemaStateFunc` is a function used to convert the value of this element to a string to be stored in the state. 
+`StateFunc` is a function used to convert the value of this element to a string to be stored in the state. 
 
 
 **Schema example:**
@@ -332,7 +332,7 @@ Value in statefile:
 
 - Only works with primitive types  
 
-`SchemaValidateFunc` is a function used to validate the value of a primitive type. Common use cases include ensuring an integer falls within a range or a string value is present in a list of valid options. The function returns two slices; the first for warnings, the second for errors which can be used to catch multiple invalid cases. Terraform will only halt execution if an error is returned. Returning warnings will warn the user but the data provided is considered valid.
+`ValidateFunc` is a function used to validate the value of a primitive type. Common use cases include ensuring an integer falls within a range or a string value is present in a list of valid options. The function returns two slices; the first for warnings, the second for errors which can be used to catch multiple invalid cases. Terraform will only halt execution if an error is returned. Returning warnings will warn the user but the data provided is considered valid.
 
 Terraform includes a number of validators for use in plugins in the validation package. A full list can be found here: https://godoc.org/github.com/hashicorp/terraform-plugin-sdk/helper/validation 
 


### PR DESCRIPTION
`SchemaStateFunc` is the name of the _type_, and I think the docs meant to refer to `StateFunc` as the function that can be passed. Likewise for  `SchemaValidateFunc`.

## Labels

- [x] cosmetic bug - fixing broken text or markup