### PR TITLE
Website StackMenu updates for 1/14

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -176,14 +176,14 @@
                         <h5 class="stackGroupHeading">HashiCorp Cloud Platform</h5>
                         <ul class="stackGroupLinkList">
                           <li class="stackItem">
-                          <a href="https://www.hashicorp.com/cloud-platform" class="itemLink">
+                          <a href="https://cloud.hashicorp.com/" class="itemLink">
                           <img
                               src="/assets/images/product-icons/consul-icon-color.svg"
                               class="productIcon"
                               alt="consul by HashiCorp"
                             />
                             <span class="productName itemName">consul</span>
-                            <span class="badge">Public Beta</span>
+                            <span class="badge">Generally Available</span>
                             </a>
                         </li>
                           <li class="stackItem">
@@ -196,13 +196,13 @@
                             >
                           </li>
                           <li class="stackItem">
-                            <a href="https://www.hashicorp.com/cloud-platform" class="itemLink"
+                            <a href="https://cloud.hashicorp.com/" class="itemLink"
                               ><img
                                 src="/assets/images/product-icons/vault-icon-color.svg"
                                 class="productIcon"
                                 alt="vault by HashiCorp"
                               /><span class="productName itemName">vault</span>
-                              <span class="badge">Private Beta</span>
+                              <span class="badge">Public Beta</span>
                               </a
                             >
                           </li>


### PR DESCRIPTION
A small version bump to the HashiStackMenu (formally known as the MegaNav) for 1/14 updates.