### PR TITLE
Add information around paginating API query

### DIFF
--- a/content/source/docs/cloud/api/teams.html.md
+++ b/content/source/docs/cloud/api/teams.html.md
@@ -42,6 +42,15 @@ Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to list teams from.
 
+### Query Parameters
+
+This endpoint supports pagination [with standard URL query parameters](./index.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+Parameter      | Description
+---------------|------------
+`page[number]` | **Optional.** If omitted, the endpoint will return the first page.
+`page[size]`   | **Optional.** If omitted, the endpoint will return 20 runs per page.
+
 ### Sample Request
 
 ```shell


### PR DESCRIPTION
As of the `v202011-1` release of Terraform Enterprise, this API endpoint is now paginated. 

This was added in https://github.com/hashicorp/atlas/pull/9785, however, the documentation was not updated to reflect it.

Asana for the change: https://app.asana.com/0/157256879238414/1189562539380073
