### PR TITLE
PR link check: add special casing for Vercel routes

### DIFF
--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -42,6 +42,11 @@ errors = {}
 
 # takes a `URI` object, returns [ok, html-or-error]
 def check_link(url)
+  # Ignore non-web protocols like mailto:
+  unless url.scheme == 'https' || url.scheme == 'http'
+    return [true, 'Not an HTTP(S) URL']
+  end
+
   # Special case for Vercel routes: can't check them against a local build, so
   # change URL to check prod.
   if url.path =~ VERCEL_REGEXP && url.to_s =~ /^#{ROOT_URL}/

--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -43,9 +43,7 @@ errors = {}
 # takes a `URI` object, returns [ok, html-or-error]
 def check_link(url)
   # Ignore non-web protocols like mailto:
-  unless url.scheme == 'https' || url.scheme == 'http'
-    return [true, 'Not an HTTP(S) URL']
-  end
+   return [true, 'Not an HTTP(S) URL'] unless url.scheme == 'https' || url.scheme == 'http'
 
   # Special case for Vercel routes: can't check them against a local build, so
   # change URL to check prod.


### PR DESCRIPTION
This should help avoid false positives for the path prefixes that get served by
the Next/Vercel app in production. Unfortunately there's not a good way to
discover which paths that currently applies to, but at the time of writing it's
just /cloud and /community, and by the time they expand it much further, we'll
probably be looking to throw this script away anyhow.

This PR also includes a fix to ignore non-HTTP(S) URL protocols like mailto:.