### PR TITLE
Revamp the README for the current state of the world

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the build infrastructure and some of the content for [t
 - [Writing Normal Docs Content](#writing-normal-docs-content)
 - [Screenshots](#screenshots)
 - [Navigation Sidebars](#navigation-sidebars)
-- [Basics of Using Submodules](#basics-of-using-submodules)
+- [Using Submodules](#using-submodules)
 - [Finding Broken Links](#finding-broken-links)
 - [More about `stable-website`](#more-about-stable-website)
 
@@ -255,11 +255,11 @@ A lot of existing sidebars have a ton of ERB tags that call a `sidebar_current` 
 
 You don't need to add anything special to a sidebar to get the dynamic JavaScript open/close behavior, but note that the "expand all" and filter controls are only added for sidebars with more than a certain number of links.
 
-## Basics of Using Submodules
+## Using Submodules
 
 ↥ [back to top](#table-of-contents)
 
-[inpage-submodules]: #basics-of-using-submodules
+[inpage-submodules]: #using-submodules
 
 Right now, the only submodule that matters much is the one for hashicorp/terraform. (We used to have a lot more, back when we hosted the documentation for most providers on terraform.io.)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Docs live in a couple different repos. (**To find a page the easy way:** view it
 
 - **For changes in this repo:** Merge the PR to master, and the site will automatically deploy in about 20m. 🙌
 - **For changes in hashicorp/terraform:** Merge the PR to master. Then, either:
-    - Wait for the next release of the project in question. The changes will be deployed automatically.
+    - Wait for the next Terraform release. The changes will be deployed automatically.
     - If you don't want to wait for a release, cherry-pick the commit(s) to that repo's `stable-website` branch and push. Then, either:
         - Wait for the next unrelated site deploy (probably happening in a couple hours), which will pick up your changes automatically.
         - Do a manual CircleCI build or ask someone in the #proj-terraform-docs channel to do so.
@@ -286,7 +286,7 @@ All of these jobs are configured in `./circleci/config.yml`, in this repo and in
 We run a global link check for the whole site after every deploy.
 
 - **Where:** The job reports its status in the `#proj-terraform-docs` channel in Hashicorp's Slack.
-- **What:** This job only checks internal links within terraform.io, not external links to the rest of the web. (We deploy a _lot,_ and we don't want to be a nuisance on someone else's servers.)
+- **What:** This job only checks internal links within terraform.io, not external links to the rest of the web. (It runs frequently, and we don't want to be a nuisance.)
 - **Who:** The Terraform Education team is ultimately responsible for dealing with any broken links this turns up, but anyone in the channel is welcome to fix something if they see it first!
 - **How:** We're using [filiph/linkcheck](https://github.com/filiph/linkcheck/) for this. In addition to checking links, this also warms up the Fastly cache for the site.
 
@@ -297,7 +297,7 @@ We run a targeted link check for docs PRs, in this repo and in hashicorp/terrafo
 - **Where:** It shows up as a GitHub PR check. It only runs for PRs from people in the HashiCorp GitHub organization (which should be fine, since we're the most likely to change a bunch of links at once.)
 - **What:** This job only checks links in the _content area_ (not navs/headers) of _pages that were changed in the current PR._ It checks both internal and external links.
 - **Who:** If this job is red in your PR, please fix your broken links before merging! Alternately, if it throws a false-positive and complains about a link that is actually fine, make sure to explain that before merging.
-- **How:** This is a custom-built Ruby script, because we weren't able to find an off-the-shelf link checker that met our requirements (i.e. don't complain about problems that have nothing to do with this PR).
+- **How:** This is a custom Ruby script, because we weren't able to find an off-the-shelf link checker that met our requirements (i.e. don't complain about problems that have nothing to do with this PR). ([content/scripts/check-pr-links.rb](./content/scripts/check-pr-links.rb))
 
 ### Known Incoming Link Check
 
@@ -306,7 +306,7 @@ We run a weekly check to make sure we don't delete popular pages without redirec
 - **Where:** The job reports its status mid-morning (PST) every Monday, in the `#proj-terraform-docs` channel in Hashicorp's Slack.
 - **What:** This job checks a list of paths from the `content/scripts/testdata/incoming-links.txt` file.
 - **Who:** The Terraform Education team is ultimately responsible for dealing with any broken links this turns up, but anyone in the channel is welcome to fix something if they see it first!
-- **How:** This is a custom-built shell script that uses `wget`.
+- **How:** This is a custom shell script that uses `wget`. ([content/scripts/check-incoming-links.sh](./content/scripts/check-incoming-links.sh))
 
 ## More About `stable-website`
 


### PR DESCRIPTION
- Provider submodules are ALMOST dead!
- New info about link checking is much simpler.
- Make sure we mention the Vercel routes somewhere up top.

The weekly incoming linkcheck info depends on https://github.com/hashicorp/terraform-website/pull/1592. 