### PR TITLE
Adding troubleshutting for unmigrated local state file

### DIFF
--- a/content/source/docs/cloud/migrate/index.html.md
+++ b/content/source/docs/cloud/migrate/index.html.md
@@ -120,3 +120,9 @@ If all went well, the plan should result in no changes or very small changes. Te
 
     In the case of a wrong state file, you can recover by fixing your local working directory and trying again. You'll need to re-set to the local backend, run `terraform init`, replace the state file with the correct one, change back to the `remote` backend, run `terraform init` again, and confirm that you want to replace the remote state with the current local state.
 - If the plan recognizes the existing resources but would make unexpected changes, check whether the designated VCS branch for the workspace is the same branch you've been running Terraform on; if not, update it. You can also check whether variables in the Terraform Cloud workspace have the correct values.
+
+- If you got a message like _"Setup failed: Terraform Cloud detected a terraform.tfstate file"_ when run `terraform plan` or `terraform apply` **after** changing a working directory to use remote backend instead of local and ran successfuly `terraform init` with no confirmation messages at all, your local state file probably was not migrated to cloud because it was empty from resources. To workarround this, follow this steps:
+  - Comment your recently applied remote backend config;
+  - Apply your terraform infrastructure;
+  - Uncomment the remote backend config;
+  - Rerun this tutorial starting form [step 6](#step-6-run-terraform-init-to-migrate-the-workspace) 


### PR DESCRIPTION
Following the [learning docs](https://learn.hashicorp.com/tutorials/terraform/azure-outputs?in=terraform/azure-get-started) the `Store Remote State` step presumes that you have the previous infrastructure up - what can be different if you get playing around as I did -.-' - and if you follow it's instructions with your infrastructure destroyed, you will face a false success result because your state couldn't migrate to Terraform Cloud as it's empty.

I didn't found too many tips about that on the internet.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
