### PR TITLE
Registry/provider sunset transition

### DIFF
--- a/terraform/external-redirects.csv
+++ b/terraform/external-redirects.csv
@@ -312,3 +312,21 @@ azure classic - to azurerm,/docs/providers/azure/r/storage_container.html,https:
 azure classic - to azurerm,/docs/providers/azure/r/storage_queue.html,https://registry.terraform.io/providers/hashicorp/azurerm/latest
 azure classic - to azurerm,/docs/providers/azure/r/storage_service.html,https://registry.terraform.io/providers/hashicorp/azurerm/latest
 azure classic - to azurerm,/docs/providers/azure/r/virtual_network.html,https://registry.terraform.io/providers/hashicorp/azurerm/latest
+chef - to github,/docs/providers/chef/r/environment.html,https://github.com/hashicorp/terraform-provider-chef/blob/stable-website/website/docs/r/environment.html.markdown
+chef - to github,/docs/providers/chef/r/data_bag_item.html,https://github.com/hashicorp/terraform-provider-chef/blob/stable-website/website/docs/r/data_bag_item.html.markdown
+chef - to github,/docs/providers/chef/r/data_bag.html,https://github.com/hashicorp/terraform-provider-chef/blob/stable-website/website/docs/r/data_bag.html.markdown
+chef - to github,/docs/providers/chef/r/node.html,https://github.com/hashicorp/terraform-provider-chef/blob/stable-website/website/docs/r/node.html.markdown
+chef - to github,/docs/providers/chef/r/role.html,https://github.com/hashicorp/terraform-provider-chef/blob/stable-website/website/docs/r/role.html.markdown
+chef - to github,/docs/providers/chef/index.html,https://github.com/hashicorp/terraform-provider-chef/blob/stable-website/website/docs/index.html.markdown
+genymotion - to github,/docs/providers/genymotion/r/genymotion_cloud.html,https://github.com/hashicorp/terraform-provider-genymotion/blob/stable-website/website/docs/r/genymotion_cloud.html.markdown
+genymotion - to github,/docs/providers/genymotion/index.html,https://github.com/hashicorp/terraform-provider-genymotion/blob/stable-website/website/docs/index.html.markdown
+mysql - to github,/docs/providers/mysql/r/grant.html,https://github.com/hashicorp/terraform-provider-mysql/blob/stable-website/website/docs/r/grant.html.markdown
+mysql - to github,/docs/providers/mysql/r/user_password.html,https://github.com/hashicorp/terraform-provider-mysql/blob/stable-website/website/docs/r/user_password.html.markdown
+mysql - to github,/docs/providers/mysql/r/role.html,https://github.com/hashicorp/terraform-provider-mysql/blob/stable-website/website/docs/r/role.html.markdown
+mysql - to github,/docs/providers/mysql/r/user.html,https://github.com/hashicorp/terraform-provider-mysql/blob/stable-website/website/docs/r/user.html.markdown
+mysql - to github,/docs/providers/mysql/r/database.html,https://github.com/hashicorp/terraform-provider-mysql/blob/stable-website/website/docs/r/database.html.markdown
+mysql - to github,/docs/providers/mysql/index.html,https://github.com/hashicorp/terraform-provider-mysql/blob/stable-website/website/docs/index.html.markdown
+rubrik - to github,/docs/providers/rubrik/r/assign_sla.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/r/assign_sla.html.markdown
+rubrik - to github,/docs/providers/rubrik/r/configure_timezone.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/r/configure_timezone.html.markdown
+rubrik - to github,/docs/providers/rubrik/index.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/index.html.markdown
+rubrik - to github,/docs/providers/rubrik/d/cluster_version.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/d/cluster_version.html.markdown

--- a/terraform/fastly.tf
+++ b/terraform/fastly.tf
@@ -48,6 +48,7 @@ resource "fastly_service_dictionary_items_v1" "tf_provider_namespaces_dictionary
     "akamai" : "akamai/akamai"
     "alicloud" : "aliyun/alicloud"
     "auth0" : "alexkappa/auth0"
+    "avi": "vmware/avi"
     "aviatrix" : "AviatrixSystems/aviatrix"
     "azuredevops" : "microsoft/azuredevops"
     "baiducloud" : "baidubce/baiducloud"
@@ -82,6 +83,7 @@ resource "fastly_service_dictionary_items_v1" "tf_provider_namespaces_dictionary
     "huaweicloudstack" : "huaweicloud/huaweicloudstack"
     "icinga2" : "Icinga/icinga2"
     "incapsula" : "imperva/incapsula"
+    "infoblox": "infobloxopen/infoblox"
     "ksyun" : "kingsoftcloud/ksyun"
     "lacework" : "lacework/lacework"
     "launchdarkly" : "launchdarkly/launchdarkly"
@@ -111,6 +113,7 @@ resource "fastly_service_dictionary_items_v1" "tf_provider_namespaces_dictionary
     "profitbricks" : "ionos-cloud/profitbricks"
     "rabbitmq" : "cyrilgdn/rabbitmq"
     "rancher2" : "rancher/rancher2"
+    "rundeck": "rundeck/rundeck"
     "scaleway" : "scaleway/scaleway"
     "selectel" : "selectel/selectel" # unverified
     "signalfx" : "splunk-terraform/signalfx"

--- a/terraform/fastly.tf
+++ b/terraform/fastly.tf
@@ -58,7 +58,7 @@ resource "fastly_service_dictionary_items_v1" "tf_provider_namespaces_dictionary
     "cloudamqp" : "cloudamqp/cloudamqp"
     "cloudflare" : "cloudflare/cloudflare"
     "cloudscale" : "cloudscale-ch/cloudscale"
-    "cobbler" : "cobber/cobbler"
+    "cobbler" : "cobbler/cobbler"
     "constellix" : "Constellix/constellix"
     "datadog" : "DataDog/datadog"
     "digitalocean" : "digitalocean/digitalocean"


### PR DESCRIPTION
This PR will merge all of the updated Fastly redirect rules to master. The `registry/provider-sunset-transition` branch will receive NO further commits, so it's safe to land!

## Context

The provider docs redirects are part of the site's Fastly configuration, and they're managed by a Terraform configuration contained right here in this repo. That configuration gets applied by a TFC workspace. 

Since TFC wasn't able to handle the ridiculous number of submodules we used to have (200+), we couldn't use it to run the configuration from the master branch. We wanted to share responsibility for runs without having to hand out Fastly credentials, so we switched the workspace to do remote operations, but pointed at a special branch (`registry/provider-sunset-transition`) where all of the provider submodules were prematurely removed. 

To redirect a new provider (at time of writing we're down to eight), we merge Terraform changes to that special branch. 

Once we're done, and all the provider submodules have been removed, we want to make sure the Terraform configuration gets updated in the master branch. We'll probably want to leave this special branch abandoned and just bring over the changes to fastly.tf.