### PR TITLE
Add missing redirect for /docs/commands/state/index.html

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -870,6 +870,9 @@
 /docs/commands/graph.html                   /docs/cli/commands/graph.html
 /docs/commands/output.html                  /docs/cli/commands/output.html
 /docs/commands/show.html                    /docs/cli/commands/show.html
+/docs/commands/state/index.html             /docs/cli/commands/state/list.html
+/docs/commands/state/                       /docs/cli/commands/state/list.html
+/docs/commands/state                        /docs/cli/commands/state/list.html
 /docs/commands/state/list.html              /docs/cli/commands/state/list.html
 /docs/commands/state/show.html              /docs/cli/commands/state/show.html
 /docs/import/index.html                     /docs/cli/import/index.html


### PR DESCRIPTION
I think I know why I missed this one, but it's a boring story.

There weren't any more links to this page (in either terraform or terraform-website) that needed updates. 