### PR TITLE
Cut old content in HCL1 from AWS RA

### DIFF
--- a/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
@@ -186,15 +186,7 @@ provided by AWS.
 
 The recommended way to deploy Terraform Enterprise is through use of a Terraform configuration
 that defines the required resources, their references to other resources, and associated
-dependencies. An [example Terraform
-configuration](https://github.com/hashicorp/private-terraform-enterprise/blob/master/examples/aws/pes/main.tf)
-is provided to demonstrate how these resources can be provisioned and how they
-interrelate. This Terraform configuration assumes the required networking
-components are already in place. If you are creating networking components for
-this installation, an [example Terraform configuration is available for
-the networking
-resources](https://github.com/hashicorp/private-terraform-enterprise/blob/master/examples/aws/network/main.tf)
-as well.
+dependencies.
 
 ## Normal Operation
 


### PR DESCRIPTION
As the ever-perspicacious @alexbasista found, the example linked in the AWS RA points to an example of deployment which is in HCL1 format which has not been updated in 3 years.  I vote that, like the other RAs which do not have the equivalent old content linked, this should be removed, especially as suitable replacements are being worked on.

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
