### PR TITLE
update audit-trails.html.md

### DIFF
--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -55,6 +55,8 @@ $ curl \
   "https://app.terraform.io/api/v2/organization/audit-trail?page[number]=1&since=2020-05-30T17:52:46.000Z"
 ```
 
+> Do not substiute ***/organization/*** in the uri. Reminder: only an [organization token](../users-teams-organizations/api-tokens.html#organization-api-tokens) can be used to perform the request into Audit Trails API.
+
 ### Sample Response
 
 ```json


### PR DESCRIPTION
- Add md blockquote to Sample Request header informing Terraform Cloud Business users not to append their organization to the uri.
- Base audit-trails API call need to be performed to: https://app.terraform.io/api/v2/organization/audit-trail

Terraform Cloud Business organizations may be confused after authentication, as browsers route to https://app.terraform.io/app/**<organization\>**

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
