### PR TITLE
Update api url to include admin

### DIFF
--- a/content/source/docs/cloud/api/admin/organizations.html.md
+++ b/content/source/docs/cloud/api/admin/organizations.html.md
@@ -207,7 +207,7 @@ curl \
 
 ## Update an Organization
 
-`PATCH /organizations/:organization_name`
+`PATCH /admin/organizations/:organization_name`
 
 Parameter            | Description
 ---------------------|------------
@@ -254,7 +254,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
-  https://tfe.example.com/api/v2/organizations/my-organization
+  https://tfe.example.com/api/v2/admin/organizations/my-organization
 ```
 
 ### Sample Response


### PR DESCRIPTION
This PR updates the url path for the admin organization update api doc - it was missing `admin`: https://www.terraform.io/docs/cloud/api/admin/organizations.html#update-an-organization

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
