### PR TITLE
[DRAFT] Update API docs for cross-org module sharing

### DIFF
--- a/content/source/docs/cloud/api/admin/module-sharing.html.md
+++ b/content/source/docs/cloud/api/admin/module-sharing.html.md
@@ -33,7 +33,10 @@ There are two ways to configure module sharing via the admin API:
 
 Enabling either option will disable the other. For more information, see [Administration: Module Sharing](/docs/enterprise/admin/module-sharing.html).
 
-## Update an Organization's Module Consumers
+~> **Important**: The `PATCH /admin/organizations/:name/module-consumers` endpoint is **deprecated** and will be removed in a future release. All existing integrations with this API should transition to the [new endpoint](./module-sharing.html#update-an-organization-39-s-module-consumers
+).
+
+## (**deprecated**) Update an Organization's Module Consumers via module-partnerships
 
 `PATCH /admin/organizations/:name/module-consumers`
 
@@ -97,6 +100,168 @@ curl \
         "consuming-organization-name": "other-organization",
         "producing-organization-id": "org-etdex8r9VLnyHFct",
         "producing-organization-name": "my-organization"
+      }
+    }
+  ]
+}
+```
+
+-> These API endpoints are available in Terraform Enterprise as of version 202103-1.
+
+This endpoint supports Cross Org Module sharing. There are two ways to configure module sharing via the admin API:
+
+- This endpoint, which allows an organization to share modules with a specific list of other organizations.
+- The [update an organization endpoint](./organizations.html#update-an-organization), whose `data.attributes.global-module-sharing` property allows an organization to share modules with every organization in the instance.
+
+Enabling either option will disable the other. For more information, see [Administration: Module Sharing](/docs/enterprise/admin/module-sharing.html).
+
+## Update an Organization's Module Consumers
+
+`PATCH /admin/organizations/:name/relationships/module-consumers`
+
+This endpoint sets the list of organizations that can use modules from the sharing organization's private registry. Sharing with specific organizations will automatically turn off global module sharing, which is configured with the [update an organization endpoint](./organizations.html#update-an-organization) (via the `data.attributes.global-module-sharing` property).
+
+Parameter  | Description
+-----------|------------
+`:name`    | The name of the organization whose registry is being shared
+
+Status  | Response                                              | Reason
+--------|-------------------------------------------------------|----------
+[204][] | No content | The list of module consumers was successfully updated
+[404][] | [JSON API error object][]                             | Organization not found or user unauthorized to perform action
+[422][] | [JSON API error object][]                             | Malformed request body (missing attributes, wrong types, module consumer not found, etc..)
+
+### Request Body
+
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
+
+Key path                                               | Type          | Default   | Description
+-------------------------------------------------------|---------------|-----------|------------
+`data[]` | array\[object\] |         | A list of resource identifier objects that defines which organizations will consume modules. These objects must contain `id` and `type` properties, and the `type` property must be `organizations` (e.g. `{ "id": "an-org", "type": "organizations" }`).
+
+### Sample Payload
+
+```json
+{
+  "data": [
+    {
+      "id": "an-org",
+      "type": "organizations"
+
+    },
+    {
+      "id": "another-org",
+      "type": "organizations"
+    }
+  ]
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PATCH \
+  --data @payload.json \
+  https://tfe.example.com/api/v2/admin/organizations/my-organization/module-consumers
+```
+
+### Sample Response
+
+The response body will be empty if successful.
+
+## List all Module Consumers for an organization
+
+`GET /admin/organizations/:name/relationships/module-consumers`
+
+This endpoint lists all organizations in the Terraform Enterprise installation.
+
+Parameter  | Description
+-----------|------------
+`:name`    | The name of the organization whose registry is being shared
+
+Status  | Response                                        | Reason
+--------|-------------------------------------------------|----------
+[200][] | [JSON API document][] (`type: "organizations"`) | The request was successful
+[404][] | [JSON API error object][]                       | Organization not found, or client is not an administrator
+
+
+### Query Parameters
+
+[These are standard URL query parameters](../index.html#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+Parameter           | Description
+--------------------|------------
+`page[number]`      | **Optional.** If omitted, the endpoint will return the first page.
+`page[size]`        | **Optional.** If omitted, the endpoint will return 20 organizations per page.
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://tfe.example.com/api/v2/admin/organizations/my-organization/relationships/module-consumers
+```
+
+### Sample Response
+
+```json
+{
+  "data": [
+    {
+      "id": "my-organization",
+      "type": "organizations",
+      "attributes": {
+        "access-beta-tools": false,
+        "external-id": "org-XBiRp755dav5p3P2",
+        "is-disabled": false,
+        "name": "my-organization",
+        "terraform-build-worker-apply-timeout": null,
+        "terraform-build-worker-plan-timeout": null,
+        "terraform-worker-sudo-enabled": false,
+        "notification-email": "my-organization@example.com",
+        "global-module-sharing": false,
+        "sso-enabled": false
+      },
+      "relationships": {
+        "module-consumers": {
+          "links": {
+            "related": "/api/v2/admin/organizations/my-organization/relationships/module-consumers"
+          }
+        },
+        "owners": {
+          "data": [
+            {
+              "id": "user-hxTQDETqnJsi5VYP",
+              "type": "users"
+            }
+          ]
+        },
+        "subscription": {
+          "data": null
+        },
+        "feature-set": {
+          "data": null
+        }
+      },
+      "links": {
+        "self": "https://app.terraform.io/api/v2/admin/organizations/my-organization/relationships/module-consumers?page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+        "first": "https://app.terraform.io/api/v2/admin/organizations/my-organization/relationships/module-consumers?page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+        "prev": null,
+        "next": null,
+        "last": "https://app.terraform.io/api/v2/admin/organizations/my-organization/relationships/module-consumers?page%5Bnumber%5D=1\u0026page%5Bsize%5D=20"
+      },
+      "meta": {
+        "pagination": {
+          "current-page": 1,
+          "prev-page": null,
+          "next-page": null,
+          "total-pages": 1,
+          "total-count": 1
+        }
       }
     }
   ]

--- a/content/source/docs/cloud/api/admin/module-sharing.html.md
+++ b/content/source/docs/cloud/api/admin/module-sharing.html.md
@@ -33,81 +33,6 @@ There are two ways to configure module sharing via the admin API:
 
 Enabling either option will disable the other. For more information, see [Administration: Module Sharing](/docs/enterprise/admin/module-sharing.html).
 
-~> **Important**: The `PATCH /admin/organizations/:name/module-consumers` endpoint is **deprecated** and will be removed in a future release. All existing integrations with this API should transition to the [new endpoint](./module-sharing.html#update-an-organization-39-s-module-consumers
-).
-
-## (**deprecated**) Update an Organization's Module Consumers via module-partnerships
-
-`PATCH /admin/organizations/:name/module-consumers`
-
-This endpoint sets the list of organizations that can use modules from the sharing organization's private registry. Sharing with specific organizations will automatically turn off global module sharing, which is configured with the [update an organization endpoint](./organizations.html#update-an-organization) (via the `data.attributes.global-module-sharing` property).
-
-Parameter  | Description
------------|------------
-`:name`    | The name of the organization whose registry is being shared
-
-Status  | Response                                              | Reason
---------|-------------------------------------------------------|----------
-[200][] | [JSON API document][] (`type: "module-partnerships"`) | The list of module consumers was successfully updated
-[404][] | [JSON API error object][]                             | Organization not found or user unauthorized to perform action
-[422][] | [JSON API error object][]                             | Malformed request body (missing attributes, wrong types, etc.)
-
-### Request Body
-
-This PATCH endpoint requires a JSON object with the following properties as a request payload.
-
-Key path                                               | Type          | Default   | Description
--------------------------------------------------------|---------------|-----------|------------
-`data.type`                                            | string        |           | Must be `"module-partnerships"`
-`data.attributes.module-consuming-organization-ids`    | array[string] |           | A list of external ids for organizations that will be able to access modules in the producing organization's registry. These should have an `org-` prefix.
-
-### Sample Payload
-
-```json
-{
-  "data": {
-    "type": "module-partnerships",
-    "attributes": {
-      "module-consuming-organization-ids": [
-        "org-939hp5K7kecppVmd"
-      ]
-    }
-  }
-}
-```
-
-### Sample Request
-
-```shell
-curl \
-  --header "Authorization: Bearer $TOKEN" \
-  --header "Content-Type: application/vnd.api+json" \
-  --request PATCH \
-  --data @payload.json \
-  https://tfe.example.com/api/v2/admin/organizations/my-organization/module-consumers
-```
-
-### Sample Response
-
-```json
-{
-  "data": [
-    {
-      "id": "mp-tQATArr4gyYDBvkF",
-      "type": "module-partnerships",
-      "attributes": {
-        "consuming-organization-id": "org-939hp5K7kecppVmd",
-        "consuming-organization-name": "other-organization",
-        "producing-organization-id": "org-etdex8r9VLnyHFct",
-        "producing-organization-name": "my-organization"
-      }
-    }
-  ]
-}
-```
-
--> These API endpoints are available in Terraform Enterprise as of version 202103-1.
-
 This endpoint supports Cross Org Module sharing. There are two ways to configure module sharing via the admin API:
 
 - This endpoint, which allows an organization to share modules with a specific list of other organizations.
@@ -115,64 +40,9 @@ This endpoint supports Cross Org Module sharing. There are two ways to configure
 
 Enabling either option will disable the other. For more information, see [Administration: Module Sharing](/docs/enterprise/admin/module-sharing.html).
 
-## Update an Organization's Module Consumers
-
-`PATCH /admin/organizations/:name/relationships/module-consumers`
-
-This endpoint sets the list of organizations that can use modules from the sharing organization's private registry. Sharing with specific organizations will automatically turn off global module sharing, which is configured with the [update an organization endpoint](./organizations.html#update-an-organization) (via the `data.attributes.global-module-sharing` property).
-
-Parameter  | Description
------------|------------
-`:name`    | The name of the organization whose registry is being shared
-
-Status  | Response                                              | Reason
---------|-------------------------------------------------------|----------
-[204][] | No content | The list of module consumers was successfully updated
-[404][] | [JSON API error object][]                             | Organization not found or user unauthorized to perform action
-[422][] | [JSON API error object][]                             | Malformed request body (missing attributes, wrong types, module consumer not found, etc..)
-
-### Request Body
-
-This PATCH endpoint requires a JSON object with the following properties as a request payload.
-
-Key path                                               | Type          | Default   | Description
--------------------------------------------------------|---------------|-----------|------------
-`data[]` | array\[object\] |         | A list of resource identifier objects that defines which organizations will consume modules. These objects must contain `id` and `type` properties, and the `type` property must be `organizations` (e.g. `{ "id": "an-org", "type": "organizations" }`).
-
-### Sample Payload
-
-```json
-{
-  "data": [
-    {
-      "id": "an-org",
-      "type": "organizations"
-
-    },
-    {
-      "id": "another-org",
-      "type": "organizations"
-    }
-  ]
-}
-```
-
-### Sample Request
-
-```shell
-curl \
-  --header "Authorization: Bearer $TOKEN" \
-  --header "Content-Type: application/vnd.api+json" \
-  --request PATCH \
-  --data @payload.json \
-  https://tfe.example.com/api/v2/admin/organizations/my-organization/module-consumers
-```
-
-### Sample Response
-
-The response body will be empty if successful.
-
 ## List all Module Consumers for an organization
+
+-> This API endpoint is available in Terraform Enterprise as of version 202103-1.
 
 `GET /admin/organizations/:name/relationships/module-consumers`
 
@@ -186,7 +56,6 @@ Status  | Response                                        | Reason
 --------|-------------------------------------------------|----------
 [200][] | [JSON API document][] (`type: "organizations"`) | The request was successful
 [404][] | [JSON API error object][]                       | Organization not found, or client is not an administrator
-
 
 ### Query Parameters
 
@@ -262,6 +131,140 @@ curl \
           "total-pages": 1,
           "total-count": 1
         }
+      }
+    }
+  ]
+}
+```
+
+## Update an Organization's Module Consumers
+
+-> This API endpoint is available in Terraform Enterprise as of version 202103-1.
+
+`PATCH /admin/organizations/:name/relationships/module-consumers`
+
+This endpoint sets the list of organizations that can use modules from the sharing organization's private registry. Sharing with specific organizations will automatically turn off global module sharing, which is configured with the [update an organization endpoint](./organizations.html#update-an-organization) (via the `data.attributes.global-module-sharing` property).
+
+Parameter  | Description
+-----------|------------
+`:name`    | The name of the organization whose registry is being shared
+
+Status  | Response                                              | Reason
+--------|-------------------------------------------------------|----------
+[204][] | No content | The list of module consumers was successfully updated
+[404][] | [JSON API error object][]                             | Organization not found or user unauthorized to perform action
+[422][] | [JSON API error object][]                             | Malformed request body (missing attributes, wrong types, module consumer not found, etc..)
+
+### Request Body
+
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
+
+Key path                                               | Type          | Default   | Description
+-------------------------------------------------------|---------------|-----------|------------
+`data[]` | array\[object\] |         | A list of resource identifier objects that defines which organizations will consume modules. These objects must contain `id` and `type` properties, and the `type` property must be `organizations` (e.g. `{ "id": "an-org", "type": "organizations" }`).
+
+### Sample Payload
+
+```json
+{
+  "data": [
+    {
+      "id": "an-org",
+      "type": "organizations"
+
+    },
+    {
+      "id": "another-org",
+      "type": "organizations"
+    }
+  ]
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PATCH \
+  --data @payload.json \
+  https://tfe.example.com/api/v2/admin/organizations/my-organization/module-consumers
+```
+
+### Sample Response
+
+The response body will be empty if successful.
+
+## (Deprecated) Update an Organization's Module Partnerships
+
+~> **Important**: The `PATCH /admin/organizations/:name/module-consumers` endpoint is **deprecated** and will be removed in a future release. All existing integrations with this API should transition to the [new endpoint](./module-sharing.html#update-an-organization-39-s-module-consumers
+).
+
+-> This API endpoint is available in Terraform Enterprise as of version 202012-1.
+
+`PATCH /admin/organizations/:name/module-consumers`
+
+This endpoint sets the list of organizations that can use modules from the sharing organization's private registry. Sharing with specific organizations will automatically turn off global module sharing, which is configured with the [update an organization endpoint](./organizations.html#update-an-organization) (via the `data.attributes.global-module-sharing` property).
+
+Parameter  | Description
+-----------|------------
+`:name`    | The name of the organization whose registry is being shared
+
+Status  | Response                                              | Reason
+--------|-------------------------------------------------------|----------
+[200][] | [JSON API document][] (`type: "module-partnerships"`) | The list of module consumers was successfully updated
+[404][] | [JSON API error object][]                             | Organization not found or user unauthorized to perform action
+[422][] | [JSON API error object][]                             | Malformed request body (missing attributes, wrong types, etc.)
+
+### Request Body
+
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
+
+Key path                                               | Type          | Default   | Description
+-------------------------------------------------------|---------------|-----------|------------
+`data.type`                                            | string        |           | Must be `"module-partnerships"`
+`data.attributes.module-consuming-organization-ids`    | array[string] |           | A list of external ids for organizations that will be able to access modules in the producing organization's registry. These should have an `org-` prefix.
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type": "module-partnerships",
+    "attributes": {
+      "module-consuming-organization-ids": [
+        "org-939hp5K7kecppVmd"
+      ]
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PATCH \
+  --data @payload.json \
+  https://tfe.example.com/api/v2/admin/organizations/my-organization/module-consumers
+```
+
+### Sample Response
+
+```json
+{
+  "data": [
+    {
+      "id": "mp-tQATArr4gyYDBvkF",
+      "type": "module-partnerships",
+      "attributes": {
+        "consuming-organization-id": "org-939hp5K7kecppVmd",
+        "consuming-organization-name": "other-organization",
+        "producing-organization-id": "org-etdex8r9VLnyHFct",
+        "producing-organization-name": "my-organization"
       }
     }
   ]

--- a/content/source/docs/cloud/api/admin/organizations.html.md
+++ b/content/source/docs/cloud/api/admin/organizations.html.md
@@ -101,6 +101,11 @@ curl \
         },
         "feature-set": {
           "data": null
+        },
+        "module-consumers": {
+          "links": {
+            "related": "/api/v2/admin/organizations/my-organization/relationships/module-consumers"
+          }
         }
       },
       "links": {
@@ -196,6 +201,11 @@ curl \
       },
       "feature-set": {
         "data": null
+      },
+      "module-consumers": {
+        "links": {
+          "related": "/api/v2/admin/organizations/my-organization/relationships/module-consumers"
+        }
       }
     },
     "links": {
@@ -290,6 +300,11 @@ curl \
       },
       "feature-set": {
         "data": null
+      },
+      "module-consumers": {
+        "links": {
+          "related": "/api/v2/admin/organizations/my-organization/relationships/module-consumers"
+        }
       }
     },
     "links": {

--- a/content/source/docs/cloud/api/organizations.html.md
+++ b/content/source/docs/cloud/api/organizations.html.md
@@ -121,6 +121,91 @@ curl \
 }
 ```
 
+_Terraform Enterprise_
+
+In Terraform Enterprise there is an additional relationship returned for module-producers:
+
+```json
+{
+  "data": [
+    {
+      "id": "hashicorp",
+      "type": "organizations",
+      "attributes": {
+        "name": "hashicorp",
+        "cost-estimation-enabled": true,
+        "created-at": "2017-09-07T14:34:40.492Z",
+        "email": "user@example.com",
+        "session-timeout": null,
+        "session-remember": null,
+        "collaborator-auth-policy": "password",
+        "plan-expired": false,
+        "plan-expires-at": null,
+        "plan-is-trial": false,
+        "plan-is-enterprise": false,
+        "permissions": {
+          "can-update": true,
+          "can-destroy": true,
+          "can-access-via-teams": true,
+          "can-create-module": true,
+          "can-create-team": true,
+          "can-create-workspace": true,
+          "can-manage-users": true,
+          "can-manage-subscription": true,
+          "can-manage-sso": false,
+          "can-update-oauth": true,
+          "can-update-sentinel": true,
+          "can-update-ssh-keys": true,
+          "can-update-api-token": true,
+          "can-traverse": true,
+          "can-start-trial": false,
+          "can-update-agent-pools": false
+        },
+        "fair-run-queuing-enabled": true,
+        "saml-enabled": false,
+        "owners-team-saml-role-id": null,
+        "two-factor-conformant": true
+      },
+      "relationships": {
+        "oauth-tokens": {
+          "links": {
+            "related": "/api/v2/organizations/hashicorp/oauth-tokens"
+          }
+        },
+        "authentication-token": {
+          "links": {
+            "related": "/api/v2/organizations/hashicorp/authentication-token"
+          }
+        },
+        "entitlement-set": {
+          "data": {
+            "id": "org-MxtxBC6ihhU6u8AG",
+            "type": "entitlement-sets"
+          },
+          "links": {
+            "related": "/api/v2/organizations/hashicorp/entitlement-set"
+          }
+        },
+        "subscription": {
+          "links": {
+            "related": "/api/v2/organizations/hashicorp/subscription"
+          }
+        },
+        "module-producers": {
+          "links": {
+            "related": "/api/v2/organizations/hashicorp/relationships/module-producers"
+          }
+        }
+      },
+      "links": {
+        "self": "/api/v2/organizations/hashicorp"
+      }
+    }
+  ]
+}
+
+```
+
 ## Show an Organization
 
 `GET /organizations/:organization_name`


### PR DESCRIPTION
Documentation changes for TFE api docs that will go with the 202103-1 release. We are deprecating 1 of the api endpoints and adding some new endpoints for TFE.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [X] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
