### PR TITLE
Plugin installation is never skipped, remove from extend docs

### DIFF
--- a/content/source/docs/extend/how-terraform-works.html.md
+++ b/content/source/docs/extend/how-terraform-works.html.md
@@ -107,9 +107,6 @@ and chooses a version for each plugin as follows:
   [providers distributed by HashiCorp](/docs/providers/index.html),
   Terraform downloads the newest acceptable version from
   releases.hashicorp.com and saves it in `.terraform/plugins/<OS>_<ARCH>`.
-
-    - This step is skipped if `terraform init` is run with the
-      `-plugin-dir=<PATH>` or `-get-plugins=false` options.
 - If no acceptable versions are installed and the plugin is not distributed
   by HashiCorp, initialization fails and the user must manually install an
   appropriate version.


### PR DESCRIPTION
Plugin installation is never skipped as of 0.13+, and so this line is misleading.


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

