### PR TITLE
add note on allowing docker0 in firewalld

### DIFF
--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -95,7 +95,7 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
         `firewall-cmd --permanent --zone=trusted --change-interface=docker0`
 
-    This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
+    This rule can be added before the `docker0` interface exists, so we recommend adding it before installing Docker.
 1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.
 1. **For GCP only:** Configure Docker to use an MTU (maximum transmission unit) of 1460, as required by Google ([GCP Cloud VPN Documentation: MTU Considerations](https://cloud.google.com/network-connectivity/docs/vpn/concepts/mtu-considerations)).
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -89,7 +89,7 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
 ## Other Configuration
 
-1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example:
+1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. 
    *  To do this with UFW run: `ufw allow in on docker0`.
    *  To do this with firewalld run:
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -90,7 +90,7 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 ## Other Configuration
 
 1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. 
-   *  To do this with UFW run: `ufw allow in on docker0`.
+   * To use UFW, run: `ufw allow in on docker0`.
    *  To do this with firewalld run:
 
         `firewall-cmd --permanent --zone=trusted --change-interface=docker0`

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -91,7 +91,7 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
 1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. 
    * To use UFW, run: `ufw allow in on docker0`.
-   *  To do this with firewalld run:
+   *  To use firewalld, run:
 
         `firewall-cmd --permanent --zone=trusted --change-interface=docker0`
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -89,7 +89,13 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
 ## Other Configuration
 
-1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example, to do this with UFW run: `ufw allow in on docker0`. This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
+1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. For example:
+   *  To do this with UFW run: `ufw allow in on docker0`.
+   *  To do this with firewalld run:
+
+        `firewall-cmd --permanent --zone=trusted --change-interface=docker0`
+
+    This rule can be added before the `docker0` interface exists, so it is best to do it now, before the Docker installation.
 1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.
 1. **For GCP only:** Configure Docker to use an MTU (maximum transmission unit) of 1460, as required by Google ([GCP Cloud VPN Documentation: MTU Considerations](https://cloud.google.com/network-connectivity/docs/vpn/concepts/mtu-considerations)).
 

--- a/content/source/docs/enterprise/before-installing/network-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/network-requirements.html.md
@@ -89,13 +89,9 @@ When [Cost Estimation](/docs/enterprise/admin/integration.html#cost-estimation-i
 
 ## Other Configuration
 
-1. If a firewall is configured on the instance, be sure that traffic can flow out of the `docker0` interface to the instance's primary address. 
-   * To use UFW, run: `ufw allow in on docker0`.
-   *  To use firewalld, run:
-
-        `firewall-cmd --permanent --zone=trusted --change-interface=docker0`
-
-    This rule can be added before the `docker0` interface exists, so we recommend adding it before installing Docker.
+1. If a firewall is configured on the instance, run one of the following to allow traffic to flow out of the `docker0` interface to the instance's primary address. We recommend doing this before you install Docker.
+   * To use UFW, run: `ufw allow in on docker0`
+   *  To use firewalld, run: `firewall-cmd --permanent --zone=trusted --change-interface=docker0`
 1. Get a domain name for the instance. Using an IP address to access the product is not supported as many systems use TLS and need to verify that the certificate is correct, which can only be done with a hostname at present.
 1. **For GCP only:** Configure Docker to use an MTU (maximum transmission unit) of 1460, as required by Google ([GCP Cloud VPN Documentation: MTU Considerations](https://cloud.google.com/network-connectivity/docs/vpn/concepts/mtu-considerations)).
 


### PR DESCRIPTION
## Labels

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout

It may be good to add an example of allowing `docker0` in `firewalld` same as there is for `UFW`.