### PR TITLE
Add `current_configuration_version` to includable resources for workspaces

### DIFF
--- a/content/source/docs/cloud/api/changelog.html.md
+++ b/content/source/docs/cloud/api/changelog.html.md
@@ -73,3 +73,7 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 ### 2021-03-11
 
 * Added [VCS Events](./vcs-events.html), limited to GitLab.com connections.
+
+### 2021-03-08
+
+* [Workspaces](./workspaces.html): added `current_configuration_version` and `current_configuration_version.ingress_attributes` as includable related resources.

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -1526,6 +1526,8 @@ Status code `204`.
 The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
 
 * `organization` - The full organization record.
+* `current_configuration_version` - The last configuration this workspace received, excluding plan-only configurations. If you start a run without providing a different configuration, it will use this one.
+* `current_configuration_version.ingress_attributes` - The commit information for the current configuration version.
 * `current_run` - Additional information about the current run.
 * `current_run.plan` - The plan used in the current run.
 * `current_run.configuration_version` - The configuration used in the current run.

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -1526,7 +1526,7 @@ Status code `204`.
 The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](./index.html#inclusion-of-related-resources). The following resource types are available:
 
 * `organization` - The full organization record.
-* `current_configuration_version` - The last configuration this workspace received, excluding plan-only configurations. If you start a run without providing a different configuration, it will use this one.
+* `current_configuration_version` - The last configuration this workspace received, excluding plan-only configurations. Terraform uses this configuration for new runs, unless you provide a different one.
 * `current_configuration_version.ingress_attributes` - The commit information for the current configuration version.
 * `current_run` - Additional information about the current run.
 * `current_run.plan` - The plan used in the current run.


### PR DESCRIPTION
This is live in production now.