### PR TITLE
Update some links in TFC docs, adjust PR link checker

### DIFF
--- a/content/scripts/check-pr-links.rb
+++ b/content/scripts/check-pr-links.rb
@@ -28,6 +28,13 @@ ROOT_URL = 'http://localhost:4567/'
 VERCEL_ROUTES = ['/community', '/cloud']
 VERCEL_REGEXP = /^(#{VERCEL_ROUTES.join('|')})/
 
+IGNORE_LIST = [
+  # The front page of TFC redirects to /session, but we *don't* want to update
+  # our links to go there, and we link to TFC a LOT.
+  'https://app.terraform.io',
+  'https://app.terraform.io/',
+]
+
 ARGF.set_encoding('utf-8')
 input = ARGF.read
 input_files = input.split(/\x00|\n/)
@@ -44,6 +51,8 @@ errors = {}
 def check_link(url)
   # Ignore non-web protocols like mailto:
    return [true, 'Not an HTTP(S) URL'] unless url.scheme == 'https' || url.scheme == 'http'
+  # Ignore special-cased URLs
+  return [true, 'Ignoring special URL'] if IGNORE_LIST.include?(url.to_s)
 
   # Special case for Vercel routes: can't check them against a local build, so
   # change URL to check prod.

--- a/content/source/docs/cloud/agents/index.html.md
+++ b/content/source/docs/cloud/agents/index.html.md
@@ -54,7 +54,7 @@ Agents should be considered a global resource within an organization. Once confi
 
 Agents are designed to allow you to run Terraform operations from a Terraform Cloud workspace on your private infrastructure. The following use cases are not supported by agents:
 
-- Connecting to private infrastructure from Sentinel policies using the [http import](https://docs.hashicorp.com/sentinel/imports/http/)
+- Connecting to private infrastructure from Sentinel policies using the [http import](https://docs.hashicorp.com/sentinel/imports/http)
 - Connecting Terraform Cloud workspaces to private VCS repositories
 
 For these use cases, we recommend you leverage the information provided by the [IP Ranges documentation](https://www.terraform.io/docs/cloud/architectural-details/ip-ranges.html) to permit direct communication from the appropriate Terraform Cloud service to your internal infrastructure.

--- a/content/source/docs/cloud/agents/index.html.md
+++ b/content/source/docs/cloud/agents/index.html.md
@@ -17,7 +17,7 @@ The agent architecture is pull-based, so no inbound connectivity is required. An
 
 ### Supported Operating Systems
 
-[Agents](https://releases.hashicorp.com/tfc-agent) currently only support 64 bit Linux operating systems. You can also run the agent within Docker using our official [Terraform Agent Docker container](https://hub.docker.com/r/hashicorp/tfc-agent).
+[Agents](https://releases.hashicorp.com/tfc-agent/) currently only support 64 bit Linux operating systems. You can also run the agent within Docker using our official [Terraform Agent Docker container](https://hub.docker.com/r/hashicorp/tfc-agent).
 
 ### Supported Terraform Versions
 
@@ -125,7 +125,7 @@ The agent software runs on your own infrastructure. Agent pool membership is det
 
 ### Download and Install the Agent
 
-1. Download the latest [agent release](https://releases.hashicorp.com/tfc-agent), the associated checksum file (.SHA256sums), and the checksum signature (.sig).
+1. Download the latest [agent release](https://releases.hashicorp.com/tfc-agent/), the associated checksum file (.SHA256sums), and the checksum signature (.sig).
 1. Verify the integrity of the downloaded archive, as well as the signature of the `SHA256SUMS` file using the instructions available on [HashiCorp's security page](https://www.hashicorp.com/security).
 1. Extract the release archive. The `unzip` utility is available on most Linux distributions and may be invoked as `unzip <archive file>`. Two individual binaries will be extracted (`tfc-agent` and `tfc-agent-core`). These binaries _must_ reside in the same directory for the agent to function properly.
 

--- a/content/source/docs/cloud/agents/index.html.md
+++ b/content/source/docs/cloud/agents/index.html.md
@@ -7,7 +7,7 @@ page_title: "Terraform Cloud Agents - Terraform Cloud and Terraform Enterprise"
 
 > **Hands-on:** Try the [Manage Private Environments with Terraform Cloud Agents](https://learn.hashicorp.com/tutorials/terraform/cloud-agents?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
--> **Note:** Terraform Cloud Agents are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/). The number of agents you are eligible to deploy is determined by the number of concurrent runs your organization is entitled to.
+-> **Note:** Terraform Cloud Agents are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing). The number of agents you are eligible to deploy is determined by the number of concurrent runs your organization is entitled to.
 
 Terraform Cloud Agents allow Terraform Cloud to communicate with isolated, private, or on-premises infrastructure. By deploying lightweight agents within a specific network segment, you can establish a simple connection between your environment and Terraform Cloud which allows for provisioning operations and management. This is useful for on-premises infrastructure types such as vSphere, Nutanix, OpenStack, enterprise networking providers, and anything you might have in a protected enclave.
 
@@ -217,7 +217,7 @@ Agent status appear on the **Organization Settings > Agents** page and will cont
 
 Agents are considered active and count towards the organization's purchased agent capacity if they are in the **Idle**, **Busy**, or **Unknown** state. Agents which are in the **Errored** or **Exited** state do not count towards the organization's total agent capacity.
 
-The number of active agents you are eligible to deploy is determined by the number of Concurrent Runs your organization is entitled to. Agents are available as part of the [Terraform Cloud Business] (https://www.hashicorp.com/products/terraform/pricing/) tier.
+The number of active agents you are eligible to deploy is determined by the number of Concurrent Runs your organization is entitled to. Agents are available as part of the [Terraform Cloud Business] (https://www.hashicorp.com/products/terraform/pricing) tier.
 
 Agents in the **Unknown** state continue to be counted against the organization's total agent allowance, as this status is typically an indicator of a temporary communication issue between the agent and Terraform Cloud. **Unknown** agents which do not respond after a period of 2 hours will automatically transition to an **Errored** state, at which point they will not count against the agent allowance.
 

--- a/content/source/docs/cloud/api/_template.md
+++ b/content/source/docs/cloud/api/_template.md
@@ -17,7 +17,7 @@ Follow this template to format each API method. There are usually multiple secti
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 
 ## Create a Something

--- a/content/source/docs/cloud/api/account.md
+++ b/content/source/docs/cloud/api/account.md
@@ -18,7 +18,7 @@ page_title: "Account - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Account API
 

--- a/content/source/docs/cloud/api/admin/organizations.html.md
+++ b/content/source/docs/cloud/api/admin/organizations.html.md
@@ -18,7 +18,7 @@ page_title: "Organizations - Admin - API Docs - Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Admin Organizations API
 

--- a/content/source/docs/cloud/api/admin/runs.html.md
+++ b/content/source/docs/cloud/api/admin/runs.html.md
@@ -18,7 +18,7 @@ page_title: "Runs - Admin - API Docs - Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Admin Runs API
 

--- a/content/source/docs/cloud/api/admin/settings.html.md
+++ b/content/source/docs/cloud/api/admin/settings.html.md
@@ -18,7 +18,7 @@ page_title: "Terraform Enterprise Settings - API Docs - Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 [speculative plans]: /docs/cloud/run/index.html#speculative-plans
 

--- a/content/source/docs/cloud/api/admin/terraform-versions.html.md
+++ b/content/source/docs/cloud/api/admin/terraform-versions.html.md
@@ -18,7 +18,7 @@ page_title: "Terraform Versions - Admin - API Docs - Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Admin Terraform Versions API
 

--- a/content/source/docs/cloud/api/admin/users.html.md
+++ b/content/source/docs/cloud/api/admin/users.html.md
@@ -18,7 +18,7 @@ page_title: "Users - Admin - API Docs - Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Admin Users API
 

--- a/content/source/docs/cloud/api/admin/workspaces.html.md
+++ b/content/source/docs/cloud/api/admin/workspaces.html.md
@@ -18,7 +18,7 @@ page_title: "Workspaces - Admin - API Docs - Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Admin Workspaces API
 

--- a/content/source/docs/cloud/api/agent-tokens.md
+++ b/content/source/docs/cloud/api/agent-tokens.md
@@ -22,7 +22,7 @@ page_title: "Agent Tokens - API Docs - Terraform Cloud and Terraform Enterprise"
 
 # Agent Tokens API
 
--> **Note:** Terraform Cloud Agents are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Terraform Cloud Agents are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## List Agent Tokens
 

--- a/content/source/docs/cloud/api/agent-tokens.md
+++ b/content/source/docs/cloud/api/agent-tokens.md
@@ -18,7 +18,7 @@ page_title: "Agent Tokens - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Agent Tokens API
 

--- a/content/source/docs/cloud/api/agents.md
+++ b/content/source/docs/cloud/api/agents.md
@@ -26,7 +26,7 @@ An Agent Pool represents a group of Agents, often related to one another by shar
 A workspace may be configured to use one of the organization's agent pools to run remote operations with isolated,
 private, or on-premises infrastructure.
 
--> **Note:** Terraform Cloud Agents are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Terraform Cloud Agents are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## List Agent Pools
 

--- a/content/source/docs/cloud/api/agents.md
+++ b/content/source/docs/cloud/api/agents.md
@@ -18,7 +18,7 @@ page_title: "Agent Pools and Agents - API Docs - Terraform Cloud and Terraform E
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Agent Pools and Agents API
 

--- a/content/source/docs/cloud/api/applies.md
+++ b/content/source/docs/cloud/api/applies.md
@@ -18,7 +18,7 @@ page_title: "Applies - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Applies API
 

--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -22,7 +22,7 @@ page_title: "Audit Trails - API Docs - Terraform Cloud"
 
 # Audit Trails API
 
--> **Note:** Audit trails are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Audit trails are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 -> **Note:** This endpoint cannot be accessed with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/api-tokens.html#team-api-tokens). You must access it with an [organization token](../users-teams-organizations/api-tokens.html#organization-api-tokens).
 

--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -18,7 +18,7 @@ page_title: "Audit Trails - API Docs - Terraform Cloud"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Audit Trails API
 

--- a/content/source/docs/cloud/api/configuration-versions.html.md
+++ b/content/source/docs/cloud/api/configuration-versions.html.md
@@ -18,7 +18,7 @@ page_title: "Configuration Versions - API Docs - Terraform Cloud and Terraform E
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Configuration Versions API
 

--- a/content/source/docs/cloud/api/cost-estimates.md
+++ b/content/source/docs/cloud/api/cost-estimates.md
@@ -18,7 +18,7 @@ page_title: "Cost Estimates - API Docs - Terraform Cloud and Terraform Enterpris
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Cost Estimates API
 

--- a/content/source/docs/cloud/api/cost-estimates.md
+++ b/content/source/docs/cloud/api/cost-estimates.md
@@ -22,7 +22,7 @@ page_title: "Cost Estimates - API Docs - Terraform Cloud and Terraform Enterpris
 
 # Cost Estimates API
 
--> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## Show a cost estimate
 

--- a/content/source/docs/cloud/api/feature-sets.html.md
+++ b/content/source/docs/cloud/api/feature-sets.html.md
@@ -18,7 +18,7 @@ page_title: "Feature Sets - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Feature Sets API
 

--- a/content/source/docs/cloud/api/invoices.html.md
+++ b/content/source/docs/cloud/api/invoices.html.md
@@ -18,7 +18,7 @@ page_title: "Invoices - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Invoices API
 

--- a/content/source/docs/cloud/api/ip-ranges.html.md
+++ b/content/source/docs/cloud/api/ip-ranges.html.md
@@ -20,7 +20,7 @@ page_title: "IP Ranges - API Docs - Terraform Cloud and Terraform Enterprise"
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [If-Modified-Since]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 [CIDR Notation]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
 
 # IP Ranges API

--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -18,7 +18,7 @@ page_title: "Modules - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Registry Modules API
 

--- a/content/source/docs/cloud/api/notification-configurations.html.md
+++ b/content/source/docs/cloud/api/notification-configurations.html.md
@@ -18,7 +18,7 @@ page_title: "Notification Configurations - API Docs - Terraform Cloud and Terraf
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Notification Configurations API
 

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -168,7 +168,7 @@ This endpoint allows you to create a VCS connection between an organization and 
 
 To learn how to generate one of these token strings for your VCS provider, you can read the following documentation:
 
-* [GitHub and GitHub Enterprise](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+* [GitHub and GitHub Enterprise](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
 * [GitLab, GitLab Community Edition, and GitLab Enterprise Edition](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html#creating-a-personal-access-token)
 * [Azure DevOps Server](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops-2019&tabs=preview-page)
 

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -18,7 +18,7 @@ page_title: "OAuth Clients - API Docs - Terraform Cloud and Terraform Enterprise
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # OAuth Clients API
 

--- a/content/source/docs/cloud/api/oauth-tokens.html.md
+++ b/content/source/docs/cloud/api/oauth-tokens.html.md
@@ -18,7 +18,7 @@ page_title: "OAuth Tokens - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # OAuth Tokens
 

--- a/content/source/docs/cloud/api/organization-memberships.html.md
+++ b/content/source/docs/cloud/api/organization-memberships.html.md
@@ -18,7 +18,7 @@ page_title: "Organization Memberships - API Docs - Terraform Cloud and Terraform
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Organization Memberships API
 

--- a/content/source/docs/cloud/api/organization-tokens.html.md
+++ b/content/source/docs/cloud/api/organization-tokens.html.md
@@ -18,7 +18,7 @@ page_title: "Organization Tokens - API Docs - Terraform Cloud and Terraform Ente
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Organization Token API
 

--- a/content/source/docs/cloud/api/plan-exports.html.md
+++ b/content/source/docs/cloud/api/plan-exports.html.md
@@ -23,7 +23,7 @@ Status  | Response                                       | Reason
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
 [JSON API document]: https://www.terraform.io/docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 ### Request Body
 
@@ -117,7 +117,7 @@ Status  | Response                                       | Reason
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [JSON API document]: https://www.terraform.io/docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -173,7 +173,7 @@ Status  | Response                  | Reason
 
 [302]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 ### Sample Request
 
@@ -199,7 +199,7 @@ Status  | Response                  | Reason
 
 [204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 ### Sample Request
 

--- a/content/source/docs/cloud/api/plans.html.md
+++ b/content/source/docs/cloud/api/plans.html.md
@@ -19,7 +19,7 @@ page_title: "Plans - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Plans API
 

--- a/content/source/docs/cloud/api/policies.html.md
+++ b/content/source/docs/cloud/api/policies.html.md
@@ -18,7 +18,7 @@ page_title: "Policies - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Policies API
 

--- a/content/source/docs/cloud/api/policies.html.md
+++ b/content/source/docs/cloud/api/policies.html.md
@@ -22,7 +22,7 @@ page_title: "Policies - API Docs - Terraform Cloud and Terraform Enterprise"
 
 # Policies API
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 [Sentinel Policy as Code](../sentinel/index.html) is an embedded policy as code framework integrated with Terraform Cloud.
 

--- a/content/source/docs/cloud/api/policy-checks.html.md
+++ b/content/source/docs/cloud/api/policy-checks.html.md
@@ -22,7 +22,7 @@ page_title: "Policy Checks - API Docs - Terraform Cloud and Terraform Enterprise
 
 # Policy Checks API
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## List Policy Checks
 

--- a/content/source/docs/cloud/api/policy-checks.html.md
+++ b/content/source/docs/cloud/api/policy-checks.html.md
@@ -18,7 +18,7 @@ page_title: "Policy Checks - API Docs - Terraform Cloud and Terraform Enterprise
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Policy Checks API
 

--- a/content/source/docs/cloud/api/policy-set-params.html.md
+++ b/content/source/docs/cloud/api/policy-set-params.html.md
@@ -22,7 +22,7 @@ page_title: "Policy Set Parameters - API Docs - Terraform Cloud and Terraform En
 
 # Policy Set Parameters API
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 This set of APIs covers create, update, list and delete operations on parameters.
 

--- a/content/source/docs/cloud/api/policy-set-params.html.md
+++ b/content/source/docs/cloud/api/policy-set-params.html.md
@@ -18,7 +18,7 @@ page_title: "Policy Set Parameters - API Docs - Terraform Cloud and Terraform En
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Policy Set Parameters API
 

--- a/content/source/docs/cloud/api/policy-sets.html.md
+++ b/content/source/docs/cloud/api/policy-sets.html.md
@@ -22,7 +22,7 @@ page_title: "Policy Sets - API Docs - Terraform Cloud and Terraform Enterprise"
 
 # Policy Sets API
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 [Sentinel Policy as Code](../sentinel/index.html) is an embedded policy as code framework integrated with Terraform Cloud.
 

--- a/content/source/docs/cloud/api/policy-sets.html.md
+++ b/content/source/docs/cloud/api/policy-sets.html.md
@@ -18,7 +18,7 @@ page_title: "Policy Sets - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Policy Sets API
 

--- a/content/source/docs/cloud/api/run-triggers.html.md
+++ b/content/source/docs/cloud/api/run-triggers.html.md
@@ -18,7 +18,7 @@ page_title: "Run Triggers - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Run Triggers API
 

--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -18,7 +18,7 @@ page_title: "Runs - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Runs API
 

--- a/content/source/docs/cloud/api/ssh-keys.html.md
+++ b/content/source/docs/cloud/api/ssh-keys.html.md
@@ -18,7 +18,7 @@ page_title: "SSH Keys - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # SSH Keys
 

--- a/content/source/docs/cloud/api/state-version-outputs.html.md
+++ b/content/source/docs/cloud/api/state-version-outputs.html.md
@@ -6,7 +6,7 @@ page_title: "State Version Outputs - API Docs - Terraform Cloud and Terraform En
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # State Version Outputs API
 

--- a/content/source/docs/cloud/api/state-versions.html.md
+++ b/content/source/docs/cloud/api/state-versions.html.md
@@ -18,7 +18,7 @@ page_title: "State Versions - API Docs - Terraform Cloud and Terraform Enterpris
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # State Versions API
 

--- a/content/source/docs/cloud/api/subscriptions.html.md
+++ b/content/source/docs/cloud/api/subscriptions.html.md
@@ -18,7 +18,7 @@ page_title: "Subscriptions - API Docs - Terraform Cloud and Terraform Enterprise
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Subscriptions API
 

--- a/content/source/docs/cloud/api/team-access.html.md
+++ b/content/source/docs/cloud/api/team-access.html.md
@@ -18,7 +18,7 @@ page_title: "Team Acccess - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Team Access API
 

--- a/content/source/docs/cloud/api/team-access.html.md
+++ b/content/source/docs/cloud/api/team-access.html.md
@@ -22,7 +22,7 @@ page_title: "Team Acccess - API Docs - Terraform Cloud and Terraform Enterprise"
 
 # Team Access API
 
--> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The team access APIs are used to associate a team to permissions on a workspace. A single `team-workspace` resource contains the relationship between the Team and Workspace, including the privileges the team has on the workspace.
 

--- a/content/source/docs/cloud/api/team-members.html.md
+++ b/content/source/docs/cloud/api/team-members.html.md
@@ -22,7 +22,7 @@ page_title: "Team Membership - API Docs - Terraform Cloud and Terraform Enterpri
 
 # Team Membership API
 
--> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. Free organizations can also use this API, but can only manage membership of their owners team. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. Free organizations can also use this API, but can only manage membership of their owners team. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The Team Membership API is used to add or remove users from teams. The [Team API](./teams.html) is used to create or destroy teams.
 

--- a/content/source/docs/cloud/api/team-members.html.md
+++ b/content/source/docs/cloud/api/team-members.html.md
@@ -18,7 +18,7 @@ page_title: "Team Membership - API Docs - Terraform Cloud and Terraform Enterpri
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Team Membership API
 

--- a/content/source/docs/cloud/api/team-tokens.html.md
+++ b/content/source/docs/cloud/api/team-tokens.html.md
@@ -18,7 +18,7 @@ page_title: "Team Tokens - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Team Token API
 

--- a/content/source/docs/cloud/api/teams.html.md
+++ b/content/source/docs/cloud/api/teams.html.md
@@ -18,7 +18,7 @@ page_title: "Teams - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Teams API
 

--- a/content/source/docs/cloud/api/teams.html.md
+++ b/content/source/docs/cloud/api/teams.html.md
@@ -22,7 +22,7 @@ page_title: "Teams - API Docs - Terraform Cloud and Terraform Enterprise"
 
 # Teams API
 
--> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The Teams API is used to create, edit, and destroy teams as well as manage a team's organization-level permissions. The [Team Membership API](./team-members.html) is used to add or remove users from a team. Use the [Team Access API](./team-access.html) to associate a team with privileges on an individual workspace.
 

--- a/content/source/docs/cloud/api/user-tokens.md
+++ b/content/source/docs/cloud/api/user-tokens.md
@@ -18,7 +18,7 @@ page_title: "User Tokens - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # User Tokens API
 

--- a/content/source/docs/cloud/api/users.md
+++ b/content/source/docs/cloud/api/users.md
@@ -18,7 +18,7 @@ page_title: "Users - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Users API
 

--- a/content/source/docs/cloud/api/variables.html.md
+++ b/content/source/docs/cloud/api/variables.html.md
@@ -18,7 +18,7 @@ page_title: "Variables - API Docs - Terraform Cloud and Terraform Enterprise"
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Variables API
 

--- a/content/source/docs/cloud/api/workspace-variables.html.md
+++ b/content/source/docs/cloud/api/workspace-variables.html.md
@@ -18,7 +18,7 @@ page_title: "Workspace Variables - API Docs - Terraform Cloud and Terraform Ente
 [500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
 [504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 [JSON API document]: /docs/cloud/api/index.html#json-api-documents
-[JSON API error object]: http://jsonapi.org/format/#error-objects
+[JSON API error object]: https://jsonapi.org/format/#error-objects
 
 # Workspace Variables API
 

--- a/content/source/docs/cloud/cost-estimation/aws.html.md
+++ b/content/source/docs/cloud/cost-estimation/aws.html.md
@@ -5,7 +5,7 @@ page_title: "AWS - Cost Estimation - Terraform Cloud and Terraform Enterprise"
 
 # Supported AWS resources in Terraform Cloud Cost Estimation
 
--> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Terraform Cloud can estimate monthly costs for many AWS Terraform resources.
 

--- a/content/source/docs/cloud/cost-estimation/azure.html.md
+++ b/content/source/docs/cloud/cost-estimation/azure.html.md
@@ -5,7 +5,7 @@ page_title: "Azure - Cost Estimation - Terraform Cloud and Terraform Enterprise"
 
 # Supported Azure resources in Terraform Cloud Cost Estimation
 
--> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Terraform Cloud can estimate monthly costs for many Azure Terraform resources.
 

--- a/content/source/docs/cloud/cost-estimation/gcp.html.md
+++ b/content/source/docs/cloud/cost-estimation/gcp.html.md
@@ -5,7 +5,7 @@ page_title: "GCP - Cost Estimation - Terraform Cloud and Terraform Enterprise"
 
 # Supported GCP resources in Terraform Cloud Cost Estimation
 
--> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Terraform Cloud can estimate monthly costs for many GCP Terraform resources.
 

--- a/content/source/docs/cloud/cost-estimation/index.html.md
+++ b/content/source/docs/cloud/cost-estimation/index.html.md
@@ -5,7 +5,7 @@ page_title: "Overview - Cost Estimation - Terraform Cloud and Terraform Enterpri
 
 # Cost Estimation in Terraform Cloud
 
--> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 > **Hands-on:** Try the [Control Costs with Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 

--- a/content/source/docs/cloud/integrations/splunk/index.html.md
+++ b/content/source/docs/cloud/integrations/splunk/index.html.md
@@ -7,7 +7,7 @@ description: |-
 
 # Terraform Cloud for Splunk setup instructions
 
--> **Note:** Terraform Cloud for Splunk is a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Terraform Cloud for Splunk is a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## Overview
 

--- a/content/source/docs/cloud/paid.html.md
+++ b/content/source/docs/cloud/paid.html.md
@@ -27,7 +27,7 @@ Free organizations are limited to five active members.
 
 Some of Terraform Cloud's features are limited to particular paid upgrade plans. In the documentation, pages that document a paid feature are marked with callout boxes, like the one below:
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Each higher paid upgrade plan is a strict superset of any lower plans — for example, the "Team & Governance" plan includes all of the features of the "Team" plan. Paid feature callouts in the documentation indicate the _lowest_ tier at which the feature is available, but any higher plans also include that feature.
 
@@ -41,4 +41,4 @@ The plan and billing settings include an integrated storefront, and you can subs
 
 ## Available Plans
 
-For up-to-date information about the currently available billing plans, as well as details about each plan's features, see [the Terraform pricing page on HashiCorp.com](https://www.hashicorp.com/products/terraform/pricing/) or the purchase interface in your plan and billing settings.
+For up-to-date information about the currently available billing plans, as well as details about each plan's features, see [the Terraform pricing page on HashiCorp.com](https://www.hashicorp.com/products/terraform/pricing) or the purchase interface in your plan and billing settings.

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -5,7 +5,7 @@ page_title: "Enforce and Override Policies - Sentinel - Terraform Cloud and Terr
 
 # Enforce and Override Policies
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 > **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 

--- a/content/source/docs/cloud/sentinel/examples.html.md
+++ b/content/source/docs/cloud/sentinel/examples.html.md
@@ -5,7 +5,7 @@ page_title: "Example Policies - Policies - Terraform Cloud and Terraform Enterpr
 
 # Example Policies
 
--> **Note:** Terraform policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Terraform policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 > **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 

--- a/content/source/docs/cloud/sentinel/examples.html.md
+++ b/content/source/docs/cloud/sentinel/examples.html.md
@@ -30,12 +30,12 @@ This page lists some example policies. These examples are not exhaustive, but th
 * [Restrict VM images](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/azure/restrict-vm-image-id.sentinel)
 * [Restrict the size of Azure VMs](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/azure/restrict-vm-size.sentinel)
 * [Enforce limits on AKS clusters](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/azure/restrict-aks-clusters.sentinel)
-* [Restict CIDR blocks of security groups](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/azure/restrict-source-address-prefixes.sentinel)
+* [Restict CIDR blocks of security groups](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/azure/restrict-inbound-source-address-prefixes.sentinel)
 
 ### Google Cloud Platform
 
 * [Enforce mandatory labels on VMs](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/gcp/enforce-mandatory-labels.sentinel)
-* [Disallow 0.0.0.0/0 CIDR block in network firewalls](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/gcp/restrict-firewall-source-ranges.sentinel)
+* [Disallow 0.0.0.0/0 CIDR block in network firewalls](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/gcp/restrict-ingress-firewall-source-ranges.sentinel)
 * [Enforce limits on GKE clusters](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/gcp/restrict-gke-clusters.sentinel)
 * [Restrict machine type of VMs](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/gcp/restrict-gce-machine-type.sentinel)
 

--- a/content/source/docs/cloud/sentinel/import/index.html.md
+++ b/content/source/docs/cloud/sentinel/import/index.html.md
@@ -5,7 +5,7 @@ page_title: "Defining Policies - Sentinel - Terraform Cloud and Terraform Enterp
 
 # Defining Policies
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Sentinel Policies for Terraform are defined using the [Sentinel policy
 language](https://docs.hashicorp.com/sentinel/language/). A policy can include

--- a/content/source/docs/cloud/sentinel/import/index.html.md
+++ b/content/source/docs/cloud/sentinel/import/index.html.md
@@ -8,7 +8,7 @@ page_title: "Defining Policies - Sentinel - Terraform Cloud and Terraform Enterp
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Sentinel Policies for Terraform are defined using the [Sentinel policy
-language](https://docs.hashicorp.com/sentinel/language/). A policy can include
+language](https://docs.hashicorp.com/sentinel/language). A policy can include
 [imports](https://docs.hashicorp.com/sentinel/concepts/imports) which enable a
 policy to access reusable libraries, external data and functions. Terraform
 Cloud provides four imports to define policy rules for the plan, configuration,
@@ -28,7 +28,7 @@ state, and run associated with a policy check.
 
 Terraform Cloud allows you to create mocks of these imports from plans for use
 with the mocking or testing features of the [Sentinel
-CLI](https://docs.hashicorp.com/sentinel/commands/). For more information, see
+CLI](https://docs.hashicorp.com/sentinel/commands). For more information, see
 [Mocking Terraform Sentinel Data](../mock.html).
 
 -> **Note:** Terraform Cloud does not currently support custom imports.

--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -5,7 +5,7 @@ description: |-
   The tfconfig/v2 import provides access to a Terraform configuration.
 ---
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 -> **Note:** This is documentation for the next version of the `tfconfig`
 Sentinel import, designed specifically for Terraform 0.12. This import requires

--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -273,7 +273,7 @@ main = rule {
 Note that _nested blocks_, sometimes known as _sub-resources_, will be nested in
 configuration as as list of blocks (reflecting their ultimate nature as a list
 of objects). An example would be the `aws_instance` resource's
-[`ebs_block_device`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#block-devices) block:
+[`ebs_block_device`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#ebs-ephemeral-and-root-block-devices) block:
 
 ```
 import "tfconfig/v2" as tfconfig

--- a/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig-v2.html.md
@@ -120,7 +120,7 @@ The collections are:
   all modules in the configuration.
 
 These collections are specifically designed to be used with the
-[`filter`](https://docs.hashicorp.com/sentinel/language/collection-operations/#filter-expression)
+[`filter`](https://docs.hashicorp.com/sentinel/language/collection-operations#filter-expression)
 quantifier expression in Sentinel, so that one can collect a list of resources
 to perform policy checks on without having to write complex module or
 configuration traversal. As an example, the following code will return all

--- a/content/source/docs/cloud/sentinel/import/tfconfig.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfconfig.html.md
@@ -7,7 +7,7 @@ description: |-
 
 # Import: tfconfig
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The `tfconfig` import provides access to a Terraform configuration.
 

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -5,7 +5,7 @@ description: |-
   The tfplan/v2 import provides access to a Terraform plan.
 ---
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 -> **Note:** This is documentation for the next version of the `tfplan` Sentinel
 import, designed specifically for Terraform 0.12. This import requires

--- a/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan-v2.html.md
@@ -88,7 +88,7 @@ The collections are:
   Terraform Cloud.
 
 These collections are specifically designed to be used with the
-[`filter`](https://docs.hashicorp.com/sentinel/language/collection-operations/#filter-expression)
+[`filter`](https://docs.hashicorp.com/sentinel/language/collection-operations#filter-expression)
 quantifier expression in Sentinel, so that one can collect a list of resources
 to perform policy checks on without having to write complex discovery code. As
 an example, the following code will return all `aws_instance` resource changes,

--- a/content/source/docs/cloud/sentinel/import/tfplan.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfplan.html.md
@@ -7,7 +7,7 @@ description: |-
 
 # Import: tfplan
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The `tfplan` import provides access to a Terraform plan. A Terraform plan is the
 file created as a result of `terraform plan` and is the input to `terraform

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -69,7 +69,7 @@ Specifies the ID that is associated with the current Terraform run.
 
 The `created_at` value within the [root namespace](#namespace-root) specifies the time that the run was created. The timestamp returned follows the format outlined in [RFC3339](https://tools.ietf.org/html/rfc3339).
 
-Users can use the `time` import to [load](https://docs.hashicorp.com/sentinel/imports/time/#timeloadtimeish) a run timestamp and create a new timespace from the specicied value. See the `time` import [documentation](https://docs.hashicorp.com/sentinel/imports/time/#import-time) for available actions that can be performed on timespaces.
+Users can use the `time` import to [load](https://docs.hashicorp.com/sentinel/imports/time/#timeloadtimeish) a run timestamp and create a new timespace from the specicied value. See the `time` import [documentation](https://docs.hashicorp.com/sentinel/imports/time#import-time) for available actions that can be performed on timespaces.
 
 ### Value: `message`
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -69,7 +69,7 @@ Specifies the ID that is associated with the current Terraform run.
 
 The `created_at` value within the [root namespace](#namespace-root) specifies the time that the run was created. The timestamp returned follows the format outlined in [RFC3339](https://tools.ietf.org/html/rfc3339).
 
-Users can use the `time` import to [load](https://docs.hashicorp.com/sentinel/imports/time/#timeloadtimeish) a run timestamp and create a new timespace from the specicied value. See the `time` import [documentation](https://docs.hashicorp.com/sentinel/imports/time#import-time) for available actions that can be performed on timespaces.
+Users can use the `time` import to [load](https://docs.hashicorp.com/sentinel/imports/time#time-load-timeish) a run timestamp and create a new timespace from the specicied value. See the `time` import [documentation](https://docs.hashicorp.com/sentinel/imports/time#import-time) for available actions that can be performed on timespaces.
 
 ### Value: `message`
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -7,7 +7,7 @@ description: |-
 
 # Import: tfrun
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The `tfrun` import provides access to data associated with a [Terraform run][run-glossary].
 

--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -72,7 +72,7 @@ The collections are:
 * [`outputs`](#the-outputs-collection) - The state of all outputs from the root module in the state.
 
 These collections are specifically designed to be used with the
-[`filter`](https://docs.hashicorp.com/sentinel/language/collection-operations/#filter-expression)
+[`filter`](https://docs.hashicorp.com/sentinel/language/collection-operations#filter-expression)
 quantifier expression in Sentinel, so that one can collect a list of resources
 to perform policy checks on without having to write complex module traversal. As
 an example, the following code will return all `aws_instance` resource types

--- a/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate-v2.html.md
@@ -5,7 +5,7 @@ description: |-
   The tfstate/v2 import provides access to a Terraform state.
 ---
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 -> **Note:** This is documentation for the next version of the `tfstate`
 Sentinel import, designed specifically for Terraform 0.12. This import requires

--- a/content/source/docs/cloud/sentinel/import/tfstate.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfstate.html.md
@@ -7,7 +7,7 @@ description: |-
 
 # Import: tfstate
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The `tfstate` import provides access to the Terraform state.
 

--- a/content/source/docs/cloud/sentinel/index.html.md
+++ b/content/source/docs/cloud/sentinel/index.html.md
@@ -5,7 +5,7 @@ page_title: "Sentinel - Terraform Cloud and Terraform Enterprise"
 
 # Sentinel Overview
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 > **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 

--- a/content/source/docs/cloud/sentinel/index.html.md
+++ b/content/source/docs/cloud/sentinel/index.html.md
@@ -16,7 +16,7 @@ information from external sources.
 
 To learn how to use Sentinel and begin writing policies with the Sentinel
 language, see [the Sentinel
-documentation](https://docs.hashicorp.com/sentinel/writing/).
+documentation](https://docs.hashicorp.com/sentinel/writing).
 
 You can also use the
 [`tfe_sentinel_policy`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/sentinel_policy) resource
@@ -44,7 +44,7 @@ Using Sentinel with Terraform Cloud involves:
   or the `terraform apply` is executed.
 - [Mocking Sentinel Terraform data](./mock.html) - Terraform Cloud provides the
   ability to generate mock data for any run within a workspace. This data can be
-  used with the [Sentinel CLI](https://docs.hashicorp.com/sentinel/commands/) to
+  used with the [Sentinel CLI](https://docs.hashicorp.com/sentinel/commands) to
   test policies before deployment.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
@@ -52,4 +52,4 @@ Using Sentinel with Terraform Cloud involves:
 ### Standard Imports
 
 The Terraform integration for HashiCorp Sentinel implements all of the
-available [standard imports](https://docs.hashicorp.com/sentinel/imports/).
+available [standard imports](https://docs.hashicorp.com/sentinel/imports).

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -5,7 +5,7 @@ page_title: "Managing Sentinel Policies - Sentinel - Terraform Cloud and Terrafo
 
 # Managing Sentinel Policies
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 > **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -100,7 +100,7 @@ When no `source` line is specified, a policy file matching the name of the polic
 
 Terraform Cloud has support for Sentinel's modules feature. This allows you to write re-usable policy code that can be imported from within several policies as once, reducing the amount of boilerplate from within a policy itself.
 
--> **NOTE:** We recommend you read the [Sentinel runtime's modules documentation](https://docs.hashicorp.com/sentinel/extending/modules/) in order to understand how to fully use modules within Sentinel. Note that the configuration examples in the runtime documentation pertain to the Sentinel CLI and not Terraform Cloud. HCL-based configuration will be coming to the Sentinel CLI in future releases, at which point in time both Sentinel and TFC configurations will be much more similar.
+-> **NOTE:** We recommend you read the [Sentinel runtime's modules documentation](https://docs.hashicorp.com/sentinel/extending/modules) in order to understand how to fully use modules within Sentinel. Note that the configuration examples in the runtime documentation pertain to the Sentinel CLI and not Terraform Cloud. HCL-based configuration will be coming to the Sentinel CLI in future releases, at which point in time both Sentinel and TFC configurations will be much more similar.
 
 To configure a module, add a `module` entry to your `sentinel.hcl` file:
 
@@ -166,11 +166,11 @@ main = rule {
 }
 ```
 
-In the example above we have used a [rule expression](https://docs.hashicorp.com/sentinel/language/spec/#rule-expressions) with the `when` predicate. If the value of `tfrun.workspace.auto_apply` is false, the rule will not be evaluated and return true
+In the example above we have used a [rule expression](https://docs.hashicorp.com/sentinel/language/spec#rule-expressions) with the `when` predicate. If the value of `tfrun.workspace.auto_apply` is false, the rule will not be evaluated and return true
 
-For a more robust or flexible policy, we could expand the enforcement logic to also restrict provisioning to occur out of hours using the [time.hour](https://docs.hashicorp.com/sentinel/imports/time/#time-hour) function.
+For a more robust or flexible policy, we could expand the enforcement logic to also restrict provisioning to occur out of hours using the [time.hour](https://docs.hashicorp.com/sentinel/imports/time#time-hour) function.
 
-The above examples use parameters to to facilitate module reuse within Terraform. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters/).
+The above examples use parameters to to facilitate module reuse within Terraform. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters).
 
 ## Managing Policy Sets
 
@@ -191,7 +191,7 @@ When creating or editing a policy set, the following fields are available:
 - **VCS Branch**: This field allows specifying the branch within a VCS repository from which to import new versions of policies. If left blank, the value your version control provides as the default branch of the VCS repository is used.
 - **Policies Path**: This field allows specifying a sub-directory within a VCS repository for the policy set files. This allows maintaining multiple policy sets within a single repository. The value of this field should be the path to the directory containing the `sentinel.hcl` configuration file of the policy set you wish to configure. If left blank, the root of the repository is used. A leading `/` may be used, but is optional (relative paths are assumed to originate from the root of the repository).
 - **Workspaces:** Which workspaces the policy set should be enforced on. This is only shown when the scope of policies is set to "Policies enforced on selected workspaces." Use the drop-down menu and "Add workspace" button to add workspaces, and the trash can (🗑) button to remove them.
-- **Parameters:** A list of key/value parameters that will be sent to the Sentinel runtime when a policy check is being performed for the policy set. If the value can be parsed as JSON, it will be sent to Sentinel as the corresponding type (string, boolean, integer, map or list). If it fails JSON validation, it will be sent as a string. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters/).
+- **Parameters:** A list of key/value parameters that will be sent to the Sentinel runtime when a policy check is being performed for the policy set. If the value can be parsed as JSON, it will be sent to Sentinel as the corresponding type (string, boolean, integer, map or list). If it fails JSON validation, it will be sent as a string. For more information on parameters, see the [Sentinel parameter documentation](https://docs.hashicorp.com/sentinel/language/parameters).
 
 -> **Note:** Parameters are only available for versioned policy sets. If you are using an individually managed policy set, you will need to migrate it to a versioned policy set.
 

--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -5,7 +5,7 @@ page_title: "Mocking Terraform Sentinel Data - Sentinel - Terraform Cloud and Te
 
 # Mocking Terraform Sentinel Data
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 We recommend that you test your Sentinel policies extensively before deploying
 them within Terraform Cloud. An important part of this process is mocking

--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -17,7 +17,7 @@ generate mock data from existing configurations. This can be used to create
 sample data for a new policy, or data to reproduce issues in an existing one.
 
 Testing policies is done using the [Sentinel
-CLI](https://docs.hashicorp.com/sentinel/commands/). More general information on
+CLI](https://docs.hashicorp.com/sentinel/commands). More general information on
 testing Sentinel policies can be found in the [Testing
 section](https://docs.hashicorp.com/sentinel/writing/testing) of the [Sentinel
 runtime documentation](https://docs.hashicorp.com/sentinel).

--- a/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
+++ b/content/source/docs/cloud/sentinel/sentinel-tf-012.html.md
@@ -7,7 +7,7 @@ description: |-
 
 # Using Sentinel with Terraform 0.12
 
--> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 The Terraform Sentinel imports
 ([`tfconfig`](./import/tfconfig.html),

--- a/content/source/docs/cloud/users-teams-organizations/permissions.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/permissions.html.md
@@ -5,7 +5,7 @@ page_title: "Permissions - Terraform Cloud and Terraform Enterprise"
 
 # Permissions
 
--> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/users-teams-organizations/single-sign-on.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/single-sign-on.html.md
@@ -5,7 +5,7 @@ page_title: "Single Sign-on - Terraform Cloud and Terraform Enterprise"
 
 # Single Sign-on
 
--> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ~> **Important:** This page is about configuring single sign-on in Terraform Cloud. Terraform Enterprise's single sign-on is configured differently. If you administer a Terraform Enterprise instance, see [Terraform Enterprise: SAML Configuration](/docs/enterprise/saml/configuration.html).
 

--- a/content/source/docs/cloud/users-teams-organizations/single-sign-on/azure-ad.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/single-sign-on/azure-ad.html.md
@@ -3,7 +3,7 @@ layout: "cloud"
 page_title: "Microsoft Azure AD - Single Sign-on - Terraform Cloud and Terraform Enterprise"
 ---
 
--> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 # Single Sign-on: Microsoft Azure AD
 

--- a/content/source/docs/cloud/users-teams-organizations/single-sign-on/okta.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/single-sign-on/okta.html.md
@@ -3,7 +3,7 @@ layout: "cloud"
 page_title: "Okta - Single Sign-on - Terraform Cloud and Terraform Enterprise"
 ---
 
--> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 # Single Sign-on: Okta
 

--- a/content/source/docs/cloud/users-teams-organizations/single-sign-on/saml.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/single-sign-on/saml.html.md
@@ -3,7 +3,7 @@ layout: "cloud"
 page_title: "SAML - Single Sign-on - Terraform Cloud and Terraform Enterprise"
 ---
 
--> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 # Single Sign-on: SAML
 

--- a/content/source/docs/cloud/users-teams-organizations/teams.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/teams.html.md
@@ -9,7 +9,7 @@ page_title: "Teams - Terraform Cloud and Terraform Enterprise"
 
 # Teams
 
--> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. Free organizations only include an owners team, which can include up to five members. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. Free organizations only include an owners team, which can include up to five members. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 > **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 

--- a/content/source/docs/cloud/workspaces/access.html.md
+++ b/content/source/docs/cloud/workspaces/access.html.md
@@ -5,7 +5,7 @@ page_title: "Managing Access - Workspaces - Terraform Cloud and Terraform Enterp
 
 # Managing Access to Workspaces
 
--> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing/).
+-> **Note:** Team management is a paid feature, available as part of the **Team** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 Terraform Cloud workspaces can only be accessed by users with the correct permissions. You can manage permissions for a workspace on a per-team basis.
 


### PR DESCRIPTION
Did a tiny docs PR, and the checker caught a broken link. But there were a bunch of other links throughout the docs that matched that pattern, so I tried fixing all instances of them... then it kept snowballing and catching more outbound links with issues. :| 

(For the record, I do NOT endorse doing that if you're doing a normal docs PR! Just catch whatever turns up in the document you're currently messing with. But since I don't always follow my own advice, here's a PR.) 

The CI will be red for this job anyway, unfortunately. Here's the "explain why"s: 

- The registry docs and the GCP docs don't render right until a bunch of javascript rehydrates, so my dumb little link checker can't find anchors in them. But the links are good!
- The API docs template isn't a real page. The link checker thinks it was probably intended to be and thus something's probably awfully wrong. But really it's fine, and it's intentional that it fails to render. 