### PR TITLE
Fix the edit page link now that Terraform repo has changed to main branch

### DIFF
--- a/content/middleman_helpers.rb
+++ b/content/middleman_helpers.rb
@@ -119,7 +119,7 @@ module Helpers
     end
 
     if fn.start_with?('../ext/terraform/')
-      return "https://github.com/hashicorp/terraform/edit/master/#{fn['../ext/terraform/'.length..-1]}"
+      return "https://github.com/hashicorp/terraform/edit/main/#{fn['../ext/terraform/'.length..-1]}"
     end
 
     if fn.start_with?('../ext/providers/')


### PR DESCRIPTION
Terraform has made the transition from the `master` branch to `main`. This broke the "Edit this page" link at the bottom of the docs. This PR changes the branch that the link sends people to. 

<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [x] OTHER: fix a broken link
