### PR TITLE
Add different link to active active document

### DIFF
--- a/content/source/layouts/_enterprise_content.erb
+++ b/content/source/layouts/_enterprise_content.erb
@@ -98,7 +98,7 @@
                 <a href="/docs/enterprise/install/automating-the-installer.html">Automated Installation</a>
               </li>
               <li>
-                <a href="/docs/enterprise/install/active-active.html">Scale to Two Nodes</a>
+                <a href="/docs/enterprise/install/active-active.html">Active/Active</a>
               </li>
               <li>
                 <a href="/docs/enterprise/install/automating-initial-user.html">Initial User Automation </a>


### PR DESCRIPTION

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout

Searching for Active/Active documentation is likely to be from a search engine, but looking through the nav bar on our site for this very (and increasingly) important page is hidden under "Scale to Two Nodes".  This will have to change when customers start to scale beyond two nodes anyway.
 