### PR TITLE
Update policy-set-params.html.md

### DIFF
--- a/content/source/docs/cloud/api/policy-set-params.html.md
+++ b/content/source/docs/cloud/api/policy-set-params.html.md
@@ -75,7 +75,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://app.terraform.io/api/v2/policy-set/pol-u3S5p2Uwk21keu1s/parameters
+  https://app.terraform.io/api/v2/policy-sets/pol-u3S5p2Uwk21keu1s/parameters
 ```
 
 ### Sample Response


### PR DESCRIPTION
Correct `policy-set` in Create Policy Set Parameter example to `policy-sets`.
Specifically, change `https://app.terraform.io/api/v2/policy-set/pol-u3S5p2Uwk21keu1s/parameters` to `https://app.terraform.io/api/v2/policy-sets/pol-u3S5p2Uwk21keu1s/parameters`
## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
