### PR TITLE
A/A doc cleanup, A/A ops doc, index names adjusted

### DIFF
--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -50,7 +50,7 @@ This command will quiesce the current node and remove it from service. It will a
 tfe-admin app-config -k <KEY> -v <VALUE>
 ```
 
-This command allows users to make ad hoc/realtime application changes, such as `capacity_concurrency` via the CLI. Both an allowable `<KEY>` (setting name) and `<VALUE>` (new setting value) must be provided. A complete list of the current `app-config` settings can be found by running `replicatedctl app-config export`. You will be warned to restart the TFE application after running this command and must do so with a `replicatedctl app restart` command for the configuration changes to be in effect.
+This command allows users to make ad hoc/realtime application changes, such as `capacity_concurrency` via the CLI. Both an allowable `<KEY>` (setting name) and `<VALUE>` (new setting value) must be provided. A complete list of the current `app-config` settings can be found by running `replicatedctl app-config export`. You will be warned to restart the TFE application after running this command and must do so with a `replicatedctl app restart` command **on each node instance** for the configuration changes to be in effect.
 
 -> **Note:** You should ensure that any ad hoc changes made in this fashion are captured in the standard node build configuration, as the next time you build/rebuild a node only the configuration stored for that purpose will be in effect and ad hoc changes could be lost.
 
@@ -88,7 +88,7 @@ replicatedctl system status
 
 ```
 
-Displays status info on the TFE application. Key values to note are that status values return as "ready".
+Displays status info on the Replicated sub-system. Key values to note are that status values return as "ready". This reports on the status of the system on the node instance that it is run on.
 
 
 #### tfe application status
@@ -98,7 +98,8 @@ replicatedctl app status
 
 ```
 
-Displays status info on the Replicated sub-system. Key values to note are that `State` and `DesiredState` are both "started" and `IsTransitioning` is false.
+Displays status info on the TFE application. Key values to note are that `State` and `DesiredState` are both "started" and `IsTransitioning` is false. This reports on the status of the application on the node instance that it is run on.
+
 
 ## Upgrading TFE or Patching TFE Node Instances
 
@@ -108,7 +109,7 @@ This is another reason why using automation to build the instances is important.
 These are the steps required to repave the node instances:
 
 *   Run the `node-drain` command as described previously on each node to complete active work and stop new work from being processed.
-*   Update the instance build configuration such as setting a new **ReleaseSequence** to upgrade versions and/or make any other alterations such as patching the base image used for building the instances.
+*   Update the instance build configuration such as setting a new `ReleaseSequence` to upgrade versions and/or make any other alterations such as patching the base image used for building the instances.
 *   Follow the instructions in [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) to scale down to zero nodes and proceed through scaling up to one node, validating success, and then scaling additional nodes.
 
 If planned and orchestrated efficiently, the total downtime for the repaving will be the amount of time it has taken to build one node as processing will resume as soon as the first node is functional.

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -13,7 +13,7 @@ The Active/Active operational mode disables use of the Replicated UI.  To accomm
 
 ### Commands
 
-Note that "tfe-admin" is an alias for "replicated admin", and can be used interchangeably.
+Note that `tfe-admin` is an alias for `replicated admin`, and can be used interchangeably.
 
 #### support-bundle
 

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -9,7 +9,7 @@ When your organization requires increased reliability or performance from Terraf
 
 ## Active/Active Admin Commands
 
-The Active/Active operational mode disables use of the replicated UI.  To accommodate this, there are now admin commands to facilitate configuration changes, safe application stops, and producing support bundles. There is a new container in the TFE architecture to support this called "tfe-admin". You must login to a node in the Active/Active cluster in a terminal mode to run these commands from the command line.
+The Active/Active operational mode disables use of the Replicated UI.  To accommodate this, there are now admin commands to facilitate configuration changes, safe application stops, and producing support bundles. There is a new container in the TFE architecture to support this called "tfe-admin". You must login to a node in the Active/Active cluster using SSH to run these commands from the command line.
 
 ### Commands
 

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -50,7 +50,7 @@ This command will quiesce the current node and remove it from service. It will a
 tfe-admin app-config -k <KEY> -v <VALUE>
 ```
 
-This command allows users to make ad-hoc/realtime application changes, such as capacity_concurrency via the CLI. Both an allowable <KEY> (setting name) and <VALUE> (new setting value) must be provided. A complete list of the current app-config settings can be found by running _replicatedctl app-config export_. You will be warned to restart the TFE application after running this command and must do so with a _replicatedctl app restart_ command for the configuration changes to be in effect.
+This command allows users to make ad hoc/realtime application changes, such as `capacity_concurrency` via the CLI. Both an allowable `<KEY>` (setting name) and `<VALUE>` (new setting value) must be provided. A complete list of the current `app-config` settings can be found by running `replicatedctl app-config export`. You will be warned to restart the TFE application after running this command and must do so with a `replicatedctl app restart` command for the configuration changes to be in effect.
 
 -> **Note:** You should ensure that any ad-hoc changes made in this fashion are captured in the standard node build configuration, as the next time you build/rebuild a node only the configuration stored for that purpose will be in effect and ad-hoc changes could be lost.
 

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -52,9 +52,9 @@ tfe-admin app-config -k <KEY> -v <VALUE>
 
 This command allows users to make ad hoc/realtime application changes, such as `capacity_concurrency` via the CLI. Both an allowable `<KEY>` (setting name) and `<VALUE>` (new setting value) must be provided. A complete list of the current `app-config` settings can be found by running `replicatedctl app-config export`. You will be warned to restart the TFE application after running this command and must do so with a `replicatedctl app restart` command for the configuration changes to be in effect.
 
--> **Note:** You should ensure that any ad-hoc changes made in this fashion are captured in the standard node build configuration, as the next time you build/rebuild a node only the configuration stored for that purpose will be in effect and ad-hoc changes could be lost.
+-> **Note:** You should ensure that any ad hoc changes made in this fashion are captured in the standard node build configuration, as the next time you build/rebuild a node only the configuration stored for that purpose will be in effect and ad hoc changes could be lost.
 
--> **Hint:** Adding a function to your Linux start-up like an alias can give you a short cut to the admin app-config command only requiring a single command and parameters, such as:
+-> **Hint:** Adding a function to your Linux start-up like an alias can give you a short cut to the admin `app-config` command only requiring a single command and parameters, such as:
 
 ```bash
 # shortcut: tfe-app-config <KEY> <VALUE>
@@ -66,7 +66,7 @@ tfe-app-config ()
 
 ## Other Supporting Commands
 
-There are additional commands available for checking status and troubleshooting directly on nodes. You can use them to confirm successful installation or to check on the status of a running node as part of troubleshooting activities.  Also, there are additional command aliases available that allow you to run more abbreviated versions of commands like just _support-bundle_. Run an _alias_ command with no parameters to see the list of available command aliases.
+There are additional commands available for checking status and troubleshooting directly on nodes. You can use them to confirm successful installation or to check on the status of a running node as part of troubleshooting activities.  Also, there are additional command aliases available that allow you to run more abbreviated versions of commands like just `support-bundle`. Run an `alias` command with no parameters to see the list of available command aliases.
 
 ### Commands
 
@@ -98,17 +98,17 @@ replicatedctl app status
 
 ```
 
-Displays status info on the replicated sub-system. Key values to note are that `State` and `DesiredState` are both "started" and `IsTransitioning` is false.
+Displays status info on the Replicated sub-system. Key values to note are that `State` and `DesiredState` are both "started" and `IsTransitioning` is false.
 
 ## Upgrading TFE or Patching TFE Node Instances
 
-The mechanism used to upgrade the TFE node instances is to fully repave the instances (destroy and rebuild entirely)
-. This is another reason why using automation to build the instances is important. Currently, the safest way to perform and upgrade is to shut down all node instances, rebuild one node to validate a successful upgrade, and then scale to additional nodes (currently max 2).
+The mechanism used to upgrade the TFE node instances is to fully repave the instances (destroy and rebuild entirely).
+This is another reason why using automation to build the instances is important. Currently, the safest way to perform and upgrade is to shut down all node instances, rebuild one node to validate a successful upgrade, and then scale to additional nodes (currently max 2).
 
 These are the steps required to repave the node instances:
 
-*   Run the _node-drain_ command as described previously on each node to complete active work and stop new work from being processed.
+*   Run the `node-drain` command as described previously on each node to complete active work and stop new work from being processed.
 *   Update the instance build configuration such as setting a new **ReleaseSequence** to upgrade versions and/or make any other alterations such as patching the base image used for building the instances.
-*   Follow the instructions in [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) to scale down to zero nodes and proceed through scaling up to 1 node, validating success, and then scaling additional nodes.
+*   Follow the instructions in [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) to scale down to zero nodes and proceed through scaling up to one node, validating success, and then scaling additional nodes.
 
-If planned and orchestrated efficiently, the total downtime for the repaving will be the amount of time it has taken to build 1 node as processing will resume as soon as the first node is functional.
+If planned and orchestrated efficiently, the total downtime for the repaving will be the amount of time it has taken to build one node as processing will resume as soon as the first node is functional.

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -1,0 +1,114 @@
+---
+layout: "enterprise"
+page_title: "Active/Active -  - Infrastructure Administration - Terraform Enterprise"
+---
+
+# Terraform Enterprise Active/Active
+
+When your organization requires increased reliability or performance from Terraform Enterprise that your current single application instance cannot provide, it is time to scale to the Active/Active architecture. Please refer to  [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) for more information on moving to Active/Active.
+
+## Active/Active Admin Commands
+
+The Active/Active operational mode disables use of the replicated UI.  To accommodate this, there are now admin commands to facilitate configuration changes, safe application stops, and producing support bundles. There is a new container in the TFE architecture to support this called "tfe-admin". You must login to a node in the Active/Active cluster in a terminal mode to run these commands from the command line.
+
+### Commands
+
+Note that "tfe-admin" is an alias for "replicated admin", and can be used interchangeably.
+
+#### support-bundle
+
+```bash
+tfe-admin support-bundle
+```
+
+This command will generate a support bundle for all nodes. The support bundles will be uploaded to the same object store bucket that is used to store Terraform statefiles. The support bundles for a specific run of the admin command will all be uploaded to a directory with the same JobID (a timestamp in RFC3339 format). If you are sending a support bundle to HashiCorp Support, package up the associated bundles and send all in order to ensure all needed information is made available.
+
+Example upload structure
+
+```bash
+support-bundles
+└── 2020-11-10T02:03:05Z
+    ├── 10.0.0.5
+    │   └── replicated-support702524260.tar.gz
+    └── 10.0.0.6
+        └── replicated-support577188727.tar.gz
+```
+
+
+#### node-drain
+
+```bash
+tfe-admin node-drain 
+```
+
+This command will quiesce the current node and remove it from service. It will allow current work to complete and safely stop the node from picking up any new jobs from the redis queue, allowing the application to be safely stopped. Currently, it only affects  localhost and so only the host it is executed on (it does not support running on one node to drain other nodes). There is also not currently a reverse drain command - a restart is needed to restore the node.
+
+
+####  app-config
+
+```bash
+tfe-admin app-config -k <KEY> -v <VALUE>
+```
+
+This command allows users to make ad-hoc/realtime application changes, such as capacity_concurrency via the CLI. Both an allowable <KEY> (setting name) and <VALUE> (new setting value) must be provided. A complete list of the current app-config settings can be found by running _replicatedctl app-config export_. You will be warned to restart the TFE application after running this command and must do so with a _replicatedctl app restart_ command for the configuration changes to be in effect.
+
+-> **Note:** You should ensure that any ad-hoc changes made in this fashion are captured in the standard node build configuration, as the next time you build/rebuild a node only the configuration stored for that purpose will be in effect and ad-hoc changes could be lost.
+
+-> **Hint:** Adding a function to your Linux start-up like an alias can give you a short cut to the admin app-config command only requiring a single command and parameters, such as:
+
+```bash
+# shortcut: tfe-app-config <KEY> <VALUE>
+tfe-app-config ()
+{
+        tfe-admin app-config -k "$1" -v "$2"
+}
+```
+
+## Other Supporting Commands
+
+There are additional commands available for checking status and troubleshooting directly on nodes. You can use them to confirm successful installation or to check on the status of a running node as part of troubleshooting activities.  Also, there are additional command aliases available that allow you to run more abbreviated versions of commands like just _support-bundle_. Run an _alias_ command with no parameters to see the list of available command aliases.
+
+### Commands
+
+#### health-check
+
+```bash
+ptfe-admin health-check
+(alias health-check)
+
+```
+
+This command tests and reports on the status of the major TFE services. Each will be listed as PASS or FAIL. If any are marked as FAIL, your TFE implementation is NOT healthy and additional action must be taken.
+
+
+#### replicated status
+
+```bash
+replicatedctl system status
+
+```
+
+Displays status info on the TFE application. Key values to note are that status values return as "ready".
+
+
+#### tfe application status
+
+```bash
+replicatedctl app status
+
+```
+
+Displays status info on the replicated sub-system. Key values to note are that `State` and `DesiredState` are both "started" and `IsTransitioning` is false.
+
+## Upgrading TFE or Patching TFE Node Instances
+
+The mechanism used to upgrade the TFE node instances is to fully repave the instances (destroy and rebuild entirely)
+. This is another reason why using automation to build the instances is important. Currently, the safest way to perform and upgrade is to shut down all node instances, rebuild one node to validate a successful upgrade, and then scale to additional nodes (currently max 2).
+
+These are the steps required to repave the node instances:
+
+*   Run the _node-drain_ command as described previously on each node to complete active work and stop new work from being processed.
+*   Update the instance build configuration such as setting a new **ReleaseSequence** to upgrade versions and/or make any other alterations such as patching the base image used for building the instances.
+*   Follow the instructions in [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) to scale down to zero nodes and proceed through scaling up to 1 node, validating success, and then scaling additional nodes.
+
+If planned and orchestrated efficiently, the total downtime for the repaving will be the amount of time it has taken to build 1 node as processing will resume as soon as the first node is functional.

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -5,7 +5,7 @@ page_title: "Active/Active - Infrastructure Administration - Terraform Enterpris
 
 # Terraform Enterprise Active/Active
 
-When your organization requires increased reliability or performance from Terraform Enterprise that your current single application instance cannot provide, it is time to scale to the Active/Active architecture. Please refer to  [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) for more information on moving to Active/Active.
+When your organization requires increased reliability or performance from Terraform Enterprise that your current single application instance cannot provide, it is time to scale to the Active/Active architecture. Please refer to  [Terraform Enterprise Active/Active](/docs/enterprise/install/active-active.html) for more information on moving to Active/Active.
 
 ## Active/Active Admin Commands
 
@@ -110,6 +110,6 @@ These are the steps required to repave the node instances:
 
 *   Run the `node-drain` command as described previously on each node to complete active work and stop new work from being processed.
 *   Update the instance build configuration such as setting a new `ReleaseSequence` to upgrade versions and/or make any other alterations such as patching the base image used for building the instances.
-*   Follow the instructions in [Terraform Enterprise Active/Active](https://www.terraform.io/docs/enterprise/install/active-active.html) to scale down to zero nodes and proceed through scaling up to one node, validating success, and then scaling additional nodes.
+*   Follow the instructions in [Terraform Enterprise Active/Active](/docs/enterprise/install/active-active.html) to scale down to zero nodes and proceed through scaling up to one node, validating success, and then scaling additional nodes.
 
 If planned and orchestrated efficiently, the total downtime for the repaving will be the amount of time it has taken to build one node as processing will resume as soon as the first node is functional.

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -41,7 +41,7 @@ support-bundles
 tfe-admin node-drain 
 ```
 
-This command will quiesce the current node and remove it from service. It will allow current work to complete and safely stop the node from picking up any new jobs from the redis queue, allowing the application to be safely stopped. Currently, it only affects  localhost and so only the host it is executed on (it does not support running on one node to drain other nodes). There is also not currently a reverse drain command - a restart is needed to restore the node.
+This command will quiesce the current node and remove it from service. It will allow current work to complete and safely stop the node from picking up any new jobs from the Redis queue, allowing the application to be safely stopped. Currently, it only affects `localhost` (it does not support running on one node to drain other nodes). Currently, there is no reverse drain command - a restart is needed to restore the node.
 
 
 ####  app-config

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -9,7 +9,7 @@ When your organization requires increased reliability or performance from Terraf
 
 ## Active/Active Admin Commands
 
-The Active/Active operational mode disables use of the Replicated UI.  To accommodate this, there are now admin commands to facilitate configuration changes, safe application stops, and producing support bundles. There is a new container in the TFE architecture to support this called "tfe-admin". You must login to a node in the Active/Active cluster using SSH to run these commands from the command line.
+The Active/Active operational mode disables use of the Replicated Admin Console.  To accommodate this, there are now admin commands to facilitate configuration changes, safe application stops, and producing support bundles. There is a new container in the TFE architecture to support this called "tfe-admin". You must login to a node in the Active/Active cluster using SSH to run these commands from the command line.
 
 ### Commands
 

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "enterprise"
-page_title: "Active/Active -  - Infrastructure Administration - Terraform Enterprise"
+page_title: "Active/Active - Infrastructure Administration - Terraform Enterprise"
 ---
 
 # Terraform Enterprise Active/Active

--- a/content/source/docs/enterprise/admin/active-active.html.md
+++ b/content/source/docs/enterprise/admin/active-active.html.md
@@ -21,7 +21,7 @@ Note that `tfe-admin` is an alias for `replicated admin`, and can be used interc
 tfe-admin support-bundle
 ```
 
-This command will generate a support bundle for all nodes. The support bundles will be uploaded to the same object store bucket that is used to store Terraform statefiles. The support bundles for a specific run of the admin command will all be uploaded to a directory with the same JobID (a timestamp in RFC3339 format). If you are sending a support bundle to HashiCorp Support, package up the associated bundles and send all in order to ensure all needed information is made available.
+This command will generate a support bundle for all nodes. The support bundles will be uploaded to the same object store bucket that is used to store Terraform statefiles. The support bundles for a specific run of the admin command will all be uploaded to a directory with the same JobID (a timestamp in [RFC3339](https://tools.ietf.org/html/rfc3339) format). If you are sending a support bundle to HashiCorp Support, package up the associated bundles and send all in order to ensure all needed information is made available.
 
 Example upload structure
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -97,7 +97,7 @@ Terraform Enterprise currently supports running under the following operating sy
 
     - Debian 7.7+
     - Ubuntu 14.04.5 / 16.04 / 18.04 / 20.04
-    - Red Hat Enterprise Linux 7.4 - 7.8
+    - Red Hat Enterprise Linux 7.4 - 7.9
     - CentOS 6.x / 7.4 - 7.8
     - Amazon Linux 2014.03 / 2014.09 / 2015.03 / 2015.09 / 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
     - Oracle Linux 7.4 - 7.8

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -97,7 +97,7 @@ Terraform Enterprise currently supports running under the following operating sy
 
     - Debian 7.7+
     - Ubuntu 14.04.5 / 16.04 / 18.04 / 20.04
-    - Red Hat Enterprise Linux 7.4 - 7.9
+    - Red Hat Enterprise Linux 7.4 - 7.8
     - CentOS 6.x / 7.4 - 7.8
     - Amazon Linux 2014.03 / 2014.09 / 2015.03 / 2015.09 / 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
     - Oracle Linux 7.4 - 7.8

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -487,7 +487,7 @@ You need to wait up to 15 minutes for the application to respond as healthy on b
 
 #### Validate Application
 
-Finally, confirm the application is functioning as expected when running multiple nodes. Run Terraform Plan and Applies through the system (and any other tests specific to your environment) like you did to validate the application in Step 3. 
+Finally, confirm the application is functioning as expected when running multiple nodes. Run Terraform plan and applies through the system (and any other tests specific to your environment) like you did to validate the application in Step 3. 
 
 Confirm the general functionality of the UI to validate the tokens you added in Step 2 are set correctly. Browse the `Run` interface and your organization's private registry to confirm your application functions as expected.
 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -24,7 +24,7 @@ As mentioned above, the Active/Active architecture requires an existing [automat
 
 The primary requirement is an Auto Scaling Group (or equivalent) with a single instance running Terraform Enterprise. This ASG should be behind a Load Balancer and can be exposed to the public internet or not depending on your requirements. As mentioned earlier, the installation of the Terraform Enterprise application should be automated completely so that the ASG can be scaled to zero and back to one without human intervention. 
 
-The application itself must be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and blob storage. 
+The application itself must be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and object storage. 
 
 All admin and application configuration must be automated via your settings files and current with running configuration, i.e. it cannot have been altered via the Admin UI and not synced to the file. Specifically, you should be using the following configuration files:
 
@@ -610,4 +610,3 @@ The minimum instance size for Redis to be used with TFE is 6 GiB. For Azure, thi
 Make sure you configure the minimum TLS version to the TFE supported version of 1.2 as the Azure resource defaults to 1.0. The default port for Azure Cache for Redis is 6380 and will need to be modified in the Application Settings `ptfe-replicated.conf` in order for TFE to connect to Azure Cache for Redis.
 
 The default example provided on the provider page can be used to deploy Azure Cache for Redis [here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache). The outputs of the resource can then be provided to the Terraform module in order to configure connectivity
-

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -45,8 +45,8 @@ The requirement for automation is two-fold. First, the nodes need to be able to 
 There are new access requirements involving ingress and egress:
 
 
-*   **Port 6379** (or the port the external Redis will be configured to use) must be open between the node instances and the Redis service
-*   **Port 8201** must be open between the node instances to allow Vault to run in [High Availability](https://www.vaultproject.io/docs/internals/high-availability) mode
+*   **Port 6379** (or the port the external Redis will be configured to use) must be open between the nodes and the Redis service
+*   **Port 8201** must be open between the nodes to allow Vault to run in [High Availability](https://www.vaultproject.io/docs/internals/high-availability) mode
 *   **Port 8800** should now be closed, as the Replicated Admin Console is no longer available when running multiple nodes
 
 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -22,7 +22,7 @@ However, the benefits that come with the Active/Active architecture need to be w
 
 As mentioned above, the Active/Active architecture requires an existing [automated installation](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html) of Terraform Enterprise that follows our [best practices for deployment](https://www.terraform.io/docs/enterprise/before-installing/reference-architecture/index.html). 
 
-The primary requirement is an auto scaling group (or equivalent) with a single instance running Terraform Enterprise. This ASG should be behind a load balancer and can be exposed to the public Internet or not depending on your requirements. As mentioned earlier, the installation of the Terraform Enterprise application should be automated completely so that the ASG can be scaled to zero and back to one without human intervention. 
+The primary requirement is an auto scaling group (or equivalent) with a single instance running Terraform Enterprise. This ASG should be behind a load balancer and can be exposed to the public Internet or not depending on your requirements. As mentioned earlier, the installation of the Terraform Enterprise application should be automated completely so that the auto scaling group can be scaled to zero and back to one without human intervention. 
 
 The application itself must be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and object storage. 
 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -22,7 +22,7 @@ However, the benefits that come with the Active/Active architecture need to be w
 
 As mentioned above, the Active/Active architecture requires an existing [automated installation](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html) of Terraform Enterprise that follows our [best practices for deployment](https://www.terraform.io/docs/enterprise/before-installing/reference-architecture/index.html). 
 
-The primary requirement is an Auto Scaling Group (or equivalent) with a single instance running Terraform Enterprise. This ASG should be behind a Load Balancer and can be exposed to the public internet or not depending on your requirements. As mentioned earlier, the installation of the Terraform Enterprise application should be automated completely so that the ASG can be scaled to zero and back to one without human intervention. 
+The primary requirement is an auto scaling group (or equivalent) with a single instance running Terraform Enterprise. This ASG should be behind a load balancer and can be exposed to the public Internet or not depending on your requirements. As mentioned earlier, the installation of the Terraform Enterprise application should be automated completely so that the ASG can be scaled to zero and back to one without human intervention. 
 
 The application itself must be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and object storage. 
 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -410,7 +410,7 @@ Terminate the existing instance by scaling down to zero. Once terminated, you ca
 
 #### Wait for Terraform Enterprise to Install
 
-It can take up to 15 minutes for the node instance to provision and the TFE application to be installed and respond as healthy. You can monitor the status of the node instance provisioning by watching your Auto Scaling Group in your cloud’s web console. To confirm the successful implementation of the TFE application you can SSH onto the instance and run the following command to monitor the installation directly:
+It can take up to 15 minutes for the node to provision and the TFE application to be installed and respond as healthy. You can monitor the status of the node provisioning by watching your auto scaling group in your cloud’s web console. To confirm the successful implementation of the TFE application you can SSH onto the node and run the following command to monitor the installation directly:
 
 
 ```bash

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -26,7 +26,7 @@ The primary requirement is an auto scaling group (or equivalent) with a single i
 
 The application itself must be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and object storage. 
 
-All admin and application configuration must be automated via your settings files and current with running configuration, i.e. it cannot have been altered via the Admin UI and not synced to the file. Specifically, you should be using the following configuration files:
+All admin and application configuration must be automated via your settings files and current with running configuration, i.e. it cannot have been altered via the Replicated Admin Console and not synced to the file. Specifically, you should be using the following configuration files:
 
 
 *   `/etc/replicated.conf`    - contains the configuration for the Replicated installer
@@ -34,7 +34,7 @@ All admin and application configuration must be automated via your settings file
 
 -> **Note**: The location for the latter is controlled by the "ImportSettingsFrom" setting in `/etc/replicated.conf` and is sometimes named `settings.json` or `replicated-tfe.conf`
 
-The requirement for automation is two-fold. First, the nodes need to be able to spin up and down without human intervention. More importantly though, you will need to ensure configuration is managed in this way going forward as the Admin UI will be disabled. **The Admin UI does not function correctly when running multiple nodes and must not be used**.
+The requirement for automation is two-fold. First, the nodes need to be able to spin up and down without human intervention. More importantly though, you will need to ensure configuration is managed in this way going forward as the Replicated Admin Console will be disabled. **The Replicated Admin Console does not function correctly when running multiple nodes and must not be used**.
 
 
 ### Step 1: Prepare to Externalize Redis
@@ -47,7 +47,7 @@ There are new access requirements involving ingress and egress:
 
 *   **Port 6379** (or the port the external Redis will be configured to use) must be open between the node instances and the Redis service
 *   **Port 8201** must be open between the node instances to allow Vault to run in [High Availability](https://www.vaultproject.io/docs/internals/high-availability) mode
-*   **Port 8800** should now be closed, as the admin dashboard is no longer available when running multiple nodes
+*   **Port 8800** should now be closed, as the Replicated Admin Console is no longer available when running multiple nodes
 
 
 #### Provision Redis 
@@ -374,7 +374,7 @@ For example:
    },
    "registry_session_secret_key":{
       "value":"6c1c4d73cc0a6cccbbb61284b0c32b35"
-   },
+   }
 }
 
 ```
@@ -456,7 +456,7 @@ You can now safely change the number of instances in your Auto Scaling Group ( o
 
 #### Disable the Admin Dashboard
 
-Before scaling beyond the first node, you must disable the Admin dashboard as mentioned earlier in this guide. This is done by adding the `disable-replicated-ui` flag as a parameter when you call the install script, as such:
+Before scaling beyond the first node, you must disable the  as mentioned earlier in this guide. This is done by adding the `disable-replicated-ui` flag as a parameter when you call the install script, as such:
 
 
 ```
@@ -489,7 +489,7 @@ You need to wait up to 15 minutes for the application to respond as healthy on b
 
 Finally, confirm the application is functioning as expected when running multiple nodes. Run Terraform plan and applies through the system (and any other tests specific to your environment) like you did to validate the application in Step 3. 
 
-Confirm the general functionality of the UI to validate the tokens you added in Step 2 are set correctly. Browse the `Run` interface and your organization's private registry to confirm your application functions as expected.
+Confirm the general functionality of the Terraform Enterprise UI to validate the tokens you added in Step 2 are set correctly. Browse the `Run` interface and your organization's private registry to confirm your application functions as expected.
 
 
 ## 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -106,7 +106,7 @@ The following example pins the deployment to the the ([v202101-1](https://github
 
 #### Update Application Settings
 
-The existing settings for the Terraform Enterprise application (`ptfe-settings.json`) are still needed and require to be expanded. Please see documentation for the existing options [here](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#application-settings).
+The existing settings for the Terraform Enterprise application (`ptfe-settings.json`) are still needed and require to be expanded. Please see documentation for the existing options [here](/docs/enterprise/install/automating-the-installer.html#application-settings).
 
 
 ##### Enable Active/Active
@@ -439,7 +439,7 @@ Which will output something similar to the following:
 
 Installation is complete once `isTransitioning` is `false` and `State` is `started`.
 
-See [Active/Active Administration](https://www.terraform.io/docs/enterprise/admin/active-active.html) for more status and troubleshooting commands.
+See [Active/Active Administration](/docs/enterprise/admin/active-active.html) for more status and troubleshooting commands.
 
 
 #### Validate Application

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -445,7 +445,7 @@ See [Active/Active Administration](https://www.terraform.io/docs/enterprise/admi
 
 #### Validate Application
 
-With installation complete, it is time to validate the new Redis connection. Terraform Enterprise uses Redis both as a cache for API requests and a queue for long running jobs, e.g. Terraform Runs.  Test the latter behavior by running real Terraform Plans & Applies through the system. 
+With installation complete, it is time to validate the new Redis connection. Terraform Enterprise uses Redis both as a cache for API requests and a queue for long running jobs, e.g. Terraform Runs. Test the latter behavior by running real Terraform plans and applies through the system. 
 
 Once you are satisfied the application is running as expected, you can move on to step 4 to scale up to two nodes.
 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -570,7 +570,7 @@ Requirements/Options:
 
 The default example provided on the provider page can be used to deploy memorystore [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance). The host output of the resource can then be provided to the terraform module in order to configure connectivity.
 
-You may consider using other options in the configuration depending on your requirements, such as including the **auth_enabled** flag set to true, which must then be accompanied by including an additional tfe configuration item called **redis_password** set to the value returned in the **auth_string** attribute from the memorystore resource.  
+You may consider using other options in the configuration depending on your requirements, such as including the **auth_enabled** flag set to true, which must then be accompanied by including an additional TFE configuration item called **redis_password** set to the value returned in the **auth_string** attribute from the memorystore resource.  
 
 
 ## 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -475,7 +475,7 @@ Scale down to zero nodes to fully disable the admin dashboard. Once the existing
 
 Now that you have tested your external Redis connection change the min and max instance count of your Auto Scaling Group to two nodes. 
 
--> **Note**: Running more than two instances is not _currently_ supported. Please contact your Technical Account Manager if there are any questions/concerns.
+-> **Note**: Running more than two instances is not _currently_ supported. Please contact your Customer Success Manager if there are any questions/concerns.
 
 
 #### Wait for Terraform Enterprise to Install

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -24,18 +24,17 @@ As mentioned above, the Active/Active architecture requires an existing [automat
 
 The primary requirement is an Auto Scaling Group (or equivalent) with a single instance running Terraform Enterprise. This ASG should be behind a Load Balancer and can be exposed to the public internet or not depending on your requirements. As mentioned earlier, the installation of the Terraform Enterprise application should be automated completely so that the ASG can be scaled to zero and back to one without human intervention. 
 
-The application itself should be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and block storage. 
+The application itself must be using [External Services](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision) mode to connect to an external PostgreSQL database and blob storage. 
 
-All admin and application configuration must be automated via your settings files, i.e. it cannot have been configured via the Admin UI. Specifically, you should be using the following configuration files:
+All admin and application configuration must be automated via your settings files and current with running configuration, i.e. it cannot have been altered via the Admin UI and not synced to the file. Specifically, you should be using the following configuration files:
 
 
+*   `/etc/replicated.conf`    - contains the configuration for the Replicated installer
+*   `/etc/ptfe-settings.json` - contains the configuration for the TFE application 
 
-*   **/etc/replicated.conf** which houses the configuration for the Replicated installer
-*   **/etc/ptfe-settings.json** which controls the configuration of TFE itself
+-> **Note**: The location for the latter is controlled by the "ImportSettingsFrom" setting in `/etc/replicated.conf` and is sometimes named `settings.json` or `replicated-tfe.conf`
 
--> **Note**: The location for the latter is controlled by the "ImportSettingsFrom" setting in `/etc/replicated.conf`
-
-The requirement for automation is two-fold. First, the nodes need to be able to spin up and down without human intervention. More importantly though, you will be disabling the Admin UI altogether later in this guide. **The Admin UI does not function correctly when running multiple nodes and must not be used** after Step 3 below.
+The requirement for automation is two-fold. First, the nodes need to be able to spin up and down without human intervention. More importantly though, you will need to ensure configuration is managed in this way going forward as the Admin UI will be disabled. **The Admin UI does not function correctly when running multiple nodes and must not be used**.
 
 
 ### Step 1: Prepare to Externalize Redis
@@ -43,13 +42,12 @@ The requirement for automation is two-fold. First, the nodes need to be able to 
 
 #### Prepare Network
 
-There are two new considerations when thinking about ingress and egress:
+There are new access requirements involving ingress and egress:
 
 
-
-*   **Port 6379** (or the port the external Redis will be configured to use below) must be open between the instances and the Redis service
-*   **Port 8201** must be open between the instances to allow Vault to run in [High Availability](https://www.vaultproject.io/docs/internals/high-availability) mode
-*   **Port 8800** should be closed; since the admin dashboard is no longer available when running multiple nodes
+*   **Port 6379** (or the port the external Redis will be configured to use) must be open between the node instances and the Redis service
+*   **Port 8201** must be open between the node instances to allow Vault to run in [High Availability](https://www.vaultproject.io/docs/internals/high-availability) mode
+*   **Port 8800** should now be closed, as the admin dashboard is no longer available when running multiple nodes
 
 
 #### Provision Redis 
@@ -61,17 +59,17 @@ Externalizing Redis allows multiple active application nodes. Terraform Enterpri
 
 ### Step 2: Update your Configuration File Templates
 
-Before installing, you need to make two sets of changes to the templates for the configuration files mentioned earlier in the prerequisites. 
+Before installing, you need to make changes to the templates for the configuration files mentioned earlier in the prerequisites. 
 
 
 #### Update Installer Settings
 
-The settings around the installer and infrastructure which are located at `/etc/replicated.conf`. Please see existing documentation around the options [here](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#installer-settings). 
+The existing settings for the installer and infrastructure (`replicated.conf`) are still needed and require to be expanded. Please see documentation for the existing options [here](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#installer-settings). 
 
 
 ##### Pin Your Version
 
-To expose the Active/Active functionality, you need to pin your installation to the appropriate  channel and release by setting the following in your `replicated.conf` file:
+To upgrade to the  Active/Active functionality and for ongoing upgrades, you need to pin your installation to the appropriate  release by setting the following:
 
 
 <table>
@@ -108,7 +106,7 @@ The following example pins the deployment to the the ([v202101-1](https://github
 
 #### Update Application Settings
 
-The settings for the Terraform Enterprise application are located by default in `/etc/ptfe-settings.json`. Please see the full documentation for more information [here](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#application-settings).
+The existing settings for the Terraform Enterprise application (`ptfe-settings.json`) are still needed and require to be expanded. Please see documentation for the existing options [here](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html#application-settings).
 
 
 ##### Enable Active/Active
@@ -148,7 +146,7 @@ The settings for the Terraform Enterprise application are located by default in 
 
 ##### Configure External Redis
 
-The updated application settings schema requires several new values in order to use an external Redis instance.
+The settings for the Terraform Enterprise application must also be expanded to support an external Redis instance:
 
 
 <table>
@@ -203,7 +201,7 @@ The updated application settings schema requires several new values in order to 
 </table>
 
 
-_* Fields marked with an asterisk are only necessary  if your external Redis instance requires them._
+_* Fields marked with an asterisk are only necessary if your particular external Redis instance requires them._
 
 For example:
 
@@ -233,7 +231,7 @@ For example:
 
 ##### Add Common Configuration
 
-!> A number of configuration values need to match between instances for the Active/Active architecture to function, the values of these tokens must be set to the same value in the `settings.json` on all instances:
+!> A number of Terraform Enterprise application configuration values must be added and are **required to be identical between node instances** for the Active/Active architecture to function:
 
 
 <table>
@@ -357,7 +355,7 @@ For example:
    
    "user_token":{
       "value":"6c403112981d0ae2ce6b4b2c7a1b1997"
-   }
+   },
   
    "archivist_token":{
       "value":"8019fe7227d1de1029ad7c1bf6f9e676"
@@ -382,7 +380,7 @@ For example:
 ```
 
 
--> **Note**: It’s the individual settings that need to match across nodes. All of these values do not need to be the same, e.g. `cookie_hash` and `internal_api_token` do not need to be the same.
+-> **Note**: The individual settings need to match across node instances. The values should not be the same, e.g. `cookie_hash` and `internal_api_token` would not contain identical values.
 
 
 ##### Tip: Generating Hex Values with Terraform
@@ -404,15 +402,15 @@ locals {
 
 ### Step 3: Connect to External Redis
 
-Once you include the above configuration options in your `settings.json` file, connect a single node to your newly provisioned Redis service. Before scaling to two nodes, ensure your new service functions as expected by testing on a single node.
+Once you are prepared to include the modified configuration options in your configuration files, you must connect a single node to your newly provisioned Redis service by rebuilding your node instance with the new settings.
 
-#### Reprovision Instance
+#### Re-provision Terraform Enterprise Instance
 
-You need to terminate the existing instance by scaling down to zero. Once you terminate the instance, you can scale back up to one instance using your latest config templates. 
+Terminate the existing instance by scaling down to zero. Once terminated, you can scale back up to one instance using your revised configuration. 
 
 #### Wait for Terraform Enterprise to Install
 
-It can take up to 15 minutes for the application to respond as healthy. You can monitor the status of the install by watching your Auto Scaling Group in your cloud’s web console. Alternatively, you can SSH onto the instance and run the following command to monitor the installation directly:
+It can take up to 15 minutes for the node instance to provision and the TFE application to be installed and respond as healthy. You can monitor the status of the node instance provisioning by watching your Auto Scaling Group in your cloud’s web console. To confirm the successful implementation of the TFE application you can SSH onto the instance and run the following command to monitor the installation directly:
 
 
 ```bash
@@ -442,12 +440,14 @@ Which will output something similar to the following:
 
 Installation is complete once `isTransitioning` is `false` and `State` is `started`.
 
+See [Active/Active Administration](https://www.terraform.io/docs/enterprise/admin/active-active.html) for more status and troubleshooting commands.
+
 
 #### Validate Application
 
-With installation complete, it is time to validate the new Redis connection. Terraform Enterprise uses Redis both as a cache for API requests and a queue for long running jobs, e.g. Terraform Runs.  You will want to test the latter behavior by running real Terraform Plans & Applies through the system. 
+With installation complete, it is time to validate the new Redis connection. Terraform Enterprise uses Redis both as a cache for API requests and a queue for long running jobs, e.g. Terraform Runs.  Test the latter behavior by running real Terraform Plans & Applies through the system. 
 
-Once you are satisfied the application is running as expected, scale to two nodes.
+Once you are satisfied the application is running as expected, you can move on to step 4 to scale up to two nodes.
 
 
 ### Step 4: Scale to Two Nodes
@@ -456,18 +456,17 @@ You can now safely change the number of instances in your Auto Scaling Group ( o
 
 #### Disable the Admin Dashboard
 
-Before you scale up, disable the Admin dashboard as mentioned earlier in this guide. Add the `disable-replicated-ui` flag when you call the install script, as such:
+Before scaling beyond the first node, you must disable the Admin dashboard as mentioned earlier in this guide. This is done by adding the `disable-replicated-ui` flag as a parameter when you call the install script, as such:
 
 
 ```
 sudo bash ./install.sh disable-replicated-ui
 ```
 
+Locate where the `install.sh` script is run as part of your provisioning/installation process and add the parameter. If there are other parameters on the same line, they should be left in place.
 
-You are almost there!
 
-
-##### Scale Down to Zero Nodes
+#### Scale Down to Zero Nodes
 
 Scale down to zero nodes to fully disable the admin dashboard. Once the existing instance has terminated...
 
@@ -476,47 +475,19 @@ Scale down to zero nodes to fully disable the admin dashboard. Once the existing
 
 Now that you have tested your external Redis connection change the min and max instance count of your Auto Scaling Group to two nodes. 
 
-!> Running more than two instances is not currently supported. Please reachout to your Technical Account Manager for questions/concerns.
+-> **Note**: Running more than two instances is not _currently_ supported. Please contact your Technical Account Manager if there are any questions/concerns.
 
 
 #### Wait for Terraform Enterprise to Install
 
-It can take up to 15 minutes for the application to respond as healthy. You can monitor the status of the install by watching your Auto Scaling Group in your cloud’s web console. Alternatively, you can SSH onto either instance and run the following command to monitor the installation directly:
+You need to wait up to 15 minutes for the application to respond as healthy on both nodes. Monitor the status of the install with the same methods used previously for one node in Step 3. 
 
-
-```bash
-replicatedctl app status
-```
-
-
-Which will output something similar to the following:
-
-
-```json
-[
-    {
-        "AppID": "218b78fa2bd6f0044c6a1010a51d5852",
-        "Sequence": 504,
-        "PatchSequence": 0,
-        "State": "starting",
-        "DesiredState": "started",
-        "IsCancellable": false,
-        "IsTransitioning": true,
-        "LastModifiedAt": "2021-01-07T21:15:11.650385151Z"
-    }
-]
-
-```
-
-
-Installation is complete once `isTransitioning` is `false` and `State` is `started`.
-
--> **Note**: This command only reports the status of the current node. 
+-> **Note**: Each node needs to be checked independently.
 
 
 #### Validate Application
 
-Finally, confirm the application is functioning as expected when running multiple nodes. You will want to run Terraform Plan and Applies through the system (and any other tests specific to your environment) like you did to validate the application in Step 3. 
+Finally, confirm the application is functioning as expected when running multiple nodes. Run Terraform Plan and Applies through the system (and any other tests specific to your environment) like you did to validate the application in Step 3. 
 
 Confirm the general functionality of the UI to validate the tokens you added in Step 2 are set correctly. Browse the `Run` interface and your organization's private registry to confirm your application functions as expected.
 
@@ -598,6 +569,8 @@ Requirements/Options:
 *   **redis_version** - Both 4.0 and 5.0 work without issue but 5.0 is recommended
 
 The default example provided on the provider page can be used to deploy memorystore [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance). The host output of the resource can then be provided to the terraform module in order to configure connectivity.
+
+You may consider using other options in the configuration depending on your requirements, such as including the **auth_enabled** flag set to true, which must then be accompanied by including an additional tfe configuration item called **redis_password** set to the value returned in the **auth_string** attribute from the memorystore resource.  
 
 
 ## 

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -453,9 +453,9 @@ Once you are satisfied the application is running as expected, you can move on t
 
 You can now safely change the number of instances in your Auto Scaling Group ( or equivalent) to two.
 
-#### Disable the Admin Dashboard
+#### Disable the Replicated Admin Console
 
-Before scaling beyond the first node, you must disable the  as mentioned earlier in this guide. This is done by adding the `disable-replicated-ui` flag as a parameter when you call the install script, as such:
+Before scaling beyond the first node, you must disable the Replicated Admin Console as mentioned earlier in this guide. This is done by adding the `disable-replicated-ui` flag as a parameter when you call the install script, as such:
 
 
 ```

--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -380,7 +380,7 @@ For example:
 ```
 
 
--> **Note**: The individual settings need to match across node instances. The values should not be the same, e.g. `cookie_hash` and `internal_api_token` would not contain identical values.
+-> **Note**: The individual settings need to match across nodes. The values should not be the same, e.g. `cookie_hash` and `internal_api_token` would not contain identical values.
 
 
 ##### Tip: Generating Hex Values with Terraform

--- a/content/source/layouts/_enterprise_content.erb
+++ b/content/source/layouts/_enterprise_content.erb
@@ -98,7 +98,7 @@
                 <a href="/docs/enterprise/install/automating-the-installer.html">Automated Installation</a>
               </li>
               <li>
-                <a href="/docs/enterprise/install/active-active.html">Scale to Two Nodes</a>
+                <a href="/docs/enterprise/install/active-active.html">Active/Active</a>
               </li>
               <li>
                 <a href="/docs/enterprise/install/automating-initial-user.html">Initial User Automation </a>
@@ -188,6 +188,9 @@
               </li>
               <li>
                 <a href="/docs/enterprise/admin/backup-restore.html">Backups and Restores</a>
+              </li>
+              <li>
+                <a href="/docs/enterprise/admin/active-active.html">Active/Active</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Updated the Active/Active migration document to clarify some items and correct some typos.
Changed the left-bar index heading to say Active/Active instead of Scale to Two Nodes to be more clear.
Added a new doc under Admin for Active/Active that describes available commands and upgrade/repaving process.

Asking the original authors and another CSA to approve the changes. Feel free to ask others if needed.