### PR TITLE
Add documentation for Manage Policy Overrides

### DIFF
--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -187,7 +187,7 @@ If the specified workspace uses Sentinel policies, those policies will run again
 Failed policies can pause or prevent an apply, depending on the enforcement level:
 
 - Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
-- Soft mandatory checks can be overridden by users with permission to [manage policies](/docs/cloud/users-teams-organizations/permissions.html#manage-policies). If your account can override a failed check, Terraform will prompt you to type "override" to confirm. (Note that typing "yes" will not work.) If you override the check, you will be prompted to apply the run (unless auto-apply is enabled).
+- Soft mandatory checks can be overridden by users with permission to [manage policy overrides](/docs/cloud/users-teams-organizations/permissions.html#manage-policy-overrides). If your account can override a failed check, Terraform will prompt you to type "override" to confirm. (Note that typing "yes" will not work.) If you override the check, you will be prompted to apply the run (unless auto-apply is enabled).
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/run/manage.html.md
+++ b/content/source/docs/cloud/run/manage.html.md
@@ -44,7 +44,7 @@ Button              | Available when:
 --------------------|----------------
 Add Comment         | Always.
 Confirm & Apply     | A plan needs confirmation.
-Override & Continue | A soft-mandatory policy failed. Requires permission to manage policies for the organization. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+Override & Continue | A soft-mandatory policy failed. Requires permission to manage policy overrides for the organization. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 Discard Run         | A plan needs confirmation or a soft-mandatory policy failed.
 Cancel Run          | A plan or apply is currently running.
 Force Cancel Run    | A plan or apply was canceled, but something went wrong and Terraform Cloud couldn't end the run gracefully. Requires admin access to the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))

--- a/content/source/docs/cloud/run/states.html.md
+++ b/content/source/docs/cloud/run/states.html.md
@@ -64,7 +64,7 @@ This stage only occurs if [Sentinel policies][] are enabled. After a successful 
 _States in this stage:_
 
 - **Policy Check:** Terraform Cloud is currently checking the plan against the organization's policies.
-- **Policy Override:** The policy check finished, but a soft-mandatory policy failed, so an apply cannot proceed without approval from a user with permission to manage policies for the organization. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html)) The run pauses in this state.
+- **Policy Override:** The policy check finished, but a soft-mandatory policy failed, so an apply cannot proceed without approval from a user with permission to manage policy overrides for the organization. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html)) The run pauses in this state.
 - **Policy Checked:** The policy check succeeded, and Sentinel will allow an apply to proceed. The run sometimes pauses in this state, depending on workspace settings.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
@@ -73,7 +73,7 @@ _Leaving this stage:_
 
 - If any hard-mandatory policies failed, the run skips to completion (**Plan Errored** state).
 - If any soft-mandatory policies failed, the run pauses in the **Policy Override** state.
-    - If a user with permission to manage policies overrides the failed policy, the run proceeds to the **Policy Checked** state. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+    - If a user with permission to manage policy overrides, overrides the failed policy, the run proceeds to the **Policy Checked** state. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
     - If a user with permission to apply runs discards the run, the run skips to completion (**Discarded** state). ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 - If the run reaches the **Policy Checked** state (no mandatory policies failed, or soft-mandatory policies were overridden):
     - If the plan can be auto-applied, the run proceeds automatically to the apply stage. Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was queued by a new VCS commit or by a user with permission to apply runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -17,7 +17,7 @@ Enforcement level details can be found in the [Managing Policies](./manage-polic
 
 All `hard mandatory` and `soft mandatory` policies must pass in order for the run to continue to the the "Confirm & Apply" state.
 
-If a `soft mandatory` policy fails, users with permission to manage policies will be presented with an "Override & Continue" button in the run. They have the ability to override the failed check and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+If a `soft mandatory` policy fails, users with permission to override policies will be presented with an "Override & Continue" button in the run. They have the ability to override the failed check and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/sentinel/manage-policies.html.md
+++ b/content/source/docs/cloud/sentinel/manage-policies.html.md
@@ -39,7 +39,7 @@ Policy sets are managed at an organization level; viewing and modifying them req
 Enforcement levels in Sentinel are used for defining behavior when policies fail to evaluate successfully. Sentinel provides three enforcement modes:
 
 * `hard-mandatory` requires that the policy passes. If a policy fails, the run is halted and may not be applied until the failure is resolved.
-* `soft-mandatory` is much like `hard-mandatory`, but allows any user with the [Manage Policies](../users-teams-organizations/permissions.html#manage-policies) permission to override policy failures on a case-by-case basis.
+* `soft-mandatory` is much like `hard-mandatory`, but allows any user with the [Manage Policy Overrides](../users-teams-organizations/permissions.html#manage-policy-overrides) permission to override policy failures on a case-by-case basis.
 * `advisory` will never interrupt the run, and instead will only surface policy failures as informational to the user.
 
 ## Constructing a policy set

--- a/content/source/docs/cloud/users-teams-organizations/permissions.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/permissions.html.md
@@ -27,6 +27,7 @@ Permissions for the owners team include:
 
 - Manage workspaces (see [Organization Permissions][] below; equivalent to admin permissions on every workspace)
 - Manage policies (see [Organization Permissions][] below)
+- Manage policy overrides (see [Organization Permissions][] below)
 - Manage VCS settings (see [Organization Permissions][] below)
 - Publish private modules (owners only)
 - Invite users to organization (owners only)
@@ -152,9 +153,15 @@ Separate from workspace permissions, teams can be granted permissions to manage 
 
 ### Manage Policies
 
-Allows members to create, edit, and delete the organization's Sentinel policies and override soft-mandatory policy checks.
+Allows members to create, edit, and delete the organization's Sentinel policies.
 
 This permission implicitly gives permission to read runs on all workspaces, which is necessary to set enforcement of [policy sets](../sentinel/manage-policies.html).
+
+### Manage Policy Overrides
+
+Allows members to override soft-mandatory policy checks.
+
+This permission implicitly gives permission to read runs on all workspaces, which is necessary to override policy checks.
 
 ### Manage Workspaces
 

--- a/content/source/docs/cloud/users-teams-organizations/teams.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/teams.html.md
@@ -121,7 +121,7 @@ Organization-level permissions (see [Managing Organization Access](./teams.html#
 
 ## Managing Organization Access
 
-A team can be granted permissions to manage policies, workspaces, and/or VCS settings across an organization.
+A team can be granted permissions to manage policies, workspaces, VCS settings, and/or policy overrides across an organization.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 


### PR DESCRIPTION
A new permission, `Manage Policy Overrides` is being added to the `Organization Permissions`. This permission specifically enables a team to perform soft-mandatory overrides on policy checks.

## Labels

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
