### PR TITLE
Remove badges from the HashiStackMenu

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -183,7 +183,6 @@
                               alt="consul by HashiCorp"
                             />
                             <span class="productName itemName">consul</span>
-                            <span class="badge">Generally Available</span>
                             </a>
                         </li>
                           <li class="stackItem">
@@ -202,7 +201,6 @@
                                 class="productIcon"
                                 alt="vault by HashiCorp"
                               /><span class="productName itemName">vault</span>
-                              <span class="badge">Public Beta</span>
                               </a
                             >
                           </li>


### PR DESCRIPTION
Remove the badges from the HCP products on the HashiStackMenu, as they are no longer needed.

## Before
<img width="825" alt="before" src="https://user-images.githubusercontent.com/2105067/113766078-e341be80-96d1-11eb-828f-8409c2b184b5.png">

## After
<img width="818" alt="after" src="https://user-images.githubusercontent.com/2105067/113766098-e8067280-96d1-11eb-84d1-3d2fc588924f.png">

## Labels

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
