### PR TITLE
Reference Arch: AWS: Be more explicit about regional outages

### DIFF
--- a/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
@@ -340,9 +340,9 @@ failure on a regional AWS service. In this section, implementation patterns to s
 We recommend provisioning an identical infrastructure in a secondary AWS
 Region. Depending on recovery time objectives and tolerances for
 additional cost to support AWS Region failure, the infrastructure can be
-running (Warm Standby) or stopped (Cold Standby). Please note that with _Standalone_ implementation mode, only one Terraform Enterprise instance can be running against the same database. This deployment acts to minimize the Mean Time To Recovery (MTTR) in the event of a regional failure, avoiding the need to replicate and stand up the data plane infrastructure during an outage. In the event of the primary AWS Region hosting the Terraform Enterprise application fail, the secondary
-AWS Region will require some configuration before traffic is directed to
-it along with some global services such as DNS.
+running (Warm Standby) or stopped (Cold Standby). Please note that with _Standalone_ implementation mode, only one Terraform Enterprise instance can be running against the same database. 
+
+This deployment acts to minimize the Mean Time To Recovery (MTTR) in the event of a regional failure, avoiding the need to replicate and stand up the data plane infrastructure during an outage. If the primary AWS Region hosting the Terraform Enterprise application fails, you will need to perform some configuration before traffic is directed to the secondary AWS Region:
 
 - [RDS cross-region read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.XRgn) can be used in a warm standby architecture or [RDS database backups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_CommonTasks.BackupRestore.html) can be used in a cold standby architecture.
 

--- a/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
@@ -340,12 +340,9 @@ failure on a regional AWS service. In this section, implementation patterns to s
 An identical infrastructure should be provisioned in a secondary AWS
 Region. Depending on recovery time objectives and tolerances for
 additional cost to support AWS Region failure, the infrastructure can be
-running (Warm Standby) or stopped (Cold Standby). In the event of the
-primary AWS Region hosting the Terraform Enterprise application failing, the secondary
+running (Warm Standby) or stopped (Cold Standby). Please note that with _Standalone_ implementation mode, only one Terraform Enterprise instance can be running against the same database. This deployment acts to minimize the Mean Time To Recovery (MTTR) in the event of a regional failure, avoiding the need to replicate and stand up the data plane infrastructure during an outage. In the event of the primary AWS Region hosting the Terraform Enterprise application fail, the secondary
 AWS Region will require some configuration before traffic is directed to
 it along with some global services such as DNS.
-
-Please note that with _Standalone_ implementation mode, only one Terraform Enterprise instance can be running against the same database. This deployment acts to minimize the Mean Time To Recovery (MTTR) in the event of a regional failure, avoiding the need to replicate and stand up the data plane infrastructure during an outage.
 
 - [RDS cross-region read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.XRgn) can be used in a warm standby architecture or [RDS database backups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_CommonTasks.BackupRestore.html) can be used in a cold standby architecture.
 

--- a/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
@@ -337,7 +337,7 @@ single AWS Region. Using multiple AWS Regions will give you greater
 control over your recovery time in the event of a hard dependency
 failure on a regional AWS service. In this section, implementation patterns to support this are discussed.
 
-An identical infrastructure should be provisioned in a secondary AWS
+We recommend provisioning an identical infrastructure in a secondary AWS
 Region. Depending on recovery time objectives and tolerances for
 additional cost to support AWS Region failure, the infrastructure can be
 running (Warm Standby) or stopped (Cold Standby). Please note that with _Standalone_ implementation mode, only one Terraform Enterprise instance can be running against the same database. This deployment acts to minimize the Mean Time To Recovery (MTTR) in the event of a regional failure, avoiding the need to replicate and stand up the data plane infrastructure during an outage. In the event of the primary AWS Region hosting the Terraform Enterprise application fail, the secondary

--- a/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
+++ b/content/source/docs/enterprise/before-installing/reference-architecture/aws.md
@@ -345,6 +345,8 @@ primary AWS Region hosting the Terraform Enterprise application failing, the sec
 AWS Region will require some configuration before traffic is directed to
 it along with some global services such as DNS.
 
+Please note that with _Standalone_ implementation mode, only one Terraform Enterprise instance can be running against the same database. This deployment acts to minimize the Mean Time To Recovery (MTTR) in the event of a regional failure, avoiding the need to replicate and stand up the data plane infrastructure during an outage.
+
 - [RDS cross-region read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html#USER_ReadRepl.XRgn) can be used in a warm standby architecture or [RDS database backups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_CommonTasks.BackupRestore.html) can be used in a cold standby architecture.
 
 - [S3 cross-region replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) must be configured so the object storage component of the Storage Layer is available in the secondary AWS Region.


### PR DESCRIPTION
The wording of "Multi-Region Deployment to Address Region Failure" seems to imply the need to replicate the TFE EC2 instance as the warm standby ("An identical infrastructure should be provisioned in a secondary AWS
Region."), but it's the data plane that requires cross-region replication.

Recently had a support ticket where this wording was a source of confusion.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
