### PR TITLE
testcase.html.md: Clear error in declaration

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -177,7 +177,7 @@ var testAccProviders map[string]*schema.Provider
 var testAccProvider *schema.Provider
 
 func init() {
-  testAccProvider = Provider().(*schema.Provider)
+  testAccProvider = Provider()
   testAccProviders = map[string]*schema.Provider{
     "example": testAccProvider,
   }


### PR DESCRIPTION
In line 180 you have `testAccProvider = Provider()(*schema.Provider)`. As is this generates the error message `Invalid type assertion: Provider().(*schema.Provider) (non-interface type *schema.Provider on the left`. `Provider()` is already of type `*schema.Provider` so you shouldn't need to cast it again. Changing it to `testAccProvider = Provider()` clears the error. Then again, I'm new so feel free to tell me if I've misunderstood something and close out the PR 😂

Signed-off-by: Grant Curell <grant_curell@dell.com>

## Labels

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
