### PR TITLE
Clarify Audit Events

### DIFF
--- a/content/source/docs/cloud/api/audit-trails.html.md
+++ b/content/source/docs/cloud/api/audit-trails.html.md
@@ -24,17 +24,17 @@ page_title: "Audit Trails - API Docs - Terraform Cloud"
 
 -> **Note:** Audit trails are a paid feature, available as part of the **Terraform Cloud for Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
--> **Note:** This endpoint cannot be accessed with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/api-tokens.html#team-api-tokens). You must access it with an [organization token](../users-teams-organizations/api-tokens.html#organization-api-tokens).
-
--> **Note:** Unlike other endpoints, the Audit Trails API does not use the [JSON API specification](./index.html#json-api-formatting).
+-> **Note:** Unlike other APIs, the Audit Trails API does not use the [JSON API specification](./index.html#json-api-formatting).
 
 -> **Note:** Terraform Cloud retains 14 days of audit log information.
 
 The audit trails API exposes a stream of audit events, which describe changes to the application entities (workspaces, runs, etc.) that belong to a Terraform Cloud organization.
 
-## List Audit Trails
+## List an organization's audit events
 
 `GET /organization/audit-trail`
+
+-> **Note:** This endpoint cannot be accessed with a [user token](../users-teams-organizations/users.html#api-tokens) or [team token](../users-teams-organizations/api-tokens.html#team-api-tokens). You must access it with an [organization token](../users-teams-organizations/api-tokens.html#organization-api-tokens).
 
 ### Query Parameters
 


### PR DESCRIPTION
A slight clarification, noticed from [adding this API to the TFC Go client](https://github.com/hashicorp/go-tfe/pull/199): The objects retrieved from this endpoint are a list of audit events, not themselves audit trails - the audit trail refers to the collection of audit events.

![image](https://user-images.githubusercontent.com/2430490/114582470-3b367300-9c46-11eb-9c3a-61e41e258725.png)

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
