### PR TITLE
Follow 301 and 308 redirects in PR link checker (instead of erroring)

### DIFF
--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -30,7 +30,7 @@ If certain hostnames should not use the proxy and the instance should connect di
 
 ```
 ./install.sh additional-no-proxy=s3.amazonaws.com,internal-vcs.mycompany.com,example.com
-````
+```
 
 Passing this option to the installation script is particularly useful if the hostnames that should not use the proxy include services that the instance needs to be able to reach during installation, such as S3. Alternately, if the only hosts you need to add are those that are not used during installation, such as a private VCS instance, you can provide these hosts after initial installation is complete, in the settings tab in your dashboard (available on port 8800 under `/console/settings`).
 


### PR DESCRIPTION
This came up in https://github.com/hashicorp/terraform-website/pull/1687.

- Return a recursive call with the new URL, so if it's 200 we're 200.
- Use URI.join in case Location is a relative (to the request) URL.
- Cheeky little guard for infinite redirect loops.
- Log a warning so you can update it if you're fixing something else anyway.