### PR TITLE
Fixing broken link

### DIFF
--- a/content/source/docs/cloud/architectural-details/security-model.html.md
+++ b/content/source/docs/cloud/architectural-details/security-model.html.md
@@ -38,7 +38,7 @@ Terraform Cloud executes Terraform configuration from connected VCS repositories
 
 ## Authorization Model
 
-<a href="/../../../assets/images/docs/terraform-cloud-authorization.png" target="_blank">
+<a href="../../../assets/images/docs/terraform-cloud-authorization.png" target="_blank">
 ![Terraform Cloud authorization model diagram](../../../assets/images/docs/terraform-cloud-authorization.png)
 </a>
 _Click on the diagram for a larger view._

--- a/content/source/docs/cloud/architectural-details/security-model.html.md
+++ b/content/source/docs/cloud/architectural-details/security-model.html.md
@@ -38,9 +38,7 @@ Terraform Cloud executes Terraform configuration from connected VCS repositories
 
 ## Authorization Model
 
-<a href="../../../assets/images/docs/terraform-cloud-authorization.png" target="_blank">
-![Terraform Cloud authorization model diagram](../../../assets/images/docs/terraform-cloud-authorization.png)
-</a>
+[![Terraform Cloud authorization model diagram](../../../assets/images/docs/terraform-cloud-authorization.png)](../../../assets/images/docs/terraform-cloud-authorization.png)
 _Click on the diagram for a larger view._
 
 ~> **Note:** This diagram displays a useful subset of TFC’s authorization model, but is not comprehensive. Some details were omitted for the sake of clarity. More information is available in our [Permissions documentation](../users-teams-organizations/permissions.html).


### PR DESCRIPTION
# Labels

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [X ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout

# Description
Fixing a broken link that prevents the image on the security model page from opening in a new tab.