### PR TITLE
Tweaks TFC runtime environment documentation to clarify that the run values can be accessed as Terraform input variables

### DIFF
--- a/content/source/docs/cloud/run/run-environment.html.md
+++ b/content/source/docs/cloud/run/run-environment.html.md
@@ -81,3 +81,9 @@ Terraform Cloud for each run:
 - `TFC_CONFIGURATION_VERSION_GIT_TAG` - This is the name of the tag
   that the associated Terraform configuration version was ingressed from
   (e.g. `"v0.1.0"`).
+
+They are also available as Terraform input variables by defining a variable with the same name. E.g.
+
+```terraform
+variable "TFC_RUN_ID" {}
+```


### PR DESCRIPTION
When I read the documentation on TFC run environment variables, it wasn't clear that they could be accessed as Terraform input variables using the same name as the environment variable.

My confusion was due to Terraform requiring the prefix `TF_VAR_` for environment variables used to set input variables. Perhaps an overly-literal reading on my part, but this will clarify it.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
