### PR TITLE
add refresh & replace to run api docs

### DIFF
--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -83,6 +83,9 @@ Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
 `data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources.
 `data.attributes.message` | string | "Queued manually via the Terraform Enterprise API" | Specifies the message to be associated with this run.
+`data.attributes.refresh` | bool | true | Specifies whether or not to refresh the state before a plan.
+`data.attributes.refresh-only` | bool | false | Specifies whether the run should ignore configuration changes and only refresh the state.
+`data.attributes.replace-addrs` | array[string] | (nothing) | Specifies an optional list of resource addresses to be passed to the `-replace` flag.
 `data.attributes.target-addrs` | array[string] | (nothing) | Specifies an optional list of resource addresses to be passed to the `-target` flag.
 `data.relationships.workspace.data.id` | string | (nothing) | Specifies the workspace ID where the run will be executed.
 `data.relationships.configuration-version.data.id` | string | (nothing) | Specifies the configuration version to use for this run. If the `configuration-version` object is omitted, the run will be created using the workspace's latest configuration version.
@@ -103,6 +106,9 @@ Status  | Response                               | Reason
     "attributes": {
       "is-destroy": false,
       "message": "Custom message",
+      "refresh": false,
+      "refresh-only": false,
+      "replace-addrs": ["example.resource_address"],
       "target-addrs": ["example.resource_address"]
     },
     "type":"runs",
@@ -143,35 +149,46 @@ curl \
     "id": "run-CZcmD7eagjhyX0vN",
     "type": "runs",
     "attributes": {
-      "auto-apply": false,
-      "error-text": null,
-      "is-destroy": false,
-      "message": "Custom Message",
-      "metadata": {},
-      "source": "tfe-ui",
-      "status": "pending",
-      "status-timestamps": {},
-      "terraform-version": "0.10.8",
-      "created-at": "2017-11-29T19:56:15.205Z",
-      "has-changes": false,
-      "target-addrs": ["example.resource_address"],
       "actions": {
         "is-cancelable": true,
         "is-confirmable": false,
         "is-discardable": false,
+        "is-force-cancelable": false
       },
+      "canceled-at": null,
+      "created-at": "2021-05-24T07:38:04.171Z",
+      "has-changes": false,
+      "is-destroy": false,
+      "message": "Custom message",
+      "plan-only": false,
+      "source": "tfe-api",
+      "status-timestamps": {
+        "plan-queueable-at": "2021-05-24T07:38:04+00:00"
+      },
+      "status": "pending",
+      "trigger-reason": "manual",
+      "target-addrs": [
+        "example.resource_address"
+      ],
       "permissions": {
         "can-apply": true,
         "can-cancel": true,
+        "can-comment": true,
         "can-discard": true,
-        "can-force-execute": true
-      }
+        "can-force-execute": true,
+        "can-force-cancel": true,
+        "can-override-policy-check": true
+      },
+      "refresh": false,
+      "refresh-only": false,
+      "replace-addrs": [
+        "example.resource_address"
+      ]
     },
     "relationships": {
       "apply": {...},
-      "canceled-by": { ... },
+      "comments": {...},
       "configuration-version": {...},
-      "confirmed-by": {...},
       "cost-estimate": {...},
       "created-by": {...},
       "input-state-version": {...},
@@ -179,7 +196,6 @@ curl \
       "run-events": {...},
       "policy-checks": {...},
       "workspace": {...},
-      "comments": {...},
       "workspace-run-alerts": {...}
       }
     },
@@ -285,52 +301,58 @@ curl \
 {
   "data": [
     {
-      "id": "run-bWSq4YeYpfrW4mx7",
+      "id": "run-CZcmD7eagjhyX0vN",
       "type": "runs",
       "attributes": {
-        "auto-apply": false,
-        "error-text": null,
-        "is-destroy": false,
-        "message": "",
-        "metadata": {},
-        "source": "tfe-configuration-version",
-        "status": "planned",
-        "status-timestamps": {
-          "planned-at": "2017-11-28T22:52:51+00:00"
-        },
-        "terraform-version": "0.11.0",
-        "created-at": "2017-11-28T22:52:46.711Z",
-        "has-changes": true,
         "actions": {
-          "is-cancelable": false,
-          "is-confirmable": true,
-          "is-discardable": true,
+          "is-cancelable": true,
+          "is-confirmable": false,
+          "is-discardable": false,
           "is-force-cancelable": false
         },
+        "canceled-at": null,
+        "created-at": "2021-05-24T07:38:04.171Z",
+        "has-changes": false,
+        "is-destroy": false,
+        "message": "Custom message",
+        "plan-only": false,
+        "source": "tfe-api",
+        "status-timestamps": {
+          "plan-queueable-at": "2021-05-24T07:38:04+00:00"
+        },
+        "status": "pending",
+        "trigger-reason": "manual",
+        "target-addrs": [
+          "example.resource_address"
+        ],
         "permissions": {
           "can-apply": true,
           "can-cancel": true,
+          "can-comment": true,
           "can-discard": true,
-          "can-force-cancel": false,
-          "can-force-execute": true
-        }
+          "can-force-execute": true,
+          "can-force-cancel": true,
+          "can-override-policy-check": true
+        },
+        "refresh": false,
+        "refresh-only": false,
+        "replace-addrs": [
+          "example.resource_address"
+        ]
       },
       "relationships": {
-        "workspace": {...},
         "apply": {...},
-        "canceled-by": {...},
+        "comments": {...},
         "configuration-version": {...},
-        "confirmed-by": {...},
         "cost-estimate": {...},
         "created-by": {...},
         "input-state-version": {...},
         "plan": {...},
         "run-events": {...},
         "policy-checks": {...},
-        "comments": {...},
-        "workspace-run-alerts": {...},
-        "triggering-source": {...},
-        "triggering-run": {...}
+        "workspace": {...},
+        "workspace-run-alerts": {...}
+        }
       },
       "links": {
         "self": "/api/v2/runs/run-bWSq4YeYpfrW4mx7"
@@ -369,52 +391,58 @@ curl \
 ```json
 {
   "data": {
-    "id": "run-bWSq4YeYpfrW4mx7",
+    "id": "run-CZcmD7eagjhyX0vN",
     "type": "runs",
     "attributes": {
-      "auto-apply": false,
-      "error-text": null,
-      "is-destroy": false,
-      "message": "",
-      "metadata": {},
-      "source": "tfe-configuration-version",
-      "status": "planned",
-      "status-timestamps": {
-        "planned-at": "2017-11-28T22:52:51+00:00"
-      },
-      "terraform-version": "0.11.0",
-      "created-at": "2017-11-28T22:52:46.711Z",
-      "has-changes": true,
       "actions": {
-        "is-cancelable": false,
-        "is-confirmable": true,
-        "is-discardable": true,
+        "is-cancelable": true,
+        "is-confirmable": false,
+        "is-discardable": false,
         "is-force-cancelable": false
       },
+      "canceled-at": null,
+      "created-at": "2021-05-24T07:38:04.171Z",
+      "has-changes": false,
+      "is-destroy": false,
+      "message": "Custom message",
+      "plan-only": false,
+      "source": "tfe-api",
+      "status-timestamps": {
+        "plan-queueable-at": "2021-05-24T07:38:04+00:00"
+      },
+      "status": "pending",
+      "trigger-reason": "manual",
+      "target-addrs": [
+        "example.resource_address"
+      ],
       "permissions": {
         "can-apply": true,
         "can-cancel": true,
+        "can-comment": true,
         "can-discard": true,
-        "can-force-cancel": false,
-        "can-force-execute": true
-      }
+        "can-force-execute": true,
+        "can-force-cancel": true,
+        "can-override-policy-check": true
+      },
+      "refresh": false,
+      "refresh-only": false,
+      "replace-addrs": [
+        "example.resource_address"
+      ]
     },
     "relationships": {
-      "workspace": {...},
       "apply": {...},
-      "canceled-by": {...},
+      "comments": {...},
       "configuration-version": {...},
-      "confirmed-by": {...},
       "cost-estimate": {...},
       "created-by": {...},
       "input-state-version": {...},
       "plan": {...},
       "run-events": {...},
       "policy-checks": {...},
-      "comments": {...},
-      "workspace-run-alerts": {...},
-      "triggering-source": {...},
-      "triggering-run": {...}
+      "workspace": {...},
+      "workspace-run-alerts": {...}
+      }
     },
     "links": {
       "self": "/api/v2/runs/run-bWSq4YeYpfrW4mx7"

--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -81,10 +81,10 @@ Properties without a default value are required.
 
 Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
-`data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources.
+`data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources. Mutually exclusive with `refresh-only`.
 `data.attributes.message` | string | "Queued manually via the Terraform Enterprise API" | Specifies the message to be associated with this run.
 `data.attributes.refresh` | bool | true | Specifies whether or not to refresh the state before a plan.
-`data.attributes.refresh-only` | bool | false | Specifies whether the run should ignore configuration changes and only refresh the state.
+`data.attributes.refresh-only` | bool | false | Whether this run should use the refresh-only plan mode, which will refresh the state without modifying any resources. Mutually exclusive with `is-destroy`.
 `data.attributes.replace-addrs` | array[string] | (nothing) | Specifies an optional list of resource addresses to be passed to the `-replace` flag.
 `data.attributes.target-addrs` | array[string] | (nothing) | Specifies an optional list of resource addresses to be passed to the `-target` flag.
 `data.relationships.workspace.data.id` | string | (nothing) | Specifies the workspace ID where the run will be executed.
@@ -104,12 +104,7 @@ Status  | Response                               | Reason
 {
   "data": {
     "attributes": {
-      "is-destroy": false,
       "message": "Custom message",
-      "refresh": false,
-      "refresh-only": false,
-      "replace-addrs": ["example.resource_address"],
-      "target-addrs": ["example.resource_address"]
     },
     "type":"runs",
     "relationships": {
@@ -167,9 +162,7 @@ curl \
       },
       "status": "pending",
       "trigger-reason": "manual",
-      "target-addrs": [
-        "example.resource_address"
-      ],
+      "target-addrs": null,
       "permissions": {
         "can-apply": true,
         "can-cancel": true,
@@ -181,9 +174,7 @@ curl \
       },
       "refresh": false,
       "refresh-only": false,
-      "replace-addrs": [
-        "example.resource_address"
-      ]
+      "replace-addrs": null
     },
     "relationships": {
       "apply": {...},
@@ -322,9 +313,7 @@ curl \
         },
         "status": "pending",
         "trigger-reason": "manual",
-        "target-addrs": [
-          "example.resource_address"
-        ],
+        "target-addrs": null,
         "permissions": {
           "can-apply": true,
           "can-cancel": true,
@@ -336,9 +325,7 @@ curl \
         },
         "refresh": false,
         "refresh-only": false,
-        "replace-addrs": [
-          "example.resource_address"
-        ]
+        "replace-addrs": null
       },
       "relationships": {
         "apply": {...},
@@ -412,9 +399,7 @@ curl \
       },
       "status": "pending",
       "trigger-reason": "manual",
-      "target-addrs": [
-        "example.resource_address"
-      ],
+      "target-addrs": null,
       "permissions": {
         "can-apply": true,
         "can-cancel": true,
@@ -426,9 +411,7 @@ curl \
       },
       "refresh": false,
       "refresh-only": false,
-      "replace-addrs": [
-        "example.resource_address"
-      ]
+      "replace-addrs": null
     },
     "relationships": {
       "apply": {...},

--- a/content/source/docs/cloud/run/cli.html.md
+++ b/content/source/docs/cloud/run/cli.html.md
@@ -220,18 +220,6 @@ Do you want to override the soft failed policy check?
   Enter a value: override
 ```
 
-## Targeted Plan and Apply
+## Options for Plans and Applies
 
--> **Version note:** Targeting support was added client-side in Terraform v0.12.26 and also requires server-side support that may not be available for all Terraform Enterprise deployments yet.
-
-The `terraform plan` and `terraform apply` commands described in earlier
-sections support [Resource Targeting](https://www.terraform.io/docs/cli/commands/plan.html#resource-targeting) as in the local operations workflow, using the `-target` option on the command line.
-
-As with local usage, targeting is intended for exceptional circumstances only
-and should not be used routinely. The usual caveats for targeting in local operations imply some additional limitations on Terraform Cloud features for remote plans created with targeting:
-
-* [Sentinel](../sentinel/) policy checks for targeted plans will see only the selected subset of resource instances planned for changes in [the `tfplan` import](../sentinel/import/tfplan.html) and [the `tfplan/v2` import](../sentinel/import/tfplan-v2.html), which may cause an unintended failure for any policy that requires a planned change to a particular resource instance selected by its address.
-
-* [Cost Estimation](../cost-estimation/) is disabled for any run created with `-target` set, to prevent producing a misleading underestimate of cost due to resource instances being excluded from the plan.
-
-You can disable or constrain use of targeting in a particular workspace using a Sentinel policy based on [the `tfrun.target_addrs` value](../sentinel/import/tfrun.html#value-target_addrs).
+To understand the various options available for plans and applies using the CLI-driven workflow, see [Run Modes and Options](/docs/cloud/run/modes-and-options.html).

--- a/content/source/docs/cloud/run/modes-and-options.html.md
+++ b/content/source/docs/cloud/run/modes-and-options.html.md
@@ -5,43 +5,51 @@ page_title: "Run Modes and Options - Runs - Terraform Cloud and Terraform Enterp
 
 # Run Modes and Options
 
-Terraform Cloud support many of the same modes and options available in local operations mode.
+Terraform Cloud runs support many of the same modes and options available in the Terraform CLI.
 
 ## Destroy Mode
 
 [Destroy mode](/docs/cli/commands/plan.html#planning-modes) instructs Terraform to create a plan which destroys all objects, regardless of configuration changes.
 
-Command line users can activate destroy mode using `terraform plan -destroy` or `terraform destroy`, while API users can use the `is-destroy` option. Destroy runs may also be created through the UI via the workspace's "Destruction and Deletion" settings page.
+- **CLI:** Use `terraform plan -destroy` or `terraform destroy`
+- **API:** Use the `is-destroy` option.
+- **UI:** Use a workspace's "Destruction and Deletion" settings page.
 
 ## Refresh-Only Mode
 
--> **Version note:** Refresh-only support is available in Terraform CLI versions v0.15.4 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202106-1 and later.
+-> **Version note:** Refresh-only support is available in Terraform Enterprise v202106-1 or later and requires a workspace using at least Terraform CLI v0.15.2.
 
 [Refresh-only mode](/docs/cli/commands/plan.html#planning-modes) instructs Terraform to create a plan which updates the Terraform state to match changes made to remote objects outside of Terraform.
 
-Activate refresh-only mode using the `-refresh-only` flag on the command line or the `refresh-only` option in the API.
+- **CLI:** Use `terraform plan -refresh-only` or `terraform apply -refresh-only`.
+- **API:** Use the `refresh-only` option.
 
-## Disable Automatic State Refresh
+## Skipping Automatic State Refresh
 
--> **Version note:** The ability to disable automatic state refresh is available in Terraform CLI versions v0.15.4 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202106-1 and later.
+-> **Version note:** The ability to skip automatic state refresh is available in Terraform Enterprise v202106-1 or later.
 
-The [`-refresh=false` option](/docs/cli/commands/plan.html#refresh-false) is used in normal planning mode to disable the default behavior of refreshing Terraform state before checking for configuration changes.
+The [`-refresh=false` option](/docs/cli/commands/plan.html#refresh-false) is used in normal planning mode to skip the default behavior of refreshing Terraform state before checking for configuration changes.
 
-Activate this option using the `-refresh=false` option on the command line or the `refresh` option in the API.
+- **CLI:** Use `terraform plan -refresh=false` or `terraform apply -refresh=false`.
+- **API:** Use the `refresh` option.
 
 ## Replacing Selected Resources
 
--> **Version note:** Replace support is available in Terraform CLI versions v0.15.4 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202106-1 and later.
+-> **Version note:** Replace support is available in Terraform Enterprise v202106-1 or later and requires a workspace using at least Terraform CLI v0.15.4.
 
 The [replace option](/docs/cli/commands/plan.html#replace-address) instructs Terraform to replace the object with the given resource address.
 
-Activate this option using the `-replace=ADDRESS` option on the command line or the `replace-addrs` option in the API.
+- **CLI:** Use `terraform plan -replace=ADDRESS` or `terraform apply -replace=ADDRESS`.
+- **API:** Use the `replace-addrs` option.
 
 ## Targeted Plan and Apply
 
--> **Version note:** Targeting support is available in Terraform CLI versions v0.12.26 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202006-1 and later.
+-> **Version note:** Targeting support is available in Terraform Enterprise v202006-1 or later.
 
-[Resource Targeting](/docs/cli/commands/plan.html#resource-targeting) is intended for exceptional circumstances only and should not be used routinely. To activate this option, use the `-target=ADDRESS` option on the command line or the `target-addrs` option in the API.
+[Resource Targeting](/docs/cli/commands/plan.html#resource-targeting) is intended for exceptional circumstances only and should not be used routinely.
+
+- **CLI:** Use `terraform plan -target=ADDRESS` or `terraform apply -target=ADDRESS`.
+- **API:** Use the `target-addrs` option.
 
 The usual caveats for targeting in local operations imply some additional limitations on Terraform Cloud features for remote plans created with targeting:
 

--- a/content/source/docs/cloud/run/modes-and-options.html.md
+++ b/content/source/docs/cloud/run/modes-and-options.html.md
@@ -1,0 +1,52 @@
+---
+layout: "cloud"
+page_title: "Run Modes and Options - Runs - Terraform Cloud and Terraform Enterprise"
+---
+
+# Run Modes and Options
+
+Terraform Cloud support many of the same modes and options available in local operations mode.
+
+## Destroy Mode
+
+[Destroy mode](/docs/cli/commands/plan.html#planning-modes) instructs Terraform to create a plan which destroys all objects, regardless of configuration changes.
+
+Command line users can activate destroy mode using `terraform plan -destroy` or `terraform destroy`, while API users can use the `is-destroy` option. Destroy runs may also be created through the UI via the workspace's "Destruction and Deletion" settings page.
+
+## Refresh-Only Mode
+
+-> **Version note:** Refresh-only support is available in Terraform CLI versions v0.15.4 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202106-1 and later.
+
+[Refresh-only mode](/docs/cli/commands/plan.html#planning-modes) instructs Terraform to create a plan which updates the Terraform state to match changes made to remote objects outside of Terraform.
+
+Activate refresh-only mode using the `-refresh-only` flag on the command line or the `refresh-only` option in the API.
+
+## Disable Automatic State Refresh
+
+-> **Version note:** The ability to disable automatic state refresh is available in Terraform CLI versions v0.15.4 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202106-1 and later.
+
+The [`-refresh=false` option](/docs/cli/commands/plan.html#refresh-false) is used in normal planning mode to disable the default behavior of refreshing Terraform state before checking for configuration changes.
+
+Activate this option using the `-refresh=false` option on the command line or the `refresh` option in the API.
+
+## Replacing Selected Resources
+
+-> **Version note:** Replace support is available in Terraform CLI versions v0.15.4 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202106-1 and later.
+
+The [replace option](/docs/cli/commands/plan.html#replace-address) instructs Terraform to replace the object with the given resource address.
+
+Activate this option using the `-replace=ADDRESS` option on the command line or the `replace-addrs` option in the API.
+
+## Targeted Plan and Apply
+
+-> **Version note:** Targeting support is available in Terraform CLI versions v0.12.26 and later, with server-side support available in Terraform Cloud and Terraform Enterprise v202006-1 and later.
+
+[Resource Targeting](/docs/cli/commands/plan.html#resource-targeting) is intended for exceptional circumstances only and should not be used routinely. To activate this option, use the `-target=ADDRESS` option on the command line or the `target-addrs` option in the API.
+
+The usual caveats for targeting in local operations imply some additional limitations on Terraform Cloud features for remote plans created with targeting:
+
+* [Sentinel](../sentinel/) policy checks for targeted plans will see only the selected subset of resource instances planned for changes in [the `tfplan` import](../sentinel/import/tfplan.html) and [the `tfplan/v2` import](../sentinel/import/tfplan-v2.html), which may cause an unintended failure for any policy that requires a planned change to a particular resource instance selected by its address.
+
+* [Cost Estimation](../cost-estimation/) is disabled for any run created with `-target` set, to prevent producing a misleading underestimate of cost due to resource instances being excluded from the plan.
+
+You can disable or constrain use of targeting in a particular workspace using a Sentinel policy based on [the `tfrun.target_addrs` value](../sentinel/import/tfrun.html#value-target_addrs).

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -70,7 +70,7 @@ Specifies the ID that is associated with the current Terraform run.
 
 * **Value Type:** String.
 
-The `created_at` value within the [root namespace](#namespace-root) specifies the time that the run was created. The timestamp returned follows the format outlined in [RFC3339](https://tools.ietf.org/html/rfc3339).
+The `created_at` value within the [root namespace](#namespace-root) specifies the time that the run was created. The timestamp returned follows the format outlined in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339).
 
 Users can use the `time` import to [load](https://docs.hashicorp.com/sentinel/imports/time#time-load-timeish) a run timestamp and create a new timespace from the specicied value. See the `time` import [documentation](https://docs.hashicorp.com/sentinel/imports/time#import-time) for available actions that can be performed on timespaces.
 

--- a/content/source/docs/cloud/sentinel/import/tfrun.html.md
+++ b/content/source/docs/cloud/sentinel/import/tfrun.html.md
@@ -20,10 +20,13 @@ tfrun
 ├── created_at (string)
 ├── message (string)
 ├── commit_sha (string)
-├── speculative (boolean)
 ├── is_destroy (boolean)
-├── variables (map of keys)
+├── refresh (boolean)
+├── refresh_only (boolean)
+├── replace_addrs (array of strings)
+├── speculative (boolean)
 ├── target_addrs (array of strings)
+├── variables (map of keys)
 ├── organization
 │   └── name (string)
 ├── workspace
@@ -85,30 +88,35 @@ The default value is *"Queued manually via the Terraform Enterprise API"*.
 
 Specifies the checksum hash (SHA) that identifies the commit.
 
-### Value: `speculative`
-
-* **Value Type:** Boolean.
-
-Specifies whether the plan associated with the run is a [speculative plan](../../run/index.html#speculative-plans) only.
-
 ### Value: `is_destroy`
 
 * **Value Type:** Boolean.
 
 Specifies if the plan is a destroy plan, which will destroy all provisioned resources.
 
-### Value: `variables`
+### Value: `refresh`
 
-* **Value Type:** A string-keyed map of values.
+* **Value Type:** Boolean.
 
-Provides the names of the variables that are configured within the run and the [sensitivity](../../workspaces/variables.html#sensitive-values) state of the value.
+Specifies whether the state was refreshed prior to the plan.
 
-```
-variables (map of keys)
-└── name (string)
-    └── category (string)
-    └── sensitive (boolean)
-```
+### Value: `refresh_only`
+
+* **Value Type:** Boolean.
+
+Specifies whether the plan is in refresh-only mode, which ignores configuration changes and updates state with any changes made outside of Terraform.
+
+### Value: `replace_addrs`
+
+* **Value Type:** An array of strings representing [resource addresses](/docs/cli/state/resource-addressing.html). 
+
+Provides the targets specified using the [`-replace`](/docs/cli/commands/plan.html#resource-targeting) flag in the CLI or the `replace-addrs` attribute in the API. Will be undefined if no resource targets are specified.
+
+### Value: `speculative`
+
+* **Value Type:** Boolean.
+
+Specifies whether the plan associated with the run is a [speculative plan](../../run/index.html#speculative-plans) only.
 
 ### Value: `target_addrs`
 
@@ -122,6 +130,19 @@ To prohibit targeted runs altogether, make sure the `target_addrs` value is unde
 import "tfrun"
 
 main = (length(tfrun.target_addrs) else 0) == 0
+```
+
+### Value: `variables`
+
+* **Value Type:** A string-keyed map of values.
+
+Provides the names of the variables that are configured within the run and the [sensitivity](../../workspaces/variables.html#sensitive-values) state of the value.
+
+```
+variables (map of keys)
+└── name (string)
+    └── category (string)
+    └── sensitive (boolean)
 ```
 
 ## Namespace: organization

--- a/content/source/layouts/_cloud_content.erb
+++ b/content/source/layouts/_cloud_content.erb
@@ -120,6 +120,9 @@
             <a href="/docs/cloud/run/states.html">Run States and Stages</a>
           </li>
           <li>
+            <a href="/docs/cloud/run/modes-and-options.html">Run Modes and Options</a>
+          </li>
+          <li>
             <a href="#">Run Workflows</a>
           <ul class="nav nav-auto-expand">
             <li>


### PR DESCRIPTION
Adds documentation for some new options available for Terraform Cloud & Enterprise runs and the `tfrun` Sentinel export:

- `refresh`
- `refresh-only`
- `replace-addrs`

Additionally adds a new "Run Modes and Options" page under the general run documentation to describe those options in more detail, including how they relate to the CLI options and the required versions of Terraform Enterprise and the Terraform CLI.

![Screen Shot 2021-05-26 at 23 20 07-fullpage](https://user-images.githubusercontent.com/17039873/119611632-cf503a00-bdaf-11eb-8401-d79ccbe59001.png)

