### PR TITLE
Add missing return statement in test sweeper

### DIFF
--- a/content/source/docs/extend/testing/acceptance-tests/sweepers.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/sweepers.html.md
@@ -62,13 +62,13 @@ import (
 
 func init() {
     resource.AddTestSweepers("example_compute", &resource.Sweeper{
-        Name:   "example_compute",
-        F:      func (region string) error {
+        Name: "example_compute",
+        F: func (region string) error {
             client, err := sharedClientForRegion(region)
             if err != nil {
                 return fmt.Errorf("Error getting client: %s", err)
             }
- 	        conn := client.(*ExampleClient)
+ 	          conn := client.(*ExampleClient)
 
             instances, err := conn.DescribeComputeInstances()
             if err != nil {
@@ -83,6 +83,7 @@ func init() {
                     }
                 }
             }
+            return nil
         },
     })
 }


### PR DESCRIPTION
The test sweeper for "example_compute" misses a return statement at the end.

Also added some indent changes.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
