### PR TITLE
Add search query to workspace list

### DIFF
--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -457,6 +457,7 @@ Parameter      | Description
 ---------------|------------
 `page[number]` | **Optional.** If omitted, the endpoint will return the first page.
 `page[size]`   | **Optional.** If omitted, the endpoint will return 20 workspaces per page.
+`search[name]` | **Optional.** Allows searching the organization's workspaces by name.
 
 ### Sample Request
 


### PR DESCRIPTION
Workspace List API can search by a name string, adding this to the documentation.

## Example

`https://app.terraform.io/api/v2/organizations/<org name>/workspaces?search[name]=test`

returns only Workspaces with name "test" in them.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
