### PR TITLE
call out which registry module apis that are being deprecated

### DIFF
--- a/content/source/docs/cloud/api/changelog.html.md
+++ b/content/source/docs/cloud/api/changelog.html.md
@@ -14,13 +14,20 @@ page_id: "api-changelog"
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ### 2021-06-8
-
 * Updated [Registry Module APIs](./modules.html).
     * added `registry_name` scoped APIs.
     * added `organization_name` scoped APIs.
     * added [Module List API](./modules.html#list-registry-modules-for-an-organization).
     * updated [Module Delete APIs](./modules.html#delete-a-module).
     * ![cloud][] added public registry module related APIs.
+* ![deprecation] [] The following [Registry Module APIs](./modules.html) have been replaced with newer apis and will be removed in the future.
+    * The following endpoints to delete modules are replaced with [Module Delete APIs](./modules.html#delete-a-module)
+        * `POST /registry-modules/actions/delete/:organization_name/:name/:provider/:version`
+        * `POST /registry-modules/actions/delete/:organization_name/:name/:provider`
+        * `POST /registry-modules/actions/delete/:organization_name/:name`
+    * `POST /registry-modules` replaced with [Updated POST Endpoint](./modules.html#publish-a-private-module-from-a-vcs)
+    * `POST /registry-modules/:organization_name/:name/:provider/versions` replaced with new [endpoint](./modules.html#create-a-module-version)
+    * `GET /registry-modules/show/:organization_name/:name/:provider` replaced with new [GET Endpoint](./modules.html#get-a-module)
 
 ### 2021-05-27
 

--- a/content/source/docs/cloud/api/changelog.html.md
+++ b/content/source/docs/cloud/api/changelog.html.md
@@ -14,6 +14,7 @@ page_id: "api-changelog"
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ### 2021-06-8
+
 * Updated [Registry Module APIs](./modules.html).
     * added `registry_name` scoped APIs.
     * added `organization_name` scoped APIs.

--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -218,7 +218,7 @@ curl \
 
 `POST /organizations/:organization_name/registry-modules/vcs`
 
-~> **Deprecation warning**: the following endpoint `POST /registry-modules` is replaced by the above endpoint and will be removed from future versions of the API!.
+~> **Deprecation warning**: the following endpoint `POST /registry-modules` is replaced by the above endpoint and will be removed from future versions of the API!
 
 Parameter            | Description
 ---------------------|------------

--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -216,9 +216,10 @@ curl \
 
 ## Publish a Private Module from a VCS
 
+~> **Deprecation warning**: the following endpoint `POST /registry-modules` is replaced by the below endpoint and will be removed from future versions of the API!
+
 `POST /organizations/:organization_name/registry-modules/vcs`
 
-~> **Deprecation warning**: the following endpoint `POST /registry-modules` is replaced by the above endpoint and will be removed from future versions of the API!
 
 Parameter            | Description
 ---------------------|------------
@@ -482,9 +483,9 @@ curl \
 
 ## Create a Module Version
 
-`POST /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider/versions`
+~> **Deprecation warning**: the following endpoint `POST /registry-modules/:organization_name/:name/:provider/versions` is replaced by the below endpoint and will be removed from future versions of the API!
 
-~> **Deprecation warning**: the following endpoint `POST /registry-modules/:organization_name/:name/:provider/versions` is replaced by the above endpoint and will be removed from future versions of the API!
+`POST /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider/versions`
 
 Parameter            | Description
 ---------------------|------------
@@ -620,9 +621,10 @@ After the registry module version is successfully parsed, its status will become
 
 ## GET a Module
 
+~> **Deprecation warning**: the following endpoint `GET /registry-modules/show/:organization_name/:name/:provider` is replaced by the below endpoint and will be removed from future versions of the API!
+
 `GET /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider`
 
-~> **Deprecation warning**: the following endpoint `GET /registry-modules/show/:organization_name/:name/:provider` is replaced by the above endpoint and will be removed from future versions of the API!
 
 ### Parameters
 
@@ -749,10 +751,6 @@ curl \
 
 ## Delete a Module
 
-* `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider/:version`
-* `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider`
-* `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name`
-
 <div class="alert alert-warning" role="alert">
   **Deprecation warning**: the following endpoints:
 
@@ -760,9 +758,12 @@ curl \
   * `POST /registry-modules/actions/delete/:organization_name/:name/:provider`
   * `POST /registry-modules/actions/delete/:organization_name/:name`
 
-  are replaced by the above endpoints and will be removed from future versions of the API!
+  are replaced by the below endpoints and will be removed from future versions of the API!
 </div>
 
+* `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider/:version`
+* `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider`
+* `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name`
 
 
 ### Parameters

--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -753,11 +753,17 @@ curl \
 * `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider`
 * `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name`
 
-~> **Deprecation warning**: the following endpoints:
+<div class="alert alert-warning" role="alert">
+  **Deprecation warning**: the following endpoints:
+
   * `POST /registry-modules/actions/delete/:organization_name/:name/:provider/:version`
   * `POST /registry-modules/actions/delete/:organization_name/:name/:provider`
   * `POST /registry-modules/actions/delete/:organization_name/:name`
-are replaced by the above endpoints and will be removed from future versions of the API!.
+
+  are replaced by the above endpoints and will be removed from future versions of the API!
+</div>
+
+
 
 ### Parameters
 

--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -218,6 +218,8 @@ curl \
 
 `POST /organizations/:organization_name/registry-modules/vcs`
 
+~> **Deprecation warning**: the following endpoint `POST /registry-modules` is replaced by the above endpoint and will be removed from future versions of the API!.
+
 Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team.
@@ -482,6 +484,8 @@ curl \
 
 `POST /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider/versions`
 
+~> **Deprecation warning**: the following endpoint `POST /registry-modules/:organization_name/:name/:provider/versions` is replaced by the above endpoint and will be removed from future versions of the API!
+
 Parameter            | Description
 ---------------------|------------
 `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team.
@@ -618,6 +622,8 @@ After the registry module version is successfully parsed, its status will become
 
 `GET /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider`
 
+~> **Deprecation warning**: the following endpoint `GET /registry-modules/show/:organization_name/:name/:provider` is replaced by the above endpoint and will be removed from future versions of the API!
+
 ### Parameters
 
 Parameter            | Description
@@ -746,6 +752,12 @@ curl \
 * `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider/:version`
 * `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider`
 * `DELETE /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name`
+
+~> **Deprecation warning**: the following endpoints:
+  * `POST /registry-modules/actions/delete/:organization_name/:name/:provider/:version`
+  * `POST /registry-modules/actions/delete/:organization_name/:name/:provider`
+  * `POST /registry-modules/actions/delete/:organization_name/:name`
+are replaced by the above endpoints and will be removed from future versions of the API!.
 
 ### Parameters
 


### PR DESCRIPTION
Update the api docs calling out which Registry Module apis are being deprecated (these endpoints were removed from the doc as part of api updates for June 8).

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [x] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
