### PR TITLE
Clarifying language re: spec plans vs applies

### DIFF
--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -86,6 +86,8 @@ Whenever a pull request is _created or updated,_ Terraform Cloud checks whether 
 
     -> **Note:** If Terraform Cloud skips a plan because the changes weren't relevant, it will still post a passing commit status to the pull request.
 
+- Status checks on the pull request are not updated after an apply, so a commit with a successful plan but an errored apply will still show the passing commit status relevant to the plan.
+
 ### Contents of Pull Request Plans
 
 Speculative plans for pull requests use the contents of the head branch (the branch that the PR proposes to merge into the destination branch), and they compare against the workspace's current state at the time of the plan. This means that if the destination branch changes significantly after the head branch is created, the speculative plan might not accurately show the results of accepting the PR. To get a more accurate view, you can rebase the head branch onto a more recent commit, or merge the destination branch into the head branch.

--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -86,7 +86,7 @@ Whenever a pull request is _created or updated,_ Terraform Cloud checks whether 
 
     -> **Note:** If Terraform Cloud skips a plan because the changes weren't relevant, it will still post a passing commit status to the pull request.
 
-- Status checks on the pull request are not updated after an apply, so a commit with a successful plan but an errored apply will still show the passing commit status relevant to the plan.
+- Terraform Cloud does not update the status checks on a pull request with the status of an associated apply. This means that a commit with a successful plan but an errored apply will still show the passing commit status from the plan.
 
 ### Contents of Pull Request Plans
 


### PR DESCRIPTION
Added a blurb per support request identifying that while a Plan may pass, the status check is not updated if the associated Apply fails.