### PR TITLE
Adding Terraform Enterprise security model

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -141,18 +141,7 @@ For other Linux distributions, check Docker compatibility:
 
 If you have chosen the [external services operational mode](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision), Terraform Enterprise will need access to an S3-compliant endpoint for object storage. You can grant access to the object storage endpoint by either assigning an AWS instance profile or an equivalent IAM system in non-AWS environments.
 
-#### Using the Instance Profile as Default Credentials for Terraform Runs
-You can use Terraform Enterprise's instance profile to provide default credentials to workspaces. Terraform will attempt to use the instance profile to provision resources when you do not set credentials as environment variables. However, this approach presents a few security risks: 
-
-1. All workspaces will have the same permissions because they have access to the same instance profile. You cannot selectively allow or deny access to the instance profile for each workspace.
-2. Workspaces will share the instance profile with the Terraform Enterprise application. All workspaces within the application will have access to any resources that Terraform Enterprise depends on, such as its S3 bucket, KMS keys, etc.
-
-~> **Important:** If you choose not to use the instance profile for default credentials, we highly recommend that you [restrict build worker metadata access](../system-overview/security-model.html#restrict-terraform-build-worker-metadata-access) to prevent workspaces from accessing the instance profile.
-
-#### AWS Instance Profile Requirements
-Below are the IAM policies Terraform Enterprise requires to operate in AWS environments:
-
-##### S3 Policy
+#### S3 Policy
 
 At a minimum, Terraform Enterprise requires the following S3 permissions:
 
@@ -175,7 +164,7 @@ At a minimum, Terraform Enterprise requires the following S3 permissions:
 -> **Note:** The `s3:ListAllMyBuckets` permission is necessary when testing authentication via the Replicated web console. However, the permission is not required for Terraform Enterprise to function and can be removed once the authentication is successfully tested.
 
 
-##### KMS Policy
+#### KMS Policy
 
 At a minimum, Terraform Enterprise will require the following permissions if the objects in the bucket are to be encrypted via resources in AWS's KMS:
 
@@ -194,6 +183,14 @@ At a minimum, Terraform Enterprise will require the following permissions if the
     ]
 }
 ```
+
+#### Using the Instance Profile as Default Credentials for Terraform Runs
+You can use Terraform Enterprise's instance profile to provide default credentials to workspaces. Terraform will attempt to use the instance profile to provision resources when you do not set credentials as environment variables. However, this approach presents a few security risks: 
+
+1. All workspaces will have the same permissions because they have access to the same instance profile. You cannot selectively allow or deny access to the instance profile for each workspace.
+2. Workspaces will share the instance profile with the Terraform Enterprise application. All workspaces within the application will have access to any resources that Terraform Enterprise depends on, such as its S3 bucket, KMS keys, etc.
+
+~> **Important:** If you choose not to use the instance profile for default credentials, we highly recommend that you [restrict build worker metadata access](../system-overview/security-model.html#restrict-terraform-build-worker-metadata-access) to prevent workspaces from accessing the instance profile.
 
 ### SELinux
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -147,7 +147,7 @@ You can use Terraform Enterprise's instance profile to provide default credentia
 1. All workspaces will have the same permissions because they have access to the same instance profile. You cannot selectively allow or deny access to the instance profile for each workspace.
 2. Workspaces will share the instance profile with the Terraform Enterprise application. All workspaces within the application will have access to any resources that Terraform Enterprise depends on, such as its S3 bucket, KMS keys, etc.
 
-~> **Important:** If you choose to not rely on the instance profile for default credentials we highly recommend that you [restrict build worker metadata access](../system-overview/security-model.html#restrict-terraform-build-worker-metadata-access), preventing workspaces from accessing the instance profile.
+~> **Important:** If you choose not to use the instance profile for default credentials, we highly recommend that you [restrict build worker metadata access](../system-overview/security-model.html#restrict-terraform-build-worker-metadata-access) to prevent workspaces from accessing the instance profile.
 
 #### AWS Instance Profile Requirements
 Below are the IAM policies Terraform Enterprise requires to operate in AWS environments:

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -142,7 +142,7 @@ For other Linux distributions, check Docker compatibility:
 If you have chosen the [external services operational mode](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision), Terraform Enterprise will need access to an S3-compliant endpoint for object storage. You can grant access to the object storage endpoint by either assigning an AWS instance profile or an equivalent IAM system in non-AWS environments.
 
 #### Using the Instance Profile as Default Credentials for Terraform Runs
-Terraform Enterprise's instance profile can also be used to provide default credentials to workspaces. Workspaces without environment variables for credentials will attempt to use the instance profile to provision resources. The convenience of credential-free workspaces comes with a few security caveats, however. Operators should be aware of these risks before choosing to rely on this behavior:
+You can use Terraform Enterprise's instance profile to provide default credentials to workspaces. Terraform will attempt to use the instance profile to provision resources when you do not set credentials as environment variables. However, this approach presents a few security risks: 
 
 1. All workspaces will have access to the same instance profile, and thus will have the same permissions. It is not possible to selectively allow or deny access to the instance profile on a per-workspace basis.
 2. Workspaces will share the instance profile with the Terraform Enterprise application. All workspaces within the application will have access to any resources that Terraform Enterprise depends on, such as its S3 bucket, KMS keys, etc.

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -184,7 +184,7 @@ At a minimum, Terraform Enterprise will require the following permissions if the
 }
 ```
 
-#### Using the Instance Profile as Default Credentials for Terraform Runs
+#### Instance Profile as Default Credentials
 You can use Terraform Enterprise's instance profile to provide default credentials to workspaces. Terraform will attempt to use the instance profile to provision resources when you do not set credentials as environment variables. However, this approach presents a few security risks: 
 
 1. All workspaces will have the same permissions because they have access to the same instance profile. You cannot selectively allow or deny access to the instance profile for each workspace.

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -139,7 +139,7 @@ For other Linux distributions, check Docker compatibility:
 
 ### IAM Policies
 
-If you have chosen the [external services operational mode](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision), Terraform Enterprise will need access to an S3-compliant endpoint for object storage. You can grant access to the object storage endpoint by assigning an AWS instance profile, or equivalent IAM system in non-AWS environments.
+If you have chosen the [external services operational mode](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision), Terraform Enterprise will need access to an S3-compliant endpoint for object storage. You can grant access to the object storage endpoint by either assigning an AWS instance profile or an equivalent IAM system in non-AWS environments.
 
 #### Using the Instance Profile as Default Credentials for Terraform Runs
 Terraform Enterprise's instance profile can also be used to provide default credentials to workspaces. Workspaces without environment variables for credentials will attempt to use the instance profile to provision resources. The convenience of credential-free workspaces comes with a few security caveats, however. Operators should be aware of these risks before choosing to rely on this behavior:

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -137,7 +137,7 @@ For other Linux distributions, check Docker compatibility:
 
 ~> **Important:** We do not recommend running Docker under a 2.x kernel.
 
-### Configuring IAM Policies
+### IAM Policies
 
 If you have chosen the [external services operational mode](https://www.terraform.io/docs/enterprise/before-installing/index.html#operational-mode-decision), Terraform Enterprise will need access to an S3-compliant endpoint for object storage. You can grant access to the object storage endpoint by assigning an AWS instance profile, or equivalent IAM system in non-AWS environments.
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -144,7 +144,7 @@ If you have chosen the [external services operational mode](https://www.terrafor
 #### Using the Instance Profile as Default Credentials for Terraform Runs
 You can use Terraform Enterprise's instance profile to provide default credentials to workspaces. Terraform will attempt to use the instance profile to provision resources when you do not set credentials as environment variables. However, this approach presents a few security risks: 
 
-1. All workspaces will have access to the same instance profile, and thus will have the same permissions. It is not possible to selectively allow or deny access to the instance profile on a per-workspace basis.
+1. All workspaces will have the same permissions because they have access to the same instance profile. You cannot selectively allow or deny access to the instance profile for each workspace.
 2. Workspaces will share the instance profile with the Terraform Enterprise application. All workspaces within the application will have access to any resources that Terraform Enterprise depends on, such as its S3 bucket, KMS keys, etc.
 
 ~> **Important:** If you choose to not rely on the instance profile for default credentials we highly recommend that you [restrict build worker metadata access](../system-overview/security-model.html#restrict-terraform-build-worker-metadata-access), preventing workspaces from accessing the instance profile.

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -39,7 +39,7 @@ Infrastructure admins are required to manage all aspects of the underlying infra
 
 Security fixes are released along with application features and bug fixes via TFE’s standard monthly release cycle. TFE infrastructure admins are responsible for applying updates.
 
-### You are Responsible for TFE’s Availability, Backups, and Disaster Recovery
+### You are Responsible for Availability, Backups, and Disaster Recovery
 
 TFE infrastructure admins are responsible for all aspects of TFE’s reliability and availability. Refer to TFE documentation on [monitoring](../admin/monitoring.html), [backups and restores](../admin/backup-restore.html), and [high availability mode (active/active)](../admin/active-active.html) for more guidance on this topic.
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -29,7 +29,7 @@ Due to the extensive capabilities granted to this role, the site admin role shou
 
 ## Differences Between Terraform Enterprise and Terraform Cloud Security Models
 
-For the most part, Terraform Enterprise’s threat model can be considered a superset of the [Terraform Cloud security model](../../cloud/architectural-details/security-model.html) and (with the exception of the points listed below) all of the content on that page applies to Terraform Enterprise. Terraform Enterprise’s threat model differs from that of Terraform Clouds in these respects:
+All of the content on [Terraform Cloud security model](../../cloud/architectural-details/security-model.html) applies to Terraform Enterprise, with the exception of the points listed below.
 
 ### TFE Requires You to Manage and Secure the Underlying Network and Infrastructure
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -5,7 +5,6 @@ page_title: "Security Model- System Overview - Terraform Enterprise"
 
 # Terraform Enterprise Security Model
 
-## Purpose of this document
 
 This page explains the aspects of the Terraform security model that are unique to Terraform Enterprise. We recommend also reviewing the core concepts in [Terraform Cloud Security model](../../cloud/architectural-details/security-model.html).
 
@@ -92,12 +91,12 @@ Terraform Enterprise allows site admins to enable [global remote state sharing](
 
 Terraform Enterprise uses support bundles to share diagnostic information with HashiCorp support. Please note that support bundles may contain sensitive information from your Terraform Enterprise installation. You should not share them with untrusted parties and should delete them as soon as possible.
 
-#### Regularly Update Terraform Enterprise
+#### Update Terraform Enterprise Often
 
 We release Terraform Enterprise updates each month. Updates may contain additional security features or fixes for existing security vulnerabilities, so we recommend establishing a process for periodically updating your Terraform Enterprise installation.
 
 #### Subscribe to Terraform Enterprise Security Bulletins
 
-We publish security updates that address security vulnerabilities in HashiCorp products. You can find them in the Security category of [HashiCorp Discuss](https://discuss.hashicorp.com/c/security/).
+We publish updates that address security vulnerabilities in HashiCorp products. You can find them in the Security category of [HashiCorp Discuss](https://discuss.hashicorp.com/c/security/).
 
 We recommend that Terraform Enterprise infrastructure admins follow the [documented steps](https://discuss.hashicorp.com/t/about-hashicorp-security-updates/15330) to subscribe to email notifications or the RSS feed for Terraform Enterprise security updates.

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -22,7 +22,7 @@ Due to the extensive capabilities granted to this role, the infrastructure admin
 
 ### Site Admin
 
-[Site admins](../admin/admin-access.html) are responsible for application-level configuration of Terraform Enterprise. Via the admin interface they will be able to manage all users, workspaces and organizations and will have access to all data stored within Terraform Enterprise. Site admins are also responsible for configuring SAML and will be the only users still able to access Terraform Enterprise via username/password once SAML is configured. 
+[Site admins](../admin/admin-access.html) are responsible for application-level configuration of Terraform Enterprise. They can manage all users, workspaces, and organizations through the admin interface and have access to all data stored within Terraform Enterprise. Site admins are also responsible for configuring SAML and are the only users that can access Terraform Enterprise with a username and password once SAML is configured. 
 
 Due to the extensive capabilities granted to this role, the site admin role should be restricted to a small number of users within your organization.
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -7,7 +7,7 @@ page_title: "Security Model- System Overview - Terraform Enterprise"
 
 ## Purpose of this document
 
-This document explains the security model of Terraform Enterprise and the security controls available to administrators and end users. This document is intended as a supplement to the [Terraform Cloud Security model](../../cloud/architectural-details/security-model.html) and describes aspects of the security model that are unique to Terraform Enterprise. We recommend familiarizing yourself with the Terraform Cloud security model before reading this document.
+This page explains the aspects of the Terraform security model that are unique to Terraform Enterprise. We recommend also reviewing the core concepts in [Terraform Cloud Security model](../../cloud/architectural-details/security-model.html).
 
 ## Personas
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -53,7 +53,7 @@ In addition those provided in the [Terraform Cloud security model](../../cloud/a
 
 ### Run Terraform Enterprise in an Isolated Network, Limit Ingress Ports, and Restrict Access to Underlying Infrastructure
 
-To minimize attack surface, we recommend running TFE in an isolated network and limiting ingress ports to only 80 and 443. 
+To minimize attack surface, we recommend running Terraform Enterprise in an isolated network and limiting ingress ports to only 80 and 443. 
 
 For standalone deployments, port 8800 is reserved for the [Replicated admin console](../admin/admin-access.html), which is used for configuring TFE. This port should only be exposed to TFE infrastructure admins. Alternatively, if you choose to configure TFE via the [automated process](../install/automating-the-installer.html), you can disable the Replicated admin console by passing the `disable-replicated-ui` argument to the installation script:
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -95,6 +95,6 @@ We release Terraform Enterprise updates each month. Updates may contain addition
 
 #### Subscribe to Terraform Enterprise Security Bulletins
 
-HashiCorp publishes security updates, which address security vulnerabilities in HashiCorp products, in the Security category of [HashiCorp Discuss](https://discuss.hashicorp.com/c/security/).
+We publish security updates that address security vulnerabilities in HashiCorp products. You can find them in the Security category of [HashiCorp Discuss](https://discuss.hashicorp.com/c/security/).
 
 We recommend that Terraform Enterprise administrators follow the [documented steps](https://discuss.hashicorp.com/t/about-hashicorp-security-updates/15330) to subscribe to email notifications or the RSS feed for Terraform Enterprise security updates.

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -24,7 +24,7 @@ Due to the extensive capabilities granted to this role, the infrastructure admin
 
 [Site admins](../admin/admin-access.html) are responsible for application-level configuration of Terraform Enterprise. They can manage all users, workspaces, and organizations through the admin interface and have access to all data stored within Terraform Enterprise. Site admins are also responsible for configuring SAML and are the only users that can access Terraform Enterprise with a username and password once SAML is configured. 
 
-Due to the extensive capabilities granted to this role, the site admin role should be restricted to a small number of users within your organization.
+Terraform Enterprise grants extensive permissions to this role, so we recommend limiting the number of users who are site admins in your organization.
 
 
 ## Differences Between Terraform Enterprise and Terraform Cloud Security Models
@@ -37,7 +37,7 @@ Infrastructure admins are required to manage all aspects of the underlying infra
 
 ### You are Responsible for Updating Your Terraform Enterprise Deployment
 
-Security fixes are released along with application features and bug fixes via TFE’s standard monthly release cycle. TFE infrastructure admins are responsible for applying updates.
+We release security fixes, application features, and bug fixes for Terraform Enterprise each month. Infrastructure admins are responsible for applying updates.
 
 ### You are Responsible for Availability, Backups, and Disaster Recovery
 
@@ -59,31 +59,34 @@ For standalone deployments, port 8800 is reserved for the [Replicated admin cons
 
 ```sudo bash ./install.sh disable-replicated-ui```
 
-Additionally, we recommend restricting access to the nodes that are running TFE. TFE can not ensure the security or integrity of its data if the underlying infrastructure is compromised.
+Additionally, we recommend restricting access to the nodes that are running Terraform Enterprise. Terraform Enterprise can not ensure the security or integrity of its data if the underlying infrastructure is compromised.
 
 ### Enable Optional Security Features
 
 Once you are ready to use Terraform Enterprise for production workloads, we recommend enabling these optional security features.
 
-#### Strict Transport Security Header
+#### Enable Strict Transport Security Header
 
-You can configure TFE to set the [Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header via the Settings page of the installer dashboard by enabling “Force TLS” radio button under “SSL/TLS Configuration”
+You can configure Terraform Enterprise to set the [Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header by:
+* Visiting the installer dashboard "Settings" page and enabling “Force TLS” under the “SSL/TLS Configuration” section.
+* Setting [force_tls](../install/automating-the-installer.html#force_tls) in the application settings file.
 
-You can also enable this setting via the application settings file file with the [force_tls](../install/automating-the-installer.html#force_tls) setting.
 
-~> **Note:** Once properly configured, the HSTS header cannot be disabled and will prevent clients from accessing your TFE domain via HTTP or HTTPS using a self-signed cert. We recommend only enabling this setting for production TFE deployments.
+~> **Note:** Once properly configured, the HSTS header cannot be disabled and will prevent clients from accessing your Terraform Enterprise domain via HTTP or HTTPS using a self-signed cert. We recommend only enabling this setting for production Terraform Enterprise deployments.
 
 #### Restrict Terraform Build Worker Metadata Access
 
-By default Terraform Enterprise does not prevent Terraform operations from accessing the instance metadata service, which may contain IAM credentials or other sensitive data. Refer to [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html), [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows), or [Google Cloud's](https://cloud.google.com/compute/docs/storing-retrieving-metadata) documentation for more information on this service.
+By default, Terraform Enterprise does not prevent Terraform operations from accessing the instance metadata service, which may contain IAM credentials or other sensitive data. Refer to [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html), [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows), or [Google Cloud](https://cloud.google.com/compute/docs/storing-retrieving-metadata) documentation for more information on this service.
 
-TFE allows you to restrict access to the metadata endpoint from Terraform operations, preventing workspaces from reading any data from the metadata service. This feature can be enabled via the “Restrict Terraform Build Worker Instance Metadata Access” setting under the “Advanced Configuration” section in the installer dashboard’s settings page, or via the [restrict_worker_metadata_access](../install/automating-the-installer.html#restrict_worker_metadata_access) setting in the application settings file.
+Terraform Enterprise allows you to restrict access to the metadata endpoint from Terraform operations, preventing workspaces from reading any data from the metadata service. You can do this by:
+* Visiting the installer dashboard "Settings" page and enabling “Restrict Terraform Build Worker Instance Metadata Access” under the “Advanced Configuration” section. 
+* Setting [restrict_worker_metadata_access](../install/automating-the-installer.html#restrict_worker_metadata_access) in the application settings file.
 
-Unless you are relying on the [instance profile as a means of providing default credentials to TFE workspaces](../before-installing/index.html#aws-specific-configuration), we recommend enabling this setting to prevent Terraform operations from accessing the instance metadata endpoint. 
+We recommend enabling this setting to prevent Terraform operations from accessing the instance metadata endpoint, unless you are relying on the [instance profile to provide default credentials to workspaces](../before-installing/index.html#aws-specific-configuration). 
 
-#### Ensure Global Remote State Sharing is Disabled
+#### Disable Global Remote State Sharing
 
-TFE allows administrators to enable [global remote state sharing](../admin/general.html#remote-state-sharing), a feature that allows any workspace to access the state versions of any other workspace within the same organization. We recommend disabling the feature and relying on [controlled remote state access](https://www.hashicorp.com/blog/announcing-controlled-remote-state-access-for-terraform-cloud-and-enterprise) if you need to share state between workspaces.
+Terraform Enterprise allows site admins to enable [global remote state sharing](../admin/general.html#remote-state-sharing), which allows any workspace to access the state versions of any other workspace within the same organization. We recommend disabling this feature and relying on [controlled remote state access](https://www.hashicorp.com/blog/announcing-controlled-remote-state-access-for-terraform-cloud-and-enterprise) if you need to share state between workspaces.
 
 #### Treat Support Bundles with Care
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -11,7 +11,7 @@ This page explains the aspects of the Terraform security model that are unique t
 
 ## Personas
 
-In addition to the personas listed in the Terraform Cloud Security Model, Terraform enterprise requires two additional personas for managing and administering the application.
+In addition to those listed in [Terraform Cloud Security model](../../cloud/architectural-details/security-model.html), Terraform Enterprise requires the following personas for managing and administering the application.
 
 
 ### Infrastructure Admin

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -43,7 +43,7 @@ Security fixes are released along with application features and bug fixes via TF
 
 Infrastructure admins are responsible for all aspects of reliability and availability. Refer to Terraform Enterprise documentation on [monitoring](../admin/monitoring.html), [backups and restores](../admin/backup-restore.html), and [high availability mode (active/active)](../admin/active-active.html) for more guidance on this topic.
 
-### TFE Isolates Terraform Operations via Docker Containers, not a separate environment
+### Terraform Enterprise Isolates Terraform Operations via Docker Containers
 
 Unlike Terraform Cloud, TFE executes all Terraform operations in Docker containers on the TFE host. The containers are assigned to an isolated Docker network to prevent them from communicating with TFE’s backend services, but may have access to resources available on hosts accessible from the your TFE instance. 
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -33,7 +33,7 @@ All of the content on [Terraform Cloud security model](../../cloud/architectural
 
 ### TFE Requires You to Manage and Secure the Underlying Network and Infrastructure
 
-TFE infrastructure admins are required to manage all aspects of the underlying infrastructure including initial provisioning, secure configuration, access control, configuring network ACLs, and OS-level software updates. TFE can not ensure the security of your data if the underlying infrastructure is compromised.
+Infrastructure admins are required to manage all aspects of the underlying infrastructure. This includes initial provisioning, secure configuration, access control, network ACL configuration, and OS-level software updates. Terraform Enterprise cannot ensure the security of your data if the underlying infrastructure is compromised.
 
 ### You are Responsible for Updating Your TFE Deployment
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -44,7 +44,7 @@ Infrastructure admins are responsible for all aspects of reliability and availab
 
 ### Terraform Enterprise Isolates Terraform Operations via Docker Containers
 
-Unlike Terraform Cloud, Terraform Enterprise executes all Terraform operations in Docker containers on the Terraform Enterprise host. The containers are assigned to an isolated Docker network to prevent them from communicating with Terraform Enterprise backend services, but may have access to resources available on hosts accessible from the your Terraform Enterprise instance. 
+Unlike Terraform Cloud, Terraform Enterprise performs all Terraform operations in Docker containers on the Terraform Enterprise host. The containers are assigned to an isolated Docker network to prevent them from communicating with Terraform Enterprise backend services. However, Terraform Enterprise does not perform any egress filtering, so Terraform runs can still access available network resources.
 
 ## Recommendations for Securely Operating Terraform Enterprise
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -91,7 +91,7 @@ Terraform Enterprise uses support bundles to share diagnostic information with H
 
 #### Regularly Update Terraform Enterprise
 
-Terraform Enterprise updates are released on a monthly cadence. Updates may contain additional security features or fixes for existing security vulnerabilities, so we recommend establishing a process for periodically updating your Terraform Enterprise installation.
+We release Terraform Enterprise updates each month. Updates may contain additional security features or fixes for existing security vulnerabilities, so we recommend establishing a process for periodically updating your Terraform Enterprise installation.
 
 #### Subscribe to Terraform Enterprise Security Bulletins
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -49,7 +49,7 @@ Unlike Terraform Cloud, Terraform Enterprise executes all Terraform operations i
 
 ## Recommendations for Securely Operating Terraform Enterprise
 
-In addition the the recommendations provided in the [Terraform Cloud security model](../../cloud/architectural-overview/security-model.html), we offer these recommendations to users of Terraform Enterprise 
+In addition those provided in the [Terraform Cloud security model](../../cloud/architectural-overview/security-model.html), we recommend the following for Terraform Enterprise users. 
 
 ### Run Terraform Enterprise in an Isolated Network, Limit Ingress Ports, and Restrict Access to Underlying Infrastructure
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -100,4 +100,4 @@ We release Terraform Enterprise updates each month. Updates may contain addition
 
 We publish security updates that address security vulnerabilities in HashiCorp products. You can find them in the Security category of [HashiCorp Discuss](https://discuss.hashicorp.com/c/security/).
 
-We recommend that Terraform Enterprise administrators follow the [documented steps](https://discuss.hashicorp.com/t/about-hashicorp-security-updates/15330) to subscribe to email notifications or the RSS feed for Terraform Enterprise security updates.
+We recommend that Terraform Enterprise infrastructure admins follow the [documented steps](https://discuss.hashicorp.com/t/about-hashicorp-security-updates/15330) to subscribe to email notifications or the RSS feed for Terraform Enterprise security updates.

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -11,7 +11,7 @@ This document explains the security model of Terraform Enterprise and the securi
 
 ## Additional Personas for Terraform Enterprise
 
-In addition to the personas listed in the Terraform Cloud Security Model, Terraform enterprise requires two additional personas required for managing and administering the application.
+In addition to the personas listed in the Terraform Cloud Security Model, Terraform enterprise requires two additional personas for managing and administering the application.
 
 
 ### Infrastructure Admin
@@ -22,7 +22,7 @@ Due to the extensive capabilities granted to this role, the infrastructure admin
 
 ### Site Admin
 
-[Site admins](../admin/admin-access.html) are responsible for application-level configuration of Terraform Enterprise. Via the Admin interface, they will be able to manage all users, workspaces and organizations, and will have access to all data stored within Terraform Enterprise. Site admins are also responsible for configuring SAML, and will be the only users still able to access Terraform Enterprise via username/password once SAML is configured. 
+[Site admins](../admin/admin-access.html) are responsible for application-level configuration of Terraform Enterprise. Via the admin interface they will be able to manage all users, workspaces and organizations and will have access to all data stored within Terraform Enterprise. Site admins are also responsible for configuring SAML and will be the only users still able to access Terraform Enterprise via username/password once SAML is configured. 
 
 Due to the extensive capabilities granted to this role, the site admin role should be restricted to a small number of users within your organization.
 
@@ -55,7 +55,7 @@ In addition the the recommendations provided in the [Terraform Cloud security mo
 
 To minimize attack surface, we recommend running TFE in an isolated network and limiting ingress ports to only 80 and 443. 
 
-For standalone deployments, port 8800 is reserved for the [Replicated admin console](../admin/admin-access.html), which is used for configuring TFE. This port should only be exposed to TFE infrastructure admins. Alternatively, if you choose to configure TFE via the [automated process](../install/automating-the-installer.html), you can disable the Replicated admin console by passing the disable-replicated-ui argument to the installation script:
+For standalone deployments, port 8800 is reserved for the [Replicated admin console](../admin/admin-access.html), which is used for configuring TFE. This port should only be exposed to TFE infrastructure admins. Alternatively, if you choose to configure TFE via the [automated process](../install/automating-the-installer.html), you can disable the Replicated admin console by passing the `disable-replicated-ui` argument to the installation script:
 
 ```sudo bash ./install.sh disable-replicated-ui```
 
@@ -75,15 +75,19 @@ You can also enable this setting via the application settings file file with the
 
 #### Restrict Terraform Build Worker Metadata Access
 
-By default Terraform Enterprise does not prevent Terraform operations from accessing the instance metadata endpoint, which may contain IAM credential or other sensitive data. Unless you are relying on the [instance profile as a means of providing default credentials to TFE workspaces](../before-installing/index.html#aws-specific-configuration), we recommend enabling this setting to prevent Terraform operations from accessing the instance metadata endpoint. This feature can be enabled via the “Restrict Terraform Build Worker Instance Metadata Access” setting under the “Advanced Configuration” section in the installer dashboard’s settings page, or via the [restrict_worker_metadata_access](../install/automating-the-installer.html#restrict_worker_metadata_access) setting in the application settings file.
+By default Terraform Enterprise does not prevent Terraform operations from accessing the instance metadata service, which may contain IAM credentials or other sensitive data. Refer to [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html), [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows), or [Google Cloud's](https://cloud.google.com/compute/docs/storing-retrieving-metadata) documentation for more information on this service.
+
+TFE allows you to restrict access to the metadata endpoint from Terraform operations, preventing workspaces from reading any data from the metadata service. This feature can be enabled via the “Restrict Terraform Build Worker Instance Metadata Access” setting under the “Advanced Configuration” section in the installer dashboard’s settings page, or via the [restrict_worker_metadata_access](../install/automating-the-installer.html#restrict_worker_metadata_access) setting in the application settings file.
+
+Unless you are relying on the [instance profile as a means of providing default credentials to TFE workspaces](../before-installing/index.html#aws-specific-configuration), we recommend enabling this setting to prevent Terraform operations from accessing the instance metadata endpoint. 
 
 #### Ensure Global Remote State Sharing is Disabled
 
-TFE allows administrators to enable [global remote state sharing](../admin/general.html#remote-state-sharing), a feature that allows any workspace to access the state file of any other workspace within the same organization. We recommend disabling the feature, and relying on [controlled remote state access](https://www.hashicorp.com/blog/announcing-controlled-remote-state-access-for-terraform-cloud-and-enterprise) if you need to share state between workspaces.
+TFE allows administrators to enable [global remote state sharing](../admin/general.html#remote-state-sharing), a feature that allows any workspace to access the state versions of any other workspace within the same organization. We recommend disabling the feature and relying on [controlled remote state access](https://www.hashicorp.com/blog/announcing-controlled-remote-state-access-for-terraform-cloud-and-enterprise) if you need to share state between workspaces.
 
 #### Treat Support Bundles with Care
 
-Support bundles are used to share diagnostic information with HashiCorp support. Please note that support bundles may contain sensitive information from your Terraform Enterprise installation. You should consider these bundles sensitive; they should not be shared with untrusted parties, and should be deleted as soon as possible.
+Support bundles are used to share diagnostic information with HashiCorp support. Please note that support bundles may contain sensitive information from your Terraform Enterprise installation. You should consider these bundles sensitive; they should not be shared with untrusted parties and should be deleted as soon as possible.
 
 #### Regularly Update Terraform Enterprise
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -55,7 +55,7 @@ In addition those provided in the [Terraform Cloud security model](../../cloud/a
 
 To minimize attack surface, we recommend running Terraform Enterprise in an isolated network and limiting ingress ports to only 80 and 443. 
 
-For standalone deployments, port 8800 is reserved for the [Replicated admin console](../admin/admin-access.html), which is used for configuring TFE. This port should only be exposed to TFE infrastructure admins. Alternatively, if you choose to configure TFE via the [automated process](../install/automating-the-installer.html), you can disable the Replicated admin console by passing the `disable-replicated-ui` argument to the installation script:
+For standalone deployments, port 8800 is reserved for the [Replicated admin console](../admin/admin-access.html), which is used for configuring Terraform Enterprise. This port should only be exposed to infrastructure admins. If you choose to configure Terraform Enterprise with the [automated process](../install/automating-the-installer.html), you can disable the Replicated admin console by passing the `disable-replicated-ui` argument to the installation script:
 
 ```sudo bash ./install.sh disable-replicated-ui```
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -35,7 +35,7 @@ All of the content on [Terraform Cloud security model](../../cloud/architectural
 
 Infrastructure admins are required to manage all aspects of the underlying infrastructure. This includes initial provisioning, secure configuration, access control, network ACL configuration, and OS-level software updates. Terraform Enterprise cannot ensure the security of your data if the underlying infrastructure is compromised.
 
-### You are Responsible for Updating Your TFE Deployment
+### You are Responsible for Updating Your Terraform Enterprise Deployment
 
 Security fixes are released along with application features and bug fixes via TFE’s standard monthly release cycle. TFE infrastructure admins are responsible for applying updates.
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -31,7 +31,7 @@ Due to the extensive capabilities granted to this role, the site admin role shou
 
 All of the content on [Terraform Cloud security model](../../cloud/architectural-details/security-model.html) applies to Terraform Enterprise, with the exception of the points listed below.
 
-### TFE Requires You to Manage and Secure the Underlying Network and Infrastructure
+### Terraform Enterprise Requires You to Manage and Secure the Underlying Network and Infrastructure
 
 Infrastructure admins are required to manage all aspects of the underlying infrastructure. This includes initial provisioning, secure configuration, access control, network ACL configuration, and OS-level software updates. Terraform Enterprise cannot ensure the security of your data if the underlying infrastructure is compromised.
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -87,7 +87,7 @@ TFE allows administrators to enable [global remote state sharing](../admin/gener
 
 #### Treat Support Bundles with Care
 
-Support bundles are used to share diagnostic information with HashiCorp support. Please note that support bundles may contain sensitive information from your Terraform Enterprise installation. You should consider these bundles sensitive; they should not be shared with untrusted parties and should be deleted as soon as possible.
+Terraform Enterprise uses support bundles to share diagnostic information with HashiCorp support. Please note that support bundles may contain sensitive information from your Terraform Enterprise installation. You should not share them with untrusted parties and should delete them as soon as possible.
 
 #### Regularly Update Terraform Enterprise
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -41,7 +41,7 @@ Security fixes are released along with application features and bug fixes via TF
 
 ### You are Responsible for Availability, Backups, and Disaster Recovery
 
-TFE infrastructure admins are responsible for all aspects of TFE’s reliability and availability. Refer to TFE documentation on [monitoring](../admin/monitoring.html), [backups and restores](../admin/backup-restore.html), and [high availability mode (active/active)](../admin/active-active.html) for more guidance on this topic.
+Infrastructure admins are responsible for all aspects of reliability and availability. Refer to Terraform Enterprise documentation on [monitoring](../admin/monitoring.html), [backups and restores](../admin/backup-restore.html), and [high availability mode (active/active)](../admin/active-active.html) for more guidance on this topic.
 
 ### TFE Isolates Terraform Operations via Docker Containers, not a separate environment
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -1,0 +1,96 @@
+---
+layout: "enterprise"
+page_title: "Security Model- System Overview - Terraform Enterprise"
+---
+
+# Terraform Enterprise Security Model
+
+## Purpose of this document
+
+This document explains the security model of Terraform Enterprise and the security controls available to administrators and end users. This document is intended as a supplement to the [Terraform Cloud Security model](../../cloud/architectural-details/security-model.html) and describes aspects of the security model that are unique to Terraform Enterprise. We recommend familiarizing yourself with the Terraform Cloud security model before reading this document.
+
+## Additional Personas for Terraform Enterprise
+
+In addition to the personas listed in the Terraform Cloud Security Model, Terraform enterprise requires two additional personas required for managing and administering the application.
+
+
+### Infrastructure Admin
+
+Outside of the application, administrators of the Terraform Enterprise deployment are responsible for managing the underlying infrastructure, upgrading the application, and configuring Terraform Enterprise either via the [Replicated admin console](../install/config.html#system-configuration) or by editing the [application settings file](../install/automating-the-installer.html).
+
+Due to the extensive capabilities granted to this role, the infrastructure admin role be restricted to a small number of users within your organization.
+
+### Site Admin
+
+[Site admins](../admin/admin-access.html) are responsible for application-level configuration of Terraform Enterprise. Via the Admin interface, they will be able to manage all users, workspaces and organizations, and will have access to all data stored within Terraform Enterprise. Site admins are also responsible for configuring SAML, and will be the only users still able to access Terraform Enterprise via username/password once SAML is configured. 
+
+Due to the extensive capabilities granted to this role, the site admin role should be restricted to a small number of users within your organization.
+
+
+## Differences Between Terraform Enterprise and Terraform Cloud Security Models
+
+For the most part, Terraform Enterprise’s threat model can be considered a superset of the [Terraform Cloud security model](../../cloud/architectural-details/security-model.html) and (with the exception of the points listed below) all of the content on that page applies to Terraform Enterprise. Terraform Enterprise’s threat model differs from that of Terraform Clouds in these respects:
+
+### TFE Requires You to Manage and Secure the Underlying Network and Infrastructure
+
+TFE infrastructure admins are required to manage all aspects of the underlying infrastructure including initial provisioning, secure configuration, access control, configuring network ACLs, and OS-level software updates. TFE can not ensure the security of your data if the underlying infrastructure is compromised.
+
+### You are Responsible for Updating Your TFE Deployment
+
+Security fixes are released along with application features and bug fixes via TFE’s standard monthly release cycle. TFE infrastructure admins are responsible for applying updates.
+
+### You are Responsible for TFE’s Availability, Backups, and Disaster Recovery
+
+TFE infrastructure admins are responsible for all aspects of TFE’s reliability and availability. Refer to TFE documentation on [monitoring](../admin/monitoring.html), [backups and restores](../admin/backup-restore.html), and [high availability mode (active/active)](../admin/active-active.html) for more guidance on this topic.
+
+### TFE Isolates Terraform Operations via Docker Containers, not a separate environment
+
+Unlike Terraform Cloud, TFE executes all Terraform operations in Docker containers on the TFE host. The containers are assigned to an isolated Docker network to prevent them from communicating with TFE’s backend services, but may have access to resources available on hosts accessible from the your TFE instance. 
+
+## Recommendations for Securely Operating Terraform Enterprise
+
+In addition the the recommendations provided in the [Terraform Cloud security model](../../cloud/architectural-overview/security-model.html), we offer these recommendations to users of Terraform Enterprise 
+
+### Run Terraform Enterprise in an Isolated Network, Limit Ingress Ports, and Restrict Access to Underlying Infrastructure
+
+To minimize attack surface, we recommend running TFE in an isolated network and limiting ingress ports to only 80 and 443. 
+
+For standalone deployments, port 8800 is reserved for the [Replicated admin console](../admin/admin-access.html), which is used for configuring TFE. This port should only be exposed to TFE infrastructure admins. Alternatively, if you choose to configure TFE via the [automated process](../install/automating-the-installer.html), you can disable the Replicated admin console by passing the disable-replicated-ui argument to the installation script:
+
+```sudo bash ./install.sh disable-replicated-ui```
+
+Additionally, we recommend restricting access to the nodes that are running TFE. TFE can not ensure the security or integrity of its data if the underlying infrastructure is compromised.
+
+### Enable Optional Security Features
+
+Once you are ready to use Terraform Enterprise for production workloads, we recommend enabling these optional security features.
+
+#### Strict Transport Security Header
+
+You can configure TFE to set the [Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header via the Settings page of the installer dashboard by enabling “Force TLS” radio button under “SSL/TLS Configuration”
+
+You can also enable this setting via the application settings file file with the [force_tls](../install/automating-the-installer.html#force_tls) setting.
+
+~> **Note:** Once properly configured, the HSTS header cannot be disabled and will prevent clients from accessing your TFE domain via HTTP or HTTPS using a self-signed cert. We recommend only enabling this setting for production TFE deployments.
+
+#### Restrict Terraform Build Worker Metadata Access
+
+By default Terraform Enterprise does not prevent Terraform operations from accessing the instance metadata endpoint, which may contain IAM credential or other sensitive data. Unless you are relying on the [instance profile as a means of providing default credentials to TFE workspaces](../before-installing/index.html#aws-specific-configuration), we recommend enabling this setting to prevent Terraform operations from accessing the instance metadata endpoint. This feature can be enabled via the “Restrict Terraform Build Worker Instance Metadata Access” setting under the “Advanced Configuration” section in the installer dashboard’s settings page, or via the [restrict_worker_metadata_access](../install/automating-the-installer.html#restrict_worker_metadata_access) setting in the application settings file.
+
+#### Ensure Global Remote State Sharing is Disabled
+
+TFE allows administrators to enable [global remote state sharing](../admin/general.html#remote-state-sharing), a feature that allows any workspace to access the state file of any other workspace within the same organization. We recommend disabling the feature, and relying on [controlled remote state access](https://www.hashicorp.com/blog/announcing-controlled-remote-state-access-for-terraform-cloud-and-enterprise) if you need to share state between workspaces.
+
+#### Treat Support Bundles with Care
+
+Support bundles are used to share diagnostic information with HashiCorp support. Please note that support bundles may contain sensitive information from your Terraform Enterprise installation. You should consider these bundles sensitive; they should not be shared with untrusted parties, and should be deleted as soon as possible.
+
+#### Regularly Update Terraform Enterprise
+
+Terraform Enterprise updates are released on a monthly cadence. Updates may contain additional security features or fixes for existing security vulnerabilities, so we recommend establishing a process for periodically updating your Terraform Enterprise installation.
+
+#### Subscribe to Terraform Enterprise Security Bulletins
+
+HashiCorp publishes security updates, which address security vulnerabilities in HashiCorp products, in the Security category of [HashiCorp Discuss](https://discuss.hashicorp.com/c/security/).
+
+We recommend that Terraform Enterprise administrators follow the [documented steps](https://discuss.hashicorp.com/t/about-hashicorp-security-updates/15330) to subscribe to email notifications or the RSS feed for Terraform Enterprise security updates.

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -45,7 +45,7 @@ Infrastructure admins are responsible for all aspects of reliability and availab
 
 ### Terraform Enterprise Isolates Terraform Operations via Docker Containers
 
-Unlike Terraform Cloud, TFE executes all Terraform operations in Docker containers on the TFE host. The containers are assigned to an isolated Docker network to prevent them from communicating with TFE’s backend services, but may have access to resources available on hosts accessible from the your TFE instance. 
+Unlike Terraform Cloud, Terraform Enterprise executes all Terraform operations in Docker containers on the Terraform Enterprise host. The containers are assigned to an isolated Docker network to prevent them from communicating with Terraform Enterprise backend services, but may have access to resources available on hosts accessible from the your Terraform Enterprise instance. 
 
 ## Recommendations for Securely Operating Terraform Enterprise
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -58,7 +58,7 @@ For standalone deployments, port 8800 is reserved for the [Replicated admin cons
 
 ```sudo bash ./install.sh disable-replicated-ui```
 
-Additionally, we recommend restricting access to the nodes that are running Terraform Enterprise. Terraform Enterprise can not ensure the security or integrity of its data if the underlying infrastructure is compromised.
+Additionally, we recommend restricting access to the nodes that are running Terraform Enterprise. Terraform Enterprise can not ensure the security or integrity of your data if the underlying infrastructure is compromised.
 
 ### Enable Optional Security Features
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -18,7 +18,7 @@ In addition to those listed in [Terraform Cloud Security model](../../cloud/arch
 
 Outside of the application, administrators of the Terraform Enterprise deployment are responsible for managing the underlying infrastructure, upgrading the application, and configuring Terraform Enterprise either via the [Replicated admin console](../install/config.html#system-configuration) or by editing the [application settings file](../install/automating-the-installer.html).
 
-Due to the extensive capabilities granted to this role, the infrastructure admin role be restricted to a small number of users within your organization.
+Terraform Enterprise grants extensive permissions to this role, so we recommend limiting the number of users who are infrastructure admins in your organization.
 
 ### Site Admin
 

--- a/content/source/docs/enterprise/system-overview/security-model.html.md
+++ b/content/source/docs/enterprise/system-overview/security-model.html.md
@@ -9,7 +9,7 @@ page_title: "Security Model- System Overview - Terraform Enterprise"
 
 This document explains the security model of Terraform Enterprise and the security controls available to administrators and end users. This document is intended as a supplement to the [Terraform Cloud Security model](../../cloud/architectural-details/security-model.html) and describes aspects of the security model that are unique to Terraform Enterprise. We recommend familiarizing yourself with the Terraform Cloud security model before reading this document.
 
-## Additional Personas for Terraform Enterprise
+## Personas
 
 In addition to the personas listed in the Terraform Cloud Security Model, Terraform enterprise requires two additional personas for managing and administering the application.
 

--- a/content/source/layouts/_enterprise_content.erb
+++ b/content/source/layouts/_enterprise_content.erb
@@ -241,6 +241,9 @@
           <li>
             <a href="/docs/enterprise/system-overview/capacity.html">Capacity &amp; Performance</a>
           </li>
+          <li>
+            <a href="/docs/enterprise/system-overview/security-model.html">Security Model</a>
+          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
Adding the Terraform Enterprise security model. This document supplements the Terraform Cloud security model, focusing on TFE.

## Labels
- [X] new docs

