### PR TITLE
Add a warning for TFE + external Vault

### DIFF
--- a/content/source/docs/enterprise/before-installing/vault.html.md
+++ b/content/source/docs/enterprise/before-installing/vault.html.md
@@ -13,6 +13,8 @@ By default, Terraform Enterprise automatically configures and manages its own in
 Choosing this option means you assume full responsibility for how the Vault cluster is managed;
 for example, how it is sealed and unsealed, replicated, etc.
 
+!> **Warning:** Multiple Terraform Enterprise instances should not be configured to use the same Vault, unless they are a pair of Active/Active instances. Doing so can result in failures and loss of data. 
+
 ~> **Important:** The external Vault option must be selected at initial installation, and cannot be changed later.
 Do not attempt to migrate an existing Terraform Enterprise instance between internal and external
 Vault options.


### PR DESCRIPTION
## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)

This changes adds an additional warning to using external Vault with TFE. Due to our current lack of support for custom paths, we cannot support two disparate TFE instances pointing to the same Vault instance/cluster. 
