### PR TITLE
Redirect legacy provider docs index

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -909,3 +909,8 @@
 /docs/commands/env.html                     /docs/cli/commands/env.html
 /docs/commands/push.html                    /docs/cli/commands/push.html
 /docs/plugins/signing.html                  /docs/cli/plugins/signing.html
+
+# Final cleanup of legacy providers docs
+/docs/providers/index.html          /docs/language/providers/index.html
+/docs/providers/                    /docs/language/providers/index.html
+/docs/providers                     /docs/language/providers/index.html


### PR DESCRIPTION
The fact that you need three redirects if it's an index.html file is a weird old quirk of this relict website builder.

More context: https://github.com/hashicorp/terraform/pull/29134