### PR TITLE
Remove about link from hashi stack menu

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -223,11 +223,6 @@
                       </menu>
                   </section>
                 </li>
-                <li class="navItem">
-                  <a
-                    class="link"
-                    href="https://www.hashicorp.com/about">About HashiCorp</a>
-                </li>
                 </menu>
             </nav>
     </header>


### PR DESCRIPTION
This PR removes the "About HashiCorp" link from the top navigation.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
