### PR TITLE
TFC Actions menu: Update references to locking and the queue plan form

### DIFF
--- a/content/source/docs/cloud/run/index.html.md
+++ b/content/source/docs/cloud/run/index.html.md
@@ -43,6 +43,14 @@ Whenever a new run is initiated, it's added to the end of the queue. If there's 
 
 When you initiate a run, Terraform Cloud locks the run to a particular configuration version and set of variable values. If you change variables or commit new code before the run finishes, it will only affect future runs, not runs that are already pending, planning, or awaiting apply.
 
+### Workspace Locks
+
+When a workspace is _locked,_ new runs can be queued (automatically or manually) but no new runs can begin until the workspace is unlocked.
+
+When a run is in progress, that run locks the workspace, as described above under "Ordering and Timing".
+
+A user or team can also deliberately lock a workspace, to perform maintenance or for any other reason. For more details, see [Locking Workspaces (Preventing Runs)](manage.html#locking-workspaces-preventing-runs-).
+
 ## Starting Runs
 
 Terraform Cloud has three main workflows for managing runs, and your chosen workflow determines when and how Terraform runs occur. For detailed information, see:
@@ -51,7 +59,7 @@ Terraform Cloud has three main workflows for managing runs, and your chosen work
 - The [API-driven run workflow](./api.html), which is more flexible but requires you to create some tooling.
 - The [CLI-driven run workflow](./cli.html), which uses Terraform's standard CLI tools to execute runs in Terraform Cloud.
 
-In more abstract terms, runs can be initiated by VCS webhooks, the manual "Queue Plan" button on a workspace, the standard `terraform apply` command (with the remote backend configured), and [the Runs API](../api/run.html) (or any tool that uses that API).
+In more abstract terms, runs can be initiated by VCS webhooks, the manual "Start new run" action in the workspace actions menu, the standard `terraform apply` command (with the remote backend configured), and [the Runs API](../api/run.html) (or any tool that uses that API).
 
 ## Plans and Applies
 
@@ -84,6 +92,10 @@ Retrying a plan requires permission to queue plans for that workspace. ([More ab
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 Retrying the run will create a new run with the same configuration version. If it is a VCS-backed workspace, the pull request interface will receive the status of the new run, along with a link to the new run.
+
+## Planning Modes and Options
+
+In addition to the normal run workflows described above, Terraform Cloud supports destroy runs, refresh-only runs, and several planning options that can modify the behavior of a run. For more details, see [Run Modes and Options](./modes-and-options.html).
 
 ## Run States
 

--- a/content/source/docs/cloud/run/manage.html.md
+++ b/content/source/docs/cloud/run/manage.html.md
@@ -73,7 +73,9 @@ If you need to temporarily stop runs from being queued, you can lock the workspa
 
 A lock prevents Terraform Cloud from performing any plans or applies in the workspace. This includes automatic runs due to new commits in the VCS repository, manual runs queued via the UI, runs started on the command line with `terraform plan` and `terraform apply`, and runs created with the API. New runs remain in the "Pending" state until the workspace is unlocked.
 
-You can find the lock button in [the workspace settings page](../workspaces/settings.html). Locking a workspace requires permission to lock and unlock the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+The current lock status is shown in the workspace header, near the "Actions" menu.
+
+You can find the lock button in the "Actions" menu in a workspace's header, or in [the workspace settings page](../workspaces/settings.html). Locking a workspace requires permission to lock and unlock the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/run/modes-and-options.html.md
+++ b/content/source/docs/cloud/run/modes-and-options.html.md
@@ -19,12 +19,13 @@ Terraform Cloud runs support many of the same modes and options available in the
 
 > **Hands-on:** Try the [Use Refresh-Only Mode to Sync Terraform State](https://learn.hashicorp.com/tutorials/terraform/refresh) tutorial on HashiCorp Learn.
 
--> **Version note:** Refresh-only support is available in Terraform Enterprise v202106-1 or later and requires a workspace using at least Terraform CLI v0.15.2.
+-> **Version note:** Refresh-only support is available in Terraform Enterprise v202106-1 or later and requires a workspace using at least Terraform CLI v0.15.4.
 
 [Refresh-only mode](/docs/cli/commands/plan.html#planning-modes) instructs Terraform to create a plan which updates the Terraform state to match changes made to remote objects outside of Terraform.
 
 - **CLI:** Use `terraform plan -refresh-only` or `terraform apply -refresh-only`.
 - **API:** Use the `refresh-only` option.
+- **UI:** Use the "Start new plan" action from a workspace's "Actions" menu, then choose the "Refresh-only" plan type in the new plan dialog.
 
 ## Skipping Automatic State Refresh
 

--- a/content/source/docs/cloud/run/modes-and-options.html.md
+++ b/content/source/docs/cloud/run/modes-and-options.html.md
@@ -38,7 +38,7 @@ The [`-refresh=false` option](/docs/cli/commands/plan.html#refresh-false) is use
 
 ## Replacing Selected Resources
 
--> **Version note:** Replace support is available in Terraform Enterprise v202106-1 or later and requires a workspace using at least Terraform CLI v0.15.4.
+-> **Version note:** Replace support is available in Terraform Enterprise v202106-1 or later and requires a workspace using at least Terraform CLI v0.15.2.
 
 The [replace option](/docs/cli/commands/plan.html#replace-address) instructs Terraform to replace the object with the given resource address.
 

--- a/content/source/docs/cloud/run/ui.html.md
+++ b/content/source/docs/cloud/run/ui.html.md
@@ -27,11 +27,13 @@ In a workspace linked to a VCS repo, runs start automatically when you merge or 
 
 A workspace is linked to one branch of its repository, and ignores changes to other branches. Workspaces can also ignore some changes within their branch: if a Terraform working directory is configured, Terraform Cloud assumes that only some of the content in the repository is relevant to Terraform, and ignores changes outside of that content. (This behavior can be configured; for details, see [Settings: Automatic Run Triggering](../workspaces/vcs.html#automatic-run-triggering).)
 
--> **Note:** A workspace with no runs will not accept new runs via VCS webhook. At least one run must be manually queued to confirm that the workspace is ready for further runs. 
+-> **Note:** A workspace with no runs will not accept new runs via VCS webhook. At least one run must be manually queued to confirm that the workspace is ready for further runs.
 
 ## Manually Starting Runs
 
-When you initially set up the workspace and add variables, or when the code in version control hasn't changed but you've modified some variables, you can manually queue a plan from the UI. Each workspace has a "Queue Plan" button for this purpose. Manually queueing a plan requires permission to queue plans for the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+When you initially set up the workspace and add variables, or when the code in version control hasn't changed but you've modified some variables, you can manually start a run from the UI. Each workspace has an "Actions" menu in its header, which includes a "Start new plan" action for this purpose. When creating a new plan, you can optionally provide a message and can choose between normal and [refresh-only](./modes-and-options.html#refresh-only-mode) modes.
+
+Manually starting a run requires permission to queue plans for the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/workspaces/index.html.md
+++ b/content/source/docs/cloud/workspaces/index.html.md
@@ -65,7 +65,6 @@ The following filters are available:
 
     The name filter can combine with a status filter, to narrow the list down further.
 
-
 ## Planning and Organizing Workspaces
 
 We recommend that organizations break down large monolithic Terraform configurations into smaller ones, then assign each one to its own workspace and delegate permissions and responsibilities for them. Terraform Cloud can manage monolithic configurations just fine, but managing infrastructure as smaller components is the best way to take full advantage of Terraform Cloud's governance and delegation features.

--- a/content/source/docs/cloud/workspaces/settings.html.md
+++ b/content/source/docs/cloud/workspaces/settings.html.md
@@ -138,6 +138,8 @@ Users with permission to lock and unlock a workspace can't unlock a workspace wh
 
 Locks are managed with a single "Lock/Unlock/Force unlock `<WORKSPACE NAME>`" button. Terraform Cloud asks for confirmation when unlocking.
 
+You can also use the "Actions" menu in a workspace's header to manage the workspace's lock.
+
 ## Notifications
 
 The "Notifications" page allows Terraform Cloud to send webhooks to external services whenever specific run events occur in a workspace.


### PR DESCRIPTION
**Draft status:** This is behind a feature flag right now, so the docs can't be merged yet. 

TFC workspaces have a new interface for manually starting runs and managing the
lock on a workspace; this updates (I think!) all of the places where we refer to
the old ways of doing those things.

It doesn't update the screenshots, because:

- We didn't have existing screenshots specifically dedicated to doing those actions.
- The number of screenshots that _incidentally_ show the old workspace header
  interface are too numerous. We need a better way to manage these! :coolcrying: