### PR TITLE
Add a warning to the docs that TFC Agent doesn't support TFE_PARALLELISM

### DIFF
--- a/content/source/docs/cloud/workspaces/variables.html.md
+++ b/content/source/docs/cloud/workspaces/variables.html.md
@@ -116,7 +116,7 @@ Terraform Cloud uses some special environment variables to control dangerous or 
 
 - `TFE_PARALLELISM` — If present, Terraform Cloud uses this to set `terraform plan` and `terraform apply`'s `-parallelism=<N>` flag ([more info](/docs/internals/graph.html#walking-the-graph)). Valid values are between 1 and 256, inclusive; the default is `10`. This is rarely necessary, but can fix problems with infrastructure providers that error on concurrent operations or use non-standard rate limiting. We recommend talking to HashiCorp support before using this.
 
-Please note that `TFE_PARALLELISM` is not supported by Terraform Cloud Agents. Modern versions of Terraform allow you to specify flags as environment variables directly via [TF_CLI_ARGS](/docs/cli/config/environment-variables.html#tf-cli-args). Use `TF_CLI_ARGS="parallelism=<N>"` instead.
+-> **Note:** `TFE_PARALLELISM` is not supported by Terraform Cloud Agents, but modern versions of Terraform allow you to specify flags as environment variables directly via [TF_CLI_ARGS](/docs/cli/config/environment-variables.html#tf-cli-args). Use `TF_CLI_ARGS="parallelism=<N>"` instead.
 
 ### Secure Storage of Variables
 

--- a/content/source/docs/cloud/workspaces/variables.html.md
+++ b/content/source/docs/cloud/workspaces/variables.html.md
@@ -116,7 +116,7 @@ Terraform Cloud uses some special environment variables to control dangerous or 
 
 - `TFE_PARALLELISM` — If present, Terraform Cloud uses this to set `terraform plan` and `terraform apply`'s `-parallelism=<N>` flag ([more info](/docs/internals/graph.html#walking-the-graph)). Valid values are between 1 and 256, inclusive; the default is `10`. This is rarely necessary, but can fix problems with infrastructure providers that error on concurrent operations or use non-standard rate limiting. We recommend talking to HashiCorp support before using this.
 
--> **Note:** `TFE_PARALLELISM` is not supported by Terraform Cloud Agents, but modern versions of Terraform allow you to specify flags as environment variables directly via [TF_CLI_ARGS](/docs/cli/config/environment-variables.html#tf-cli-args). Use `TF_CLI_ARGS="parallelism=<N>"` instead.
+-> **Note:** `TFE_PARALLELISM` is not supported by Terraform Cloud Agents, but Terraform allows you to specify flags as environment variables directly via [TF_CLI_ARGS](/docs/cli/config/environment-variables.html#tf-cli-args). Use `TF_CLI_ARGS="parallelism=<N>"` instead.
 
 ### Secure Storage of Variables
 

--- a/content/source/docs/cloud/workspaces/variables.html.md
+++ b/content/source/docs/cloud/workspaces/variables.html.md
@@ -116,6 +116,8 @@ Terraform Cloud uses some special environment variables to control dangerous or 
 
 - `TFE_PARALLELISM` — If present, Terraform Cloud uses this to set `terraform plan` and `terraform apply`'s `-parallelism=<N>` flag ([more info](/docs/internals/graph.html#walking-the-graph)). Valid values are between 1 and 256, inclusive; the default is `10`. This is rarely necessary, but can fix problems with infrastructure providers that error on concurrent operations or use non-standard rate limiting. We recommend talking to HashiCorp support before using this.
 
+Please note that `TFE_PARALLELISM` is not supported by Terraform Cloud Agents. Modern versions of Terraform allow you to specify flags as environment variables directly via [TF_CLI_ARGS](/docs/cli/config/environment-variables.html#tf-cli-args). Use `TF_CLI_ARGS="parallelism=<N>"` instead.
+
 ### Secure Storage of Variables
 
 Terraform Cloud encrypts all variable values securely using [Vault's transit backend](https://www.vaultproject.io/docs/secrets/transit/index.html) prior to saving them. This ensures that no out-of-band party can read these values without proper authorization.


### PR DESCRIPTION
TFC Agent doesn't support `TFE_PARALLELISM`, but that's okay, because Terraform supports setting flags via environment variables directly now.

<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
