### PR TITLE
Fix broken contributing link on publish providers page

### DIFF
--- a/content/source/docs/registry/providers/publishing.html.md
+++ b/content/source/docs/registry/providers/publishing.html.md
@@ -27,7 +27,7 @@ Providers published to the Terraform Registry are written and built in the same 
 - Example providers for reference:
     - [AWS](https://github.com/terraform-providers/terraform-provider-aws)
     - [AzureRM](https://github.com/terraform-providers/terraform-provider-azurerm)
-- [Contributing to Terraform guidelines](/docs/extend/community/contributing.html)
+- [Contributing to Terraform](https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md)
 
 ~> **Important:** In order to be detected by the Terraform Registry, all provider repositories on GitHub must match the pattern `terraform-provider-{NAME}`, and the repository must be public. Only lowercase repository names are supported.
 


### PR DESCRIPTION
Fixing a broken link to the deleted Terraform Contributing pages that came as a result of merging https://github.com/hashicorp/terraform-website/pull/1769

Note that we can merge despite the circleci link check - these are because of redirects, and the links aren't really broken.