### PR TITLE
Typo in Agent Pool creation URL

### DIFF
--- a/content/source/docs/cloud/api/agents.md
+++ b/content/source/docs/cloud/api/agents.md
@@ -341,7 +341,7 @@ curl \
 
 ## Create an Agent Pool
 
-`POST /organizations/:organization_name/agent-pool`
+`POST /organizations/:organization_name/agent-pools`
 
 Parameter            | Description
 ---------------------|------------


### PR DESCRIPTION
The Agent Pool POST URL is missing a "s" at the end in the definition.


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
