### PR TITLE
Scope broken link checker to just docs page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ jobs:
       - run:
           name: check links in changed pages
           working_directory: content
-          command: git diff --name-only -z --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
+          command:
+            git diff --name-only -z --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
             # --name-only: Return a list of affected files but don't show the changes.
             # -z: Make that a null-separated list (instead of newline-separated), and
             #     DON'T mangle non-ASCII characters.
@@ -115,7 +116,7 @@ jobs:
 
       - run:
           name: Warm cache and check for broken links
-          command: /root/.pub-cache/bin/linkcheck https://www.terraform.io/
+          command: /root/.pub-cache/bin/linkcheck https://www.terraform.io/docs
 
       - slack/status:
           success_message: ":white_check_mark: Finished warming cache for terraform.io. :meow_yay: No broken links!"


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)

Broken link checker is throwing an error. Testing locally, this is the output, which is causing similar errors in the CI pipelines. Proposing we scope the link checker to just the docs which works as expected. In addition, this repo only touches the docs so this makes more sense imo.

Proposed:
```
$ linkcheck https://www.terraform.io/docs/
Perfect. Checked 170670 links, 832 destination URLs (1273 ignored).
```

Current:
```
$ linkcheck https://www.terraform.io/
Crawling: 0Unhandled exception:
Bad state: Element <html link> does not have any of the attributes [href, src]
#0      extractLink (package:linkcheck/src/parsers/html.dart:36)
#1      parseHtml.<anonymous closure> (package:linkcheck/src/parsers/html.dart:125)
#2      MappedListIterable.elementAt (dart:_internal/iterable.dart:415)
#3      ListIterable.toList (dart:_internal/iterable.dart:219)
#4      parseHtml (package:linkcheck/src/parsers/html.dart:127)
#5      checkPage (package:linkcheck/src/worker/worker.dart:169)
#6      _RootZone.runUnary (dart:async/zone.dart:1379)
## ...
Done crawling.
```
