### PR TITLE
Fix redirect formatting for plugin-types deleted page

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -926,4 +926,4 @@
 #/docs/extend/community                         https://www.terraform.io/community
 #/docs/extend/community/                        https://www.terraform.io/community
 #/docs/extend/community/maintainers.html        https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
-/docs/extend/plugin-types.html               /docs/extend/index.html
+/docs/extend/plugin-types.html                  /docs/extend/index.html

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -926,4 +926,4 @@
 #/docs/extend/community                         https://www.terraform.io/community
 #/docs/extend/community/                        https://www.terraform.io/community
 #/docs/extend/community/maintainers.html        https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
-/docs/extend/plugin-types.html.md               /docs/extend/index.html
+/docs/extend/plugin-types.html               /docs/extend/index.html


### PR DESCRIPTION
I formatted a redirect link incorrectly, and this PR should fix. (Sorry! I'm new at this :-) )

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
