### PR TITLE
content/source/docs: Replace golang.org/pkg links with pkg.go.dev

### DIFF
--- a/content/source/docs/extend/schemas/schema-behaviors.html.md
+++ b/content/source/docs/extend/schemas/schema-behaviors.html.md
@@ -25,7 +25,7 @@ configuration, as opposed to trying to update the existing resource.
 -> **Note:** The primitive behavior fields cannot be set to `false`. You can opt out of a behavior by omitting it.
 
 ### Optional
-**Data structure:** [bool](https://golang.org/pkg/builtin/#bool)    
+**Data structure:** [bool](https://pkg.go.dev/builtin#bool)    
 **Values:** `true` 
 **Restrictions:**
 
@@ -54,7 +54,7 @@ resource "example_volume" "ex" {
 ```
 
 ### Required
-**Data structure:** [bool](https://golang.org/pkg/builtin/#bool)    
+**Data structure:** [bool](https://pkg.go.dev/builtin#bool)    
 **Values:** `true`
 **Restrictions:**  
 
@@ -124,7 +124,7 @@ resource "example_volume" "ex" {
 ```
 
 ### Computed
-**Data structure:** [bool](https://golang.org/pkg/builtin/#bool)    
+**Data structure:** [bool](https://pkg.go.dev/builtin#bool)    
 **Value:** `true`   
 **Restrictions:**  
 
@@ -161,7 +161,7 @@ output "volume_uuid" {
 ```
 
 ### ForceNew
-**Data structure:** [bool](https://golang.org/pkg/builtin/#bool)    
+**Data structure:** [bool](https://pkg.go.dev/builtin#bool)    
 **Value:** `true` 
 
 `ForceNew` indicates that any change in this field requires the resource to be

--- a/content/source/docs/extend/schemas/schema-types.html.md
+++ b/content/source/docs/extend/schemas/schema-types.html.md
@@ -76,7 +76,7 @@ tracks the number of items the property contains.
 ## Primitive Types
 
 ### TypeBool
-**Data structure:** [bool](https://golang.org/pkg/builtin/#bool)    
+**Data structure:** [bool](https://pkg.go.dev/builtin#bool)    
 **Example:** `true` or `false`
 
 **Schema example:**
@@ -102,7 +102,7 @@ resource "example_volume" "ex" {
 ```
 
 ### TypeInt
-**Data structure:** [int](https://golang.org/pkg/builtin/#int)  
+**Data structure:** [int](https://pkg.go.dev/builtin#int)  
 **Example:** `-9`, `0`, `1`, `2`, `9`
 
 **Schema example:**
@@ -127,7 +127,7 @@ resource "example_compute_instance" "ex" {
 ```
 
 ### TypeFloat 
-**Data structure:** [float64](https://golang.org/pkg/builtin/#float64)  
+**Data structure:** [float64](https://pkg.go.dev/builtin#float64)  
 **Example:** `1.0`, `7.19009`
 
 **Schema example:**
@@ -154,7 +154,7 @@ resource "example_spot_request" "ex" {
 
 ### TypeString
 
-**Data structure:** [string](https://golang.org/pkg/builtin/#string)  
+**Data structure:** [string](https://pkg.go.dev/builtin#string)  
 **Example:** `"Hello, world!"`
 
 **Schema example:**

--- a/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
+++ b/content/source/docs/extend/testing/acceptance-tests/testcase.html.md
@@ -94,7 +94,7 @@ each test, defined below. The source for `TestCase` can be viewed [here on
 godoc.org](https://godoc.org/github.com/hashicorp/terraform-plugin-sdk/helper/resource#TestCase)
 
 ### IsUnitTest
-**Type:** [bool](https://golang.org/pkg/builtin/#bool)  
+**Type:** [bool](https://pkg.go.dev/builtin#bool)  
 **Default:** `false`  
 **Required:** no  
 
@@ -304,4 +304,4 @@ to create these scenarios by iterating on Terraform configurations.
 
 [1]: https://github.com/hashicorp/terraform-plugin-sdk/blob/9f0df37a8fdb2627ae32db6ceaf7f036d89b6768/helper/resource/testing.go#L205-L257
 [2]: /docs/extend/testing/acceptance-tests/teststep.html
-[3]: https://golang.org/pkg/testing/#T
+[3]: https://pkg.go.dev/testing#T

--- a/content/source/docs/plugin/framework/accessing-values.html.md
+++ b/content/source/docs/plugin/framework/accessing-values.html.md
@@ -160,7 +160,7 @@ null or unknown:
 * `int`, `int8`, `int16`, `int32`, `int64`
 * `uint`, `uint8`, `uint16`, `uint32`, `uint64`
 * `float32`, `float64`
-* [`*big.Int`](https://golang.org/pkg/math/big#Int), [`*big.Float`](https://golang.org/pkg/math/big#Float)
+* [`*big.Int`](https://pkg.go.dev/math/big#Int), [`*big.Float`](https://pkg.go.dev/math/big#Float)
 
 An error will be returned if the value of the number cannot be stored in the numeric type supplied because of an overflow or other loss of precision.
 

--- a/content/source/docs/plugin/framework/types.html.md
+++ b/content/source/docs/plugin/framework/types.html.md
@@ -103,7 +103,7 @@ struct in config, state, and plan. The `types.Number` struct has the following
 properties:
 
 * `Value` contains the number's value as a Go
-  [`*big.Float`](https://golang.org/pkg/math/big#Float) type.
+  [`*big.Float`](https://pkg.go.dev/math/big#Float) type.
 * `Null` is set to `true` when the number's value is null.
 * `Unknown` is set to `true` when the number's value is unknown.
 

--- a/content/source/docs/plugin/framework/writing-state.html.md
+++ b/content/source/docs/plugin/framework/writing-state.html.md
@@ -140,7 +140,7 @@ aliases of them, like `type MyNumber int`):
 * `int`, `int8`, `int16`, `int32`, `int64`
 * `uint`, `uint8`, `uint16`, `uint32`, `uint64`
 * `float32`, `float64`
-* [`*big.Int`](https://golang.org/pkg/math/big#Int), [`*big.Float`](https://golang.org/pkg/math/big#Float)
+* [`*big.Int`](https://pkg.go.dev/math/big#Int), [`*big.Float`](https://pkg.go.dev/math/big#Float)
 
 ### Boolean
 


### PR DESCRIPTION
Go has recently migrated standard library packages from golang.org/pkg to pkg.go.dev. Adjusting these links will prevent the link checker failures for the redirects.


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
