### PR TITLE
Update About the Docs page content

### DIFF
--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -39,7 +39,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 ### Develop Plugins
 
 - [Create a provider](/docs/extend/index.html) to allow Terraform to interact with a service.
-- [Publish your provider](/docs/registry/index.html) to the Terraform Registry to make it publicly available.
+- [Publish a provider or module](/docs/registry/index.html) to the Terraform Registry to make it publicly available.
 </div>
 
 </div></div>

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -22,7 +22,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 
 ### Manage Infrastructure
 
-- Use [Terraform's configuration language](/docs/language/index.html) to describe infrastructure on various [providers](/docs/language/providers/index.html).
+- Describe infrastructure with [Terraform's configuration language](/docs/language/index.html) on various [providers](/docs/language/providers/index.html).
 - Use the [Terraform CLI](/docs/cli/index.html) with the Terraform binary for command-line workflows.
 
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -33,7 +33,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 
 ### Collaborate
 
-- [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, enabling version control, data sharing, and more.
+- [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, with version control, state sharing, and more.
 - [Terraform Enterprise](/docs/enterprise/index.html) is a self-hosted instance of Terraform Cloud.
 
 ### Develop Plugins

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -34,7 +34,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 ### Collaborate
 
 - [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, enabling version control, data sharing, and more.
-- [Terraform Enterprise](/docs/enterprise/index.html) offers a private instance of Terraform Cloud, with features like access control and governance.
+- [Terraform Enterprise](/docs/enterprise/index.html) is a self-hosted instance of Terraform Cloud.
 
 ### Develop Plugins
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -10,70 +10,35 @@ show_notification: false
 
 # Terraform Documentation
 
-Welcome to the Terraform documentation!
-
-We've divided the Terraform docs into several sections to make it easier to find things. Navigate using this index page, or jump from section to section in the "Other Docs" section of the navigation sidebar.
-
 <div class="container-fluid"><div class="row">
-
 <div class="col-md-6 col-sm-12">
 
-### [Introduction to Terraform ➜](/intro/index.html)
+### Get Started
 
--> Visitors who are curious about Terraform can start here.
+- Learn how Terraform [solves infrastructure challenges](/intro/index.html) and how it [compares to other tools and services](/intro/vs/index.html).
+- [Follow the tutorials on HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) to install Terraform, learn the Terraform workflow, and explore use cases.
 
-A broad overview of what Terraform is and why people use it.
 
-### [Terraform Glossary ➜](/docs/glossary.html)
+### Manage Infrastructure
 
-Definitions (and helpful links) for technical terms used throughout Terraform's documentation, help text, and UI. Visit the glossary whenever you get lost.
+- Use the [Terraform Configuration Language](/docs/language/index.html) to describe infrastructure.
+- Use the [Terraform CLI](/docs/cli/index.html) with the Terraform binary for command-line workflows.
 
-### [Configuration Language ➜](/docs/language/index.html)
 
--> Intermediate and advanced users spend most of their time here.
-
-Documentation for Terraform's configuration language.
-
-The Terraform configuration language is Terraform's primary user interface. This section is relevant to all users of Terraform, including Terraform Cloud and Terraform Enterprise users.
-
-### [Terraform CLI ➜](/docs/cli/index.html)
-
-Documentation for Terraform's command-line workflows, including docs for [the `terraform` binary and its subcommands](/docs/cli/commands/index.html).
-
-### [Learn Terraform ➜](https://learn.hashicorp.com/terraform?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) (external site)
-
--> New users can start here.
-
-Interactive tutorials to teach you how to use Terraform's features. Begin with the [Get Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS), then continue with task-specific tutorials or go directly to the [Terraform CLI docs](/docs/cli/index.html).
 
 </div>
 
 <div class="col-md-6 col-sm-12">
 
-### [Terraform Cloud ➜](/docs/cloud/index.html)
+### Collaborate
 
-Documentation for Terraform Cloud.
+- [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, enabling version control, data sharing, and more.
+- [Terraform Enterprise](/docs/enterprise/index.html) offers a private instance of Terraform Cloud, with features like access control and governance.
 
-Terraform Cloud is an application that helps teams use Terraform together. It manages Terraform runs in a consistent and reliable environment, and includes easy access to shared state and secret data, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more. Terraform Cloud offers free accounts for small teams, and paid plans with additional feature sets for medium-sized businesses.
+### Develop Plugins
 
-### [Terraform Enterprise ➜](/docs/enterprise/index.html)
-
-Documentation for Terraform Enterprise.
-
-Terraform Enterprise is an on-premise distribution of Terraform Cloud. It offers enterprises a private instance of the Terraform Cloud application, with no resource limits and with additional enterprise-grade architectural features like audit logging and SAML single sign-on.
-
-### [Terraform Registry Publishing ➜](/docs/registry/index.html)
-
-Documentation about publishing Terraform providers and modules on the [Terraform Registry](https://registry.terraform.io/).
-
-### [Plugin Development ➜](/docs/extend/index.html)
-
--> If you need to create a new Terraform provider (for a public cloud service or a purely internal service), go here.
-
-Documentation about developing Terraform providers, with extensive information about Terraform's internals.
-
-Terraform relies on provider plugins to manage infrastructure resources across a wide variety of infrastructure services. Anyone can make and distribute a Terraform provider for their own service.
-
+- [Create a provider](/docs/extend/index.html) to allow Terraform to interact with a service.
+- [Publish your provider](/docs/registry/index.html) to the Terraform Registry to make it publicly available.
 </div>
 
 </div></div>

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -36,7 +36,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 - [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, with version control, state sharing, and more.
 - [Terraform Enterprise](/docs/enterprise/index.html) is a self-hosted instance of Terraform Cloud.
 
-### Develop Plugins
+### Develop Modules and Plugins
 
 - [Create a provider](/docs/extend/index.html) to allow Terraform to interact with a service.
 - [Publish a provider or module](/docs/registry/index.html) to the Terraform Registry to make it publicly available.

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -22,7 +22,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 
 ### Manage Infrastructure
 
-- Describe infrastructure with [Terraform's configuration language](/docs/language/index.html) on various [providers](/docs/language/providers/index.html).
+- Describe infrastructure on various [providers](/docs/language/providers/index.html) with [Terraform's configuration language](/docs/language/index.html).
 - Use the [Terraform CLI](/docs/cli/index.html) to manage configuration, plugins, infrastructure, and state.
 
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -16,7 +16,7 @@ show_notification: false
 ### Get Started
 
 - Learn how Terraform [solves infrastructure challenges](/intro/index.html) and how it [compares to other tools and services](/intro/vs/index.html).
-- [Follow the tutorials on HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) to install Terraform, learn the Terraform workflow, and explore use cases.
+- [Follow hands-on tutorials on HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/aws-get-started) to install Terraform, create infrastructure, and explore use cases.
 
 
 ### Manage Infrastructure

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -23,7 +23,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 ### Manage Infrastructure
 
 - Describe infrastructure with [Terraform's configuration language](/docs/language/index.html) on various [providers](/docs/language/providers/index.html).
-- Use the [Terraform Command Line Interface (CLI)](/docs/cli/index.html) to manage configuration, plugins, infrastructure, and state.
+- Use the [Terraform CLI](/docs/cli/index.html) to manage configuration, plugins, infrastructure, and state.
 
 
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -23,7 +23,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 ### Manage Infrastructure
 
 - Describe infrastructure with [Terraform's configuration language](/docs/language/index.html) on various [providers](/docs/language/providers/index.html).
-- Use the [Terraform CLI](/docs/cli/index.html) with the Terraform binary for command-line workflows.
+- Use the [Terraform Command Line Interface (CLI)](/docs/cli/index.html) to manage configuration, plugins, infrastructure, and state.
 
 
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -3,8 +3,7 @@ layout: 'docs-frontpage'
 page_title: 'Documentation'
 sidebar_current: 'docs-frontpage'
 description: |-
-  A brief map of the documentation for Terraform CLI, Terraform Enterprise, the
-  Terraform GitHub Actions, and the rest of the Terraform ecosystem.
+  Documentation for Terraform, including Terraform CLI, Terraform Cloud, and Terraform Enterprise.
 show_notification: false
 ---
 
@@ -21,7 +20,7 @@ show_notification: false
 
 ### Manage Infrastructure
 
-- Use the [Terraform Configuration Language](/docs/language/index.html) to describe infrastructure.
+- Use [Terraform's configuration language](/docs/language/index.html) to describe infrastructure on various [providers](/docs/language/providers/index.html).
 - Use the [Terraform CLI](/docs/cli/index.html) with the Terraform binary for command-line workflows.
 
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -9,6 +9,8 @@ show_notification: false
 
 # Terraform Documentation
 
+Terraform is an infrastructure as code (IaC) tool that allows you to build, change, and version infrastructure safely and efficiently. This includes both low-level components like compute instances, storage, and networking, as well as high-level components like DNS entries and SaaS features.
+
 <div class="container-fluid"><div class="row">
 <div class="col-md-6 col-sm-12">
 

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -17,7 +17,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 ### Get Started
 
 - Learn how Terraform [solves infrastructure challenges](/intro/index.html) and how it [compares to other tools and services](/intro/vs/index.html).
-- [Follow hands-on tutorials on HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/aws-get-started) to install Terraform, create infrastructure, and explore use cases.
+- Install Terraform and explore use cases with the [hands-on tutorials on HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/aws-get-started).
 
 
 ### Manage Infrastructure
@@ -33,12 +33,13 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 
 ### Collaborate
 
-- [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, with version control, state sharing, and more.
+- [Terraform Cloud](/docs/cloud/index.html) helps teams use Terraform together, with version control, state sharing, [governance](/docs/cloud/sentinel/index.html), and more.
 - [Terraform Enterprise](/docs/enterprise/index.html) is a self-hosted instance of Terraform Cloud.
 
-### Develop Modules and Plugins
+### Develop and Share
 
 - [Create a provider](/docs/extend/index.html) to allow Terraform to interact with a service.
+- Create reusable configurations with [modules](/docs/language/modules/index.html).
 - [Publish a provider or module](/docs/registry/index.html) to the Terraform Registry to make it publicly available.
 </div>
 


### PR DESCRIPTION
**Goals:**
- Make the content more concise and easier to read.
- Help new users understand where they should go next. When you don't know the products or what they're used for, it can be very difficult to build a mental model of how all of the elements in the docs dropdown fit together or how to find the right docs for your use case. The new content tries to align docs content with what users are trying to do (or what they may want to do) with Terraform.
- Reduce the need for scrolling. In the previous version, you had to scroll down to get to some of the descriptions about what elements are or why you'd click them. The goal is to make **the section titles** of this intro material fit above the fold in users' laptop and desktop screens. That way, they're more likely to find what they're looking for.


I can verify that I:
- [x] Built the content locally
- [x] Assigned at least one reviewer
- [x] Added at least one label
- [x] Checked for broken links

Here's what the first draft of this looks like rendered, for context:

<img width="950" alt="Screen Shot 2021-08-12 at 11 03 28 AM" src="https://user-images.githubusercontent.com/83350965/129220510-b7066935-699e-4b2a-b00d-57ba9881b520.png">
