### PR TITLE
Correct gcflags command line flag

### DIFF
--- a/content/source/docs/extend/debugging.html.md
+++ b/content/source/docs/extend/debugging.html.md
@@ -144,7 +144,7 @@ providers. The main differences are:
    to have the debugger work efficiently with the provider binary.
    To do so, build the provider binary with the necessary
    [Go compiler flags (gcflags)](https://golang.org/cmd/compile/):
-   `go build gcflags="all=-N -l"`
+   `go build -gcflags="all=-N -l"`
    
 ### Starting A Provider In Debug Mode
 


### PR DESCRIPTION
Add a missing `-` to the `gcflags` argument

## Labels

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)