### PR TITLE
Update external redirects for community docs

### DIFF
--- a/terraform/external-redirects.csv
+++ b/terraform/external-redirects.csv
@@ -330,3 +330,7 @@ rubrik - to github,/docs/providers/rubrik/r/assign_sla.html,https://github.com/h
 rubrik - to github,/docs/providers/rubrik/r/configure_timezone.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/r/configure_timezone.html.markdown
 rubrik - to github,/docs/providers/rubrik/index.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/index.html.markdown
 rubrik - to github,/docs/providers/rubrik/d/cluster_version.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/d/cluster_version.html.markdown
+community - to github,/docs/extend/community/contributing.html,https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
+community - to github,/docs/extend/community/maintainers.html,https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
+community - to io,/docs/extend/community/index.html,https://www.terraform.io/community
+community - to io,/docs/extend/community/events/2018/fall-gardening.html,https://www.terraform.io/community


### PR DESCRIPTION
Updating external redirects for removed community links due to failed circleci "website-check-incoming-links" 

@alvin-huang  suggested updating the `external-redirects.csv` file with the redirects. 
## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
