### PR TITLE
add community redirects to correct file

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -927,3 +927,10 @@
 #/docs/extend/community/                        https://www.terraform.io/community
 #/docs/extend/community/maintainers.html        https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
 /docs/extend/plugin-types.html                  /docs/extend/index.html
+
+# External redirects for Community docs
+
+#/docs/extend/community/contributing.html                  https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
+#/docs/extend/community/maintainers.html                   https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
+#/docs/extend/community/index.html                         https://www.terraform.io/community
+#/docs/extend/community/events/2018/fall-gardening.html    https://www.terraform.io/community

--- a/terraform/external-redirects.csv
+++ b/terraform/external-redirects.csv
@@ -330,7 +330,3 @@ rubrik - to github,/docs/providers/rubrik/r/assign_sla.html,https://github.com/h
 rubrik - to github,/docs/providers/rubrik/r/configure_timezone.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/r/configure_timezone.html.markdown
 rubrik - to github,/docs/providers/rubrik/index.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/index.html.markdown
 rubrik - to github,/docs/providers/rubrik/d/cluster_version.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/d/cluster_version.html.markdown
-community - to github,/docs/extend/community/contributing.html,https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
-community - to github,/docs/extend/community/maintainers.html,https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
-community - to io,/docs/extend/community/index.html,https://www.terraform.io/community
-community - to io,/docs/extend/community/events/2018/fall-gardening.html,https://www.terraform.io/community


### PR DESCRIPTION
## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)

This PR cleans up the redirects that were added in #1802 to the external redirects CSV that only runs on the `registry/provider-sunset-transition` branch.  While this code was merged into master, there were errors running the TF configuration on the master branch with the error: `Setup failed: Failed to copy slug dir: illegal upload content error: lstat /tmp/terraform-build-worker228294579/slug/ext/terraform/website/docs/providers: no such file or directory` which no longer exists. 

These redirects were all added manually in Fastly and captured in `redirects.txt` for posterity. 

Along with the comments in #1764 and #1604 , it looks like the TF runs on `master` _almost_ works but it's looking for a path that is no longer there. @nfagerlund might have some ideas or https://support.hashicorp.com/hc/en-us/articles/360044709533-Runs-in-Terraform-Cloud-or-Terraform-Enterprise-fail-to-copy-all-configuration-files might help. 