### PR TITLE
Update community redirects

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -919,7 +919,6 @@
 /docs/providers                     /docs/language/providers/index.html
 
 # Clean up Extend section (now Plugin Development)
-# /docs/extend/community/code-of-conduct.html             https://www.hashicorp.com/community-guidelines
 /docs/extend/community/events/index.html                  /community
 /docs/extend/community/events/2018/fall-gardening.html    /community
 /docs/extend/community/index.html                         /community
@@ -929,5 +928,6 @@
 
 # External redirects for Community docs
 
-# /docs/extend/community/contributing.html   https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
-# /docs/extend/community/maintainers.html    https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
+# /docs/extend/community/code-of-conduct.html  https://www.hashicorp.com/community-guidelines
+# /docs/extend/community/contributing.html     https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
+# /docs/extend/community/maintainers.html      https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers

--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -919,18 +919,15 @@
 /docs/providers                     /docs/language/providers/index.html
 
 # Clean up Extend section (now Plugin Development)
-#/docs/extend/community/code-of-conduct.html    https://www.hashicorp.com/community-guidelines
-#/docs/extend/community/contributing.html       https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
-#/docs/extend/community/events/index.html       https://www.terraform.io/community
-#/docs/extend/community/index.html              https://www.terraform.io/community
-#/docs/extend/community                         https://www.terraform.io/community
-#/docs/extend/community/                        https://www.terraform.io/community
-#/docs/extend/community/maintainers.html        https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
-/docs/extend/plugin-types.html                  /docs/extend/index.html
+# /docs/extend/community/code-of-conduct.html             https://www.hashicorp.com/community-guidelines
+/docs/extend/community/events/index.html                  /community
+/docs/extend/community/events/2018/fall-gardening.html    /community
+/docs/extend/community/index.html                         /community
+/docs/extend/community                                    /community
+/docs/extend/community/                                   /community
+/docs/extend/plugin-types.html                            /docs/extend/index.html
 
 # External redirects for Community docs
 
-#/docs/extend/community/contributing.html                  https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
-#/docs/extend/community/maintainers.html                   https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers
-#/docs/extend/community/index.html                         https://www.terraform.io/community
-#/docs/extend/community/events/2018/fall-gardening.html    https://www.terraform.io/community
+# /docs/extend/community/contributing.html   https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
+# /docs/extend/community/maintainers.html    https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers

--- a/terraform/external-redirects.csv
+++ b/terraform/external-redirects.csv
@@ -330,3 +330,6 @@ rubrik - to github,/docs/providers/rubrik/r/assign_sla.html,https://github.com/h
 rubrik - to github,/docs/providers/rubrik/r/configure_timezone.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/r/configure_timezone.html.markdown
 rubrik - to github,/docs/providers/rubrik/index.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/index.html.markdown
 rubrik - to github,/docs/providers/rubrik/d/cluster_version.html,https://github.com/hashicorp/terraform-provider-rubrik/blob/stable-website/website/docs/d/cluster_version.html.markdown
+community - to hashicorp,/docs/extend/community/code-of-conduct.html,https://www.hashicorp.com/community-guidelines
+community - to hashicorp,/docs/extend/community/contributing.html,https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
+community - to hashicorp,/docs/extend/community/maintainers.html,https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#maintainers


### PR DESCRIPTION
This PR adds new external redirects for `/community` pages as well as simplifies some of the internal ones.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
