### PR TITLE
Specify the type of VCS instance that cannot be accessed.

### DIFF
--- a/content/source/docs/cloud/agents/index.html.md
+++ b/content/source/docs/cloud/agents/index.html.md
@@ -52,10 +52,10 @@ Agents should be considered a global resource within an organization. Once confi
 
 ### Limitations
 
-Agents are designed to allow you to run Terraform operations from a Terraform Cloud workspace on your private infrastructure. The following use cases are not supported by agents:
+Agents allow you to run Terraform operations from a Terraform Cloud workspace on your private infrastructure. Agents do not support:
 
-- Connecting to private infrastructure from Sentinel policies using the [http import](https://docs.hashicorp.com/sentinel/imports/http)
-- Connecting Terraform Cloud workspaces to VCS instances that do not allow access from the public internet, for example a GitHub Enterprise Server instance that requires access to your VPN
+- Connecting to private infrastructure from Sentinel policies using the [http import](https://docs.hashicorp.com/sentinel/imports/http).
+- Connecting Terraform Cloud workspaces to VCS instances that do not allow access from the public internet. For example, you cannot use agents to connect to a GitHub Enterprise Server instance that requires access to your VPN.
 
 For these use cases, we recommend you leverage the information provided by the [IP Ranges documentation](https://www.terraform.io/docs/cloud/architectural-details/ip-ranges.html) to permit direct communication from the appropriate Terraform Cloud service to your internal infrastructure.
 

--- a/content/source/docs/cloud/agents/index.html.md
+++ b/content/source/docs/cloud/agents/index.html.md
@@ -55,7 +55,7 @@ Agents should be considered a global resource within an organization. Once confi
 Agents are designed to allow you to run Terraform operations from a Terraform Cloud workspace on your private infrastructure. The following use cases are not supported by agents:
 
 - Connecting to private infrastructure from Sentinel policies using the [http import](https://docs.hashicorp.com/sentinel/imports/http)
-- Connecting Terraform Cloud workspaces to private VCS repositories
+- Connecting Terraform Cloud workspaces to VCS instances that do not allow access from the public internet, for example a GitHub Enterprise Server instance that requires access to your VPN
 
 For these use cases, we recommend you leverage the information provided by the [IP Ranges documentation](https://www.terraform.io/docs/cloud/architectural-details/ip-ranges.html) to permit direct communication from the appropriate Terraform Cloud service to your internal infrastructure.
 


### PR DESCRIPTION
The current wording, that TFC Agents cannot connect to "private VCS repositories" is a bit misleading. This implies that TFC Agents will not work with a private repository on GitHub dot com, which they can (as long as you have properly configured VCS access in TFC).

Where TFC Agents _do not_ work is in attempting to connect to a network isolated private VCS instance. When using TFC Agents in Terraform Cloud, your repository is still cloned from HashiCorp's servers, which, for example, may not have access to VCS systems that require access to your corporate VPN.

This PR attempts to be a bit more clear about the types of VCS setup that Agents do not allow.
