### PR TITLE
Update show a workspace GET endpoint description

### DIFF
--- a/content/source/docs/cloud/api/admin/workspaces.html.md
+++ b/content/source/docs/cloud/api/admin/workspaces.html.md
@@ -144,7 +144,7 @@ curl \
 
 `GET /api/v2/admin/workspaces/:id`
 
-This endpoint lists all workspaces in the Terraform Enterprise installation.
+This endpoint returns the workspace with the specified `workspace_id`.
 
 Status  | Response                                     | Reason
 --------|----------------------------------------------|----------


### PR DESCRIPTION
Fixing an incorrect description for the "Show a Workspace" endpoint, as noted in [this ticket](https://github.com/hashicorp/terraform-website/issues/1357). 
