### PR TITLE
psql - Added other managed services

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -33,7 +33,7 @@ The operational mode is selected at install time and cannot be changed once Terr
    check the [PostgreSQL Requirements](./postgres-requirements.html) for information that
    needs to be present for Terraform Enterprise to work. This option is best
    for users with expertise managing PostgreSQL or users that have access
-   to managed PostgreSQL offerings like [AWS RDS](https://aws.amazon.com/rds/).
+   to managed PostgreSQL offerings like the offers from [Amazon](https://aws.amazon.com/rds/), [Azure](https://azure.microsoft.com/en-us/services/postgresql/), or [Google Cloud](https://cloud.google.com/sql/docs/postgres/).
 
 1. *Mounted Disk* - This mode stores data in a separate
    directory on the host, with the intention that the directory is


### PR DESCRIPTION
For Managed PostgreSQL, there were only references to the AWS offering. Changed this to reflect services across the three major clouds, which should be the minimum for any vendor neutral documentation.

I see that there are more things related only to Amazon on this page. I will go through more documentation and see what I can do to help from an Azure perspective here, when time permits.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [X] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
