### PR TITLE
Update Using Private Modules page

### DIFF
--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -118,9 +118,9 @@ To configure authentication to Terraform Cloud or your Terraform Enterprise inst
 - (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save a user API token.
 - Create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
-Make sure the hostname matches the hostname you use in module sources because if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying a different hostname each time.
+Make sure the hostname matches the hostname you use in module sources because if the same Terraform Cloud server is available at two hostnames, Terraform will not know that they are the same. To support multiple hostnames for module sources, use the `terraform login` command multiple times, and specify a different hostname each time.
 
--> **Note** When SAML SSO is enabled, there is a session timeout for user API tokens, and you must periodically re-authenticate through the web UI to keep your token active. See  [API Token Expiration] (/docs/enterprise/saml/login.html#api-token-expiration) for more details.
+-> **Note** When SAML SSO is enabled, there is a [session timeout for user API tokens] (/docs/enterprise/saml/login.html#api-token-expiration), requiring you to periodically re-authenticate through the web UI. Expired tokens produce a _401 Unauthorized_ error.
 
 
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -20,7 +20,7 @@ By design, Terraform Cloud's private module registry works much like the [public
     ```
 - Terraform Cloud can automatically access your private modules during Terraform runs. However, when running Terraform on the command line, you must configure a `credentials` block in your [CLI configuration file (`.terraformrc`)](/docs/cli/config/config-file.html). See below for the [credentials format](#on-the-command-line).
 
-## Finding Modules
+## Finding Private Modules
 
 All users in your organization can view your private module registry.
 
@@ -38,7 +38,7 @@ You can browse the complete list, or shrink the list by searching or filtering.
 - The search field searches by keyword. This only searches the titles of modules, not READMEs or resource details.
 
 
-### Shared Modules in Terraform Enterprise
+### Shared Modules - Terraform Enterprise
 
 On Terraform Enterprise, you may have access to modules outside your organization depending on how your site admin has configured [module sharing](/docs/enterprise/admin/module-sharing.html). Modules that are shared with the current organization will have a "Shared"
 badge.
@@ -71,9 +71,12 @@ Use the "Examples" dropdown to navigate to example modules and use the  Readme/I
 
 ![Terraform Cloud screenshot: a module submodules detail page](./images/using-module-examples.png)
 
-## Using Private Modules in Terraform Configurations
+## Using Private Modules
 
-In Terraform configurations, you can use any private module from your organization's registry. The syntax for referencing private modules in `source` attributes is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
+The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` attribute is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
+
+- **Hostname:** For the SaaS version of Terraform Cloud, use `app.terraform.io`. In Terraform Enterprise, use the hostname for your instance or the [generic hostname](/docs/cloud/registry/using.html#generic-hostname-terraform-enterprise).
+- **Organization:** If you are using a shared module with Terraform Enterprise, the module's organization name may be different than your organization's name. The source string on the module's registry page will always include the proper organization name.
 
 ```hcl
 module "vpc" {
@@ -82,21 +85,11 @@ module "vpc" {
 }
 ```
 
-If you're using the SaaS version of Terraform Cloud, the hostname is `app.terraform.io`; Terraform Enterprise instances have their own hostnames. The second part of the source string (the namespace) is the name of your organization. If you are using a shared module with Terraform Enterprise, be sure to use the module's organization name in the module source, which may be different than your organization's name. The source string shown on a module's registry page will always include the proper organization name.
+To get started, you can copy and paste the usage example on the module's registry page, or use the [configuration designer](./design.html) to select multiple modules and fill in their variables.
 
-For more details on using modules in Terraform configurations, see ["Configuration Language: Modules"](/docs/configuration/modules.html) in the Terraform docs.
+### Generic Hostname - Terraform Enterprise
 
-### Usage Examples and the Configuration Designer
-
-Each registry page for a module version includes a usage example, which you can copy and paste to get started.
-
-Alternately, you can use the configuration designer, which lets you select multiple modules and fill in their variables to build a much more useful initial configuration. See [the configuration designer docs](./design.html) for details.
-
-### The Generic Module Hostname (`localterraform.com`)
-
-Optionally, you can use the generic hostname `localterraform.com` in module sources instead of the literal hostname of a Terraform Enterprise instance. When Terraform is executed on a Terraform Enterprise instance, it automatically requests any `localterraform.com` modules from that instance.
-
-For example:
+You can use the generic hostname `localterraform.com` in module sources instead of the literal Terraform Enterprise hostname to reference modules without modifying the Terraform Enterprise instance. When Terraform is executed on a Terraform Enterprise instance, it automatically requests any `localterraform.com` modules from that instance.
 
 ```hcl
 module "vpc" {
@@ -105,9 +98,17 @@ module "vpc" {
 }
 ```
 
-Configurations that reference modules via the generic hostname can be used without modification on any Terraform Enterprise instance, which is not possible when using hardcoded hostnames.
+~> **Important:** The generic hostname only works within a Terraform Enterprise instance.
 
-~> **Important:** `localterraform.com` only works within a Terraform Enterprise instance — when run outside of Terraform Enterprise, Terraform can only use private modules with a literal hostname. To test configurations on a developer workstation without the remote backend configured, you must replace the generic hostname with a literal hostname in any module sources, then change them back before committing to VCS. We are working on ways to make this smoother in the future; in the meantime, we only recommend `localterraform.com` for large organizations that use multiple Terraform Enterprise instances.
+To test configurations on a developer workstation without the remote backend configured, you must replace the generic hostname with a literal hostname in any module sources, then change them back before committing to VCS. We are working on making smoother in the future, but we currently only recommend `localterraform.com` for large organizations that use multiple Terraform Enterprise instances.
+
+### Module Availability
+
+A workspace can only use private modules from its own organization's registry. To use modules from multiple organizations in the same configuration, we recommend:
+
+- **Terraform Cloud:** [Adding modules to the registry](./publish.html#sharing-modules-across-organizations) for each organization that requires access.  Users with the right permissions (see below) may be able to run configurations with modules from multiple organizations, but this can make collaboration more difficult.
+
+- **Terraform Enterprise:** Checking your site's [module sharing](../../enterprise/admin/module-sharing.html) configuration to make sure it allows mixing modules from multiple organizations into the same configuration. Note that in Terraform Enterprise v202012-1 or higher, workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
 
 ## Running Configurations with Private Modules
 
@@ -116,30 +117,26 @@ Configurations that reference modules via the generic hostname can be used witho
 Terraform 0.11 or higher is required to:
 
 - Use the CLI to apply configurations with private modules.
-- Include private modules in a Terraform Cloud configuration with no extra configuration.
-
-TBD what do they do if they have a version before this?
-
-### Module Availability
-
-In Terraform Cloud, a workspace can only use private modules from its own organization. Mixing modules from different organizations might work on the CLI with your user token, but it will make your configuration difficult or impossible to collaborate with. To make the module available to multiple organizations, you should [add it to each organization's registry](./publish.html#sharing-modules-across-organizations).
-
- On Terraform Enterprise, it is possible to mix modules from different organizations according to your site's [module sharing](../../enterprise/admin/module-sharing.html) configuration. In Terraform Enterprise v202012-1 or higher, workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
+- Run Terraform Cloud configurations that include private modules with no extra setup. TBD what do they do if they have a version before this?
 
 ### Authentication
 
-You need to authenticate against Terraform Cloud or your Terraform Enterprise instance to configure private module access. If you're using Terraform 0.12.21 or later with the CLI, you can use the `terraform login` command. Alternatively, you can create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
+To configure authentication to Terraform Cloud or your Terraform Enterprise instance, you can:
+
+- (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save an API token.
+- Create an [API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
 Make sure the hostname matches the hostname you use in module sources — if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying the hostname each time.
 
-#### Permissions
+#### Token Permissions
 
-You can use either a user or a team token to access private modules.
+You can use either a user token or a team token to access private modules.
 
-- **User Token**: Allows you to access modules from any organization in which you are a member. A user is a member of an organization if they belong to any team in that organization. If you are using Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any organization in which you are a member.
-- **Team Token**:
+- [**User Token**](/docs/cloud/users-teams-organizations/users.html#api-tokens): Allows you to access modules from any organization in which you are a member. A user is a member of an organization if they belong to any team in that organization. If you are using Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any organization in which you are a member.
+- [**Team Token**](/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens): Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
 
-ADD AN EXAMPLE
+For example: A user belongs to three organizations called A, B, and C. Organizations A and B share private module access with each other. The user's token gives them acces to the private module registries for all of the organizations they belong to: A, B, and C. But team token from a team in organization A would only give them access the private modules in organizations A and B.
+
 
 [user-token]: ../users-teams-organizations/users.html#api-tokens
 [cli-credentials]: /docs/cli/config/config-file.html#credentials

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -113,30 +113,28 @@ Terraform 0.11 or later is required to:
 
 ### Authentication
 
-To configure authentication to Terraform Cloud or your Terraform Enterprise instance, you can:
-
-- (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save a user API token.
-- Create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
-
-Make sure the hostname matches the hostname you use in module sources because if the same Terraform Cloud server is available at two hostnames, Terraform will not know that they are the same. To support multiple hostnames for module sources, use the `terraform login` command multiple times, and specify a different hostname each time.
-
-
-
-
-#### Permissions
-
 You can use either a [user token](/docs/cloud/users-teams-organizations/users.html#api-tokens) or a [team token](/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens) for authentication, but the type of token you choose may grant different permissions.
 
 - **User Token**: Allows you to access modules from any organization in which you are a member. You are a member of an organization if you belong to any team in that organization. In Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any of your organizations.
 
--> **Note** When SAML SSO is enabled, there is a [session timeout for user API tokens] (/docs/enterprise/saml/login.html#api-token-expiration), requiring you to periodically re-authenticate through the web UI. Expired tokens produce a _401 Unauthorized_ error. A SAML SSO account with [IsServiceAccount](https://www.terraform.io/docs/enterprise/saml/attributes.html#isserviceaccount) is treated as a service account and will not have the session timeout.
+    -> **Note** When SAML SSO is enabled, there is a [session timeout for user API tokens] (/docs/enterprise/saml/login.html#api-token-expiration), requiring you to periodically re-authenticate through the web UI. Expired tokens produce a _401 Unauthorized_ error. A SAML SSO account with [IsServiceAccount](https://www.terraform.io/docs/enterprise/saml/attributes.html#isserviceaccount) is treated as a service account and will not have the session timeout.
 
 - **Team Token**: Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
 
-
+<br>
 _Permissions Example_
 
 A user belongs to three organizations (1, 2, and 3), and organizations 1 and 2 share private module access with each other. In this case, the user's token gives them access to the private module registries for all of the organizations they belong to: 1, 2, and 3. However, a team token from a team in organization 1 only gives the user access the private modules in organizations 1 and 2.
+
+#### Configure Authentication
+
+To configure authentication to Terraform Cloud or your Terraform Enterprise instance, you can:
+
+- (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save a user API token.
+- Create a token and [manually configure credentials in the CLI config file][cli-credentials].
+
+Make sure the hostname matches the hostname you use in module sources because if the same Terraform Cloud server is available at two hostnames, Terraform will not know that they are the same. To support multiple hostnames for module sources, use the `terraform login` command multiple times, and specify a different hostname each time.
+
 
 
 [user-token]: ../users-teams-organizations/users.html#api-tokens

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -129,6 +129,8 @@ You can use either a [user token](/docs/cloud/users-teams-organizations/users.ht
 
 - **User Token**: Allows you to access modules from any organization in which you are a member. You are a member of an organization if you belong to any team in that organization. In Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any of your organizations.
 
+-> **Note** When SAML SSO is enabled, there is a [session timeout for user API tokens] (/docs/enterprise/saml/login.html#api-token-expiration), requiring you to periodically re-authenticate through the web UI. Expired tokens produce a _401 Unauthorized_ error. A SAML SSO account with [IsServiceAccount](https://www.terraform.io/docs/enterprise/saml/attributes.html#isserviceaccount) is treated as a service account and will not have the session timeout.
+
 - **Team Token**: Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
 
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -11,7 +11,7 @@ page_title: "Using Private Modules - Private Module Registry - Terraform Cloud a
 A Terraform Cloud private module registry has a few key differences from the [public Terraform Registry](/docs/registry/index.html):
 
 - **Location:** You must use Terraform Cloud's web UI to search for modules and usage examples.
-- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-private-modules-in-configurations).
+- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-private-modules-in-configurations): `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
 - **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [authenticate](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance.
 
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -111,29 +111,36 @@ Configurations that reference modules via the generic hostname can be used witho
 
 ## Running Configurations with Private Modules
 
-### In Terraform Cloud
+### Version Requirements
 
-Terraform Cloud can use your private modules during plans and applies with no extra configuration, _as long as the workspace is configured to use Terraform 0.11 or higher._
+Terraform 0.11 or higher is required to:
 
-A given Terraform Cloud workspace can only use private modules from the organization it belongs to. If you want to use the same module in multiple organizations, you should add it to both organizations' registries. (See [Sharing Modules Across Organizations](./publish.html#sharing-modules-across-organizations).) If you are using Terraform Enterprise v202012-1 or later, workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
+- Use the CLI to apply configurations with private modules.
+- Include private modules in a Terraform Cloud configuration with no extra configuration.
 
-### On the Command Line
+TBD what do they do if they have a version before this?
 
-If you're using Terraform 0.11 or higher, you can use private modules when applying configurations on the CLI. To do this, you must provide a valid [Terraform Cloud API token](../users-teams-organizations/users.html#api-tokens).
+### Module Availability
 
-#### Permissions
+In Terraform Cloud, a workspace can only use private modules from its own organization. Mixing modules from different organizations might work on the CLI with your user token, but it will make your configuration difficult or impossible to collaborate with. To make the module available to multiple organizations, you should [add it to each organization's registry](./publish.html#sharing-modules-across-organizations).
 
-When you authenticate with a user token, you can access modules from any organization you are a member of. (A user is a member of an organization if they belong to any team in that organization.) If you are using Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any organization you are a member of.
+ On Terraform Enterprise, it is possible to mix modules from different organizations according to your site's [module sharing](../../enterprise/admin/module-sharing.html) configuration. In Terraform Enterprise v202012-1 or higher, workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
 
-[permissions-citation]: #intentionally-unused---keep-for-maintainers
+### Authentication
 
-Within a given Terraform configuration, you should only use modules from one organization. Mixing modules from different organizations might work on the CLI with your user token, but it will make your configuration difficult or impossible to collaborate with. If you want to use the same module in multiple Terraform Cloud organizations, you should add it to both organizations' registries. (See [Sharing Modules Across Organizations](./publish.html#sharing-modules-across-organizations).) On Terraform Enterprise, it is possible to mix modules from different organizations according to your site's [module sharing](../../enterprise/admin/module-sharing.html) configuration.
-
-#### Configuration
-
-To configure private module access, you need to authenticate against Terraform Cloud (or your Terraform Enterprise instance).  If you're using Terraform 0.12.21 or later, you can use the `terraform login` command. Alternatively, you can create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
+You need to authenticate against Terraform Cloud or your Terraform Enterprise instance to configure private module access. If you're using Terraform 0.12.21 or later with the CLI, you can use the `terraform login` command. Alternatively, you can create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
 Make sure the hostname matches the hostname you use in module sources — if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying the hostname each time.
 
+#### Permissions
+
+You can use either a user or a team token to access private modules.
+
+- **User Token**: Allows you to access modules from any organization in which you are a member. A user is a member of an organization if they belong to any team in that organization. If you are using Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any organization in which you are a member.
+- **Team Token**:
+
+ADD AN EXAMPLE
+
 [user-token]: ../users-teams-organizations/users.html#api-tokens
 [cli-credentials]: /docs/cli/config/config-file.html#credentials
+[permissions-citation]: #intentionally-unused---keep-for-maintainers

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -11,7 +11,7 @@ page_title: "Using Private Modules - Private Module Registry - Terraform Cloud a
 A Terraform Cloud private module registry has a few key differences from the [public Terraform Registry](/docs/registry/index.html):
 
 - **Location:** You must use Terraform Cloud's web UI to search for modules and usage examples.
-- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#adding-private-modules-to-configurations).
+- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-private-modules-in-configurations).
 - **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [configure authentication](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance
 
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -12,7 +12,7 @@ A Terraform Cloud private module registry has a few key differences from the [pu
 
 - **Location:** You must use Terraform Cloud's web UI to search for modules and usage examples.
 - **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-private-modules-in-configurations).
-- **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [configure authentication](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance.
+- **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [authenticate](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance.
 
 
 ## Finding Private Modules

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -120,7 +120,6 @@ To configure authentication to Terraform Cloud or your Terraform Enterprise inst
 
 Make sure the hostname matches the hostname you use in module sources because if the same Terraform Cloud server is available at two hostnames, Terraform will not know that they are the same. To support multiple hostnames for module sources, use the `terraform login` command multiple times, and specify a different hostname each time.
 
--> **Note** When SAML SSO is enabled, there is a [session timeout for user API tokens] (/docs/enterprise/saml/login.html#api-token-expiration), requiring you to periodically re-authenticate through the web UI. Expired tokens produce a _401 Unauthorized_ error.
 
 
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -71,7 +71,7 @@ Use the "Examples" dropdown to navigate to example modules and use the  Readme/I
 
 ![Terraform Cloud screenshot: a module submodules detail page](./images/using-module-examples.png)
 
-## Using Private Modules
+## Adding Private Modules to Configurations
 
 The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` attribute is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
 
@@ -123,19 +123,26 @@ Terraform 0.11 or higher is required to:
 
 To configure authentication to Terraform Cloud or your Terraform Enterprise instance, you can:
 
-- (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save an API token.
-- Create an [API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
+- (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save a user API token.
+- Create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
 Make sure the hostname matches the hostname you use in module sources — if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying the hostname each time.
 
-#### Token Permissions
+-> **Note** When SAML SSO is enabled, there is a session timeout for user API tokens, and you must periodically re-authenticate through the web UI to keep your token active. See  [API Token Expiration] (/docs/enterprise/saml/login.html#api-token-expiration) for more details.
 
-You can use either a user token or a team token to access private modules.
 
-- [**User Token**](/docs/cloud/users-teams-organizations/users.html#api-tokens): Allows you to access modules from any organization in which you are a member. A user is a member of an organization if they belong to any team in that organization. If you are using Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any organization in which you are a member.
-- [**Team Token**](/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens): Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
 
-For example: A user belongs to three organizations called A, B, and C. Organizations A and B share private module access with each other. The user's token gives them acces to the private module registries for all of the organizations they belong to: A, B, and C. But team token from a team in organization A would only give them access the private modules in organizations A and B.
+#### Permissions
+
+You can use either a [user token](/docs/cloud/users-teams-organizations/users.html#api-tokens) or a [team token](/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens) for authentication, but the type of token you choose may grant you different permissions.
+
+- **User Token**: Allows you to access modules from any organization in which you are a member. You are a member of an organization if you belong to any team in that organization. For Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any of your organizations.
+- **Team Token**: Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
+
+
+_Permissions Example_
+
+A user belongs to three organizations called A, B, and C. Organizations A and B share private module access with each other. The user's token gives them access to the private module registries for all of the organizations they belong to: A, B, and C. But team token from a team in organization A would only give them access the private modules in organizations A and B.
 
 
 [user-token]: ../users-teams-organizations/users.html#api-tokens

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -23,8 +23,8 @@ All users in your organization can view your private module registry. To find av
 
 The module page appears, containing a list of all available modules. You can filter with the:
 
-- **"Providers" dropdown**: Shows only modules for the selected provider.
 - **Search field**: Shows modules with titles that contain the specified keyword. Note that it does not search READMEs or resource details.
+- **"Providers" dropdown**: Shows only modules for the selected provider.
 
 ![Terraform Cloud screenshot: the list of available modules](./images/using-modules-list.png)
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -12,7 +12,7 @@ A Terraform Cloud private module registry has a few key differences from the [pu
 
 - **Location:** You must use Terraform Cloud's web UI to search for modules and usage examples.
 - **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-private-modules-in-configurations).
-- **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [configure authentication](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance
+- **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [configure authentication](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance.
 
 
 ## Finding Private Modules
@@ -33,11 +33,11 @@ The module page appears, containing a list of all available modules. You can fil
 
 ### Shared Modules - Terraform Enterprise
 
-On Terraform Enterprise, you may have access to modules outside your organization depending on how your site admin has configured [module sharing](/docs/enterprise/admin/module-sharing.html). Modules that are shared with the current organization have a "Shared" badge.
+On Terraform Enterprise, your [module sharing](/docs/enterprise/admin/module-sharing.html) configuration may grant you access to modules outside your organization. Modules that are shared with your current organization have a "Shared" badge.
 
 ![Terraform Enterprise screenshot: shared module](./images/using-modules-list-shared.png)
 
-Modules in the current organization that are shared with other organizations have a badge that says "Sharing".
+Modules in your current organization that are shared with other organizations have a badge that says "Sharing".
 
 ![Terraform Enterprise screenshot: sharing module](./images/using-modules-list-sharing.png)
 
@@ -49,7 +49,7 @@ Click a module's "Details" button to view its details page. Use the "Versions" d
 
 ### Viewing Nested Modules and Examples
 
-If a module contains nested modules following the [standard module structure](/docs/language/modules/develop/structure.html), then a "Submodules" dropdown will appear below the module source information. The "Examples" dropdown will appear if there are examples.
+If a module contains nested modules following the [standard module structure](/docs/language/modules/develop/structure.html), then a "Submodules" dropdown appears below the module source information. An "Examples" dropdown also appears if there are examples.
 
 ![Terraform Cloud screenshot: a module submodules button](./images/using-submodules-dropdown.png)
 
@@ -77,7 +77,7 @@ module "vpc" {
 }
 ```
 
-To get started, you can copy and paste the usage example on the module's registry page, or use the [configuration designer](./design.html) to select multiple modules and fill in their variables.
+To get started, you can copy and paste the usage example on the module's registry page or use the [configuration designer](./design.html) to select multiple modules and fill in their variables.
 
 ### Generic Hostname - Terraform Enterprise
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -6,46 +6,38 @@ page_title: "Using Private Modules - Private Module Registry - Terraform Cloud a
 # Using Modules from the Terraform Cloud Private Module Registry
 
 > **Hands-on:** Try the [Use Modules from the Registry](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+<br>
 
-By design, Terraform Cloud's private module registry works much like the [public Terraform Registry](/docs/registry/index.html). If you're already familiar with the public registry, here are the main differences:
+A Terraform Cloud private module registry has a few key differences from the [public Terraform Registry](/docs/registry/index.html):
 
-- Use Terraform Cloud's web UI to browse and search for modules.
-- Module `source` strings are slightly different. The public registry uses a three-part `<NAMESPACE>/<MODULE NAME>/<PROVIDER>` format, and private modules use a four-part `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>` format. For example, to load a module from the `example_corp` organization on the SaaS version of Terraform Cloud:
+- **Location:** You must use Terraform Cloud's web UI to search for modules and usage examples.
+- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#adding-private-modules-to-configurations).
+- **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [configure authentication](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform enterprise instance
 
-    ```hcl
-    module "vpc" {
-      source  = "app.terraform.io/example_corp/vpc/aws"
-      version = "1.0.4"
-    }
-    ```
-- Terraform Cloud can automatically access your private modules during Terraform runs. However, when running Terraform on the command line, you must configure a `credentials` block in your [CLI configuration file (`.terraformrc`)](/docs/cli/config/config-file.html). See below for the [credentials format](#on-the-command-line).
 
 ## Finding Private Modules
 
-All users in your organization can view your private module registry.
-
-To see which modules are available, click the "Modules" button in Terraform Cloud's main navigation bar.
+All users in your organization can view your private module registry. To find available modules, click the "Modules" button in the Terraform Cloud main navigation bar.
 
 ![Terraform Cloud screenshot: Navigation bar with modules button highlighted](./images/using-modules-button.png)
 
-This brings you to the modules page, which lists all available modules.
+The module page appears, containing a list of all available modules. You can filter with the:
+
+- **"Providers" dropdown**: Shows only modules for the selected provider.
+- **Search field**: Shows modules with titles that contain the specified keyword. Note that it does not search READMEs or resource details.
 
 ![Terraform Cloud screenshot: the list of available modules](./images/using-modules-list.png)
 
-You can browse the complete list, or shrink the list by searching or filtering.
 
-- The "Providers" drop-down filters the list to show only modules for the selected provider.
-- The search field searches by keyword. This only searches the titles of modules, not READMEs or resource details.
 
 
 ### Shared Modules - Terraform Enterprise
 
-On Terraform Enterprise, you may have access to modules outside your organization depending on how your site admin has configured [module sharing](/docs/enterprise/admin/module-sharing.html). Modules that are shared with the current organization will have a "Shared"
-badge.
+On Terraform Enterprise, you may have access to modules outside your organization depending on how your site admin has configured [module sharing](/docs/enterprise/admin/module-sharing.html). Modules that are shared with the current organization have a "Shared" badge.
 
 ![Terraform Enterprise screenshot: shared module](./images/using-modules-list-shared.png)
 
-If the current organization's modules are being shared with other organizations, they will have a badge on them that says "Sharing".
+Modules in the current organization that are shared with other organizations have a badge that says "Sharing".
 
 ![Terraform Enterprise screenshot: sharing module](./images/using-modules-list-sharing.png)
 
@@ -73,10 +65,10 @@ Use the "Examples" dropdown to navigate to example modules and use the  Readme/I
 
 ## Adding Private Modules to Configurations
 
-The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` attribute is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
+The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` argument is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
 
 - **Hostname:** For the SaaS version of Terraform Cloud, use `app.terraform.io`. In Terraform Enterprise, use the hostname for your instance or the [generic hostname](/docs/cloud/registry/using.html#generic-hostname-terraform-enterprise).
-- **Organization:** If you are using a shared module with Terraform Enterprise, the module's organization name may be different than your organization's name. The source string on the module's registry page will always include the proper organization name.
+- **Organization:** If you are using a shared module with Terraform Enterprise, the module's organization name may be different than your organization's name. Check the source string at the top of the module's registry page to find the proper organization name.
 
 ```hcl
 module "vpc" {
@@ -89,7 +81,7 @@ To get started, you can copy and paste the usage example on the module's registr
 
 ### Generic Hostname - Terraform Enterprise
 
-You can use the generic hostname `localterraform.com` in module sources instead of the literal Terraform Enterprise hostname to reference modules without modifying the Terraform Enterprise instance. When Terraform is executed on a Terraform Enterprise instance, it automatically requests any `localterraform.com` modules from that instance.
+You can use the generic hostname `localterraform.com` in module sources to reference modules without modifying the Terraform Enterprise instance. When you run Terraform, it automatically requests any `localterraform.com` modules from the Terraform Enterprise instance.
 
 ```hcl
 module "vpc" {
@@ -100,24 +92,24 @@ module "vpc" {
 
 ~> **Important:** The generic hostname only works within a Terraform Enterprise instance.
 
-To test configurations on a developer workstation without the remote backend configured, you must replace the generic hostname with a literal hostname in any module sources, then change them back before committing to VCS. We are working on making smoother in the future, but we currently only recommend `localterraform.com` for large organizations that use multiple Terraform Enterprise instances.
+To test configurations on a developer workstation without the remote backend configured, you must replace the generic hostname with a literal hostname in all module sources and then change them back before committing to VCS. We are working on making this workflow smoother, but we currently only recommend `localterraform.com` for large organizations that use multiple Terraform Enterprise instances.
 
 ### Module Availability
 
-A workspace can only use private modules from its own organization's registry. To use modules from multiple organizations in the same configuration, we recommend:
+A workspace can only use private modules from its own organization's registry. When using modules from multiple organizations in the same configuration, we recommend:
 
-- **Terraform Cloud:** [Adding modules to the registry](./publish.html#sharing-modules-across-organizations) for each organization that requires access.  Users with the right permissions (see below) may be able to run configurations with modules from multiple organizations, but this can make collaboration more difficult.
+- **Terraform Cloud:** [Add modules to the registry](./publish.html#sharing-modules-across-organizations) for each organization that requires access.  
 
-- **Terraform Enterprise:** Checking your site's [module sharing](../../enterprise/admin/module-sharing.html) configuration to make sure it allows mixing modules from multiple organizations into the same configuration. Note that in Terraform Enterprise v202012-1 or higher, workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
+- **Terraform Enterprise:** Check your site's [module sharing](../../enterprise/admin/module-sharing.html) configuration. Note that in Terraform Enterprise v202012-1 or higher, workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
 
 ## Running Configurations with Private Modules
 
 ### Version Requirements
 
-Terraform 0.11 or higher is required to:
+Terraform 0.11 or later is required to:
 
+- Use private modules in Terraform Cloud workspaces with no extra setup.
 - Use the CLI to apply configurations with private modules.
-- Run Terraform Cloud configurations that include private modules with no extra setup. TBD what do they do if they have a version before this?
 
 ### Authentication
 
@@ -126,7 +118,7 @@ To configure authentication to Terraform Cloud or your Terraform Enterprise inst
 - (Terraform 0.12.21 or later) Use the [`terraform login`](/docs/cli/commands/login.html) command to obtain and save a user API token.
 - Create a [user API token][user-token] and [manually configure credentials in the CLI config file][cli-credentials].
 
-Make sure the hostname matches the hostname you use in module sources — if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying the hostname each time.
+Make sure the hostname matches the hostname you use in module sources because if the same Terraform Cloud server is available at two hostnames, Terraform doesn't have any way to know that they're the same. If you need to support multiple hostnames for module sources, use the `terraform login` command multiple times, specifying a different hostname each time.
 
 -> **Note** When SAML SSO is enabled, there is a session timeout for user API tokens, and you must periodically re-authenticate through the web UI to keep your token active. See  [API Token Expiration] (/docs/enterprise/saml/login.html#api-token-expiration) for more details.
 
@@ -134,15 +126,16 @@ Make sure the hostname matches the hostname you use in module sources — if th
 
 #### Permissions
 
-You can use either a [user token](/docs/cloud/users-teams-organizations/users.html#api-tokens) or a [team token](/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens) for authentication, but the type of token you choose may grant you different permissions.
+You can use either a [user token](/docs/cloud/users-teams-organizations/users.html#api-tokens) or a [team token](/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens) for authentication, but the type of token you choose may grant different permissions.
 
-- **User Token**: Allows you to access modules from any organization in which you are a member. You are a member of an organization if you belong to any team in that organization. For Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any of your organizations.
+- **User Token**: Allows you to access modules from any organization in which you are a member. You are a member of an organization if you belong to any team in that organization. In Terraform Enterprise v202012-1 or higher, you can also access modules from any organization that is sharing modules with any of your organizations.
+
 - **Team Token**: Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
 
 
 _Permissions Example_
 
-A user belongs to three organizations called A, B, and C. Organizations A and B share private module access with each other. The user's token gives them access to the private module registries for all of the organizations they belong to: A, B, and C. But team token from a team in organization A would only give them access the private modules in organizations A and B.
+A user belongs to three organizations (1, 2, and 3), and organizations 1 and 2 share private module access with each other. In this case, the user's token gives them access to the private module registries for all of the organizations they belong to: 1, 2, and 3. However, a team token from a team in organization 1 only gives the user access the private modules in organizations 1 and 2.
 
 
 [user-token]: ../users-teams-organizations/users.html#api-tokens

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -121,7 +121,7 @@ You can use either a [user token](/docs/cloud/users-teams-organizations/users.ht
 
 - **Team Token**: Allows you to access the private module registry from that team's organization and modules from any organizations that are sharing a private module registry with that team's organization.
 
-<br>
+<br/>
 _Permissions Example_
 
 A user belongs to three organizations (1, 2, and 3), and organizations 1 and 2 share private module access with each other. In this case, the user's token gives them access to the private module registries for all of the organizations they belong to: 1, 2, and 3. However, a team token from a team in organization 1 only gives the user access the private modules in organizations 1 and 2.

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -63,7 +63,7 @@ Use the "Examples" dropdown to navigate to example modules and use the  Readme/I
 
 ![Terraform Cloud screenshot: a module submodules detail page](./images/using-module-examples.png)
 
-## Adding Private Modules to Configurations
+## Using Private Modules in Configurations
 
 The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` argument is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
 


### PR DESCRIPTION
This PR focuses on revamping the Using Private Modules page in the Terraform Cloud documentation. It addresses a ticket that identified the following issues:

- The "On the Command Line" section applies to anywhere that the user has to set the Terraform binary token (CI, etc), not just users running Terraform locally on the command line. We might want to change the header to something like "Terraform binary" or "Set your own token"? 
- The permissions section is also slightly unclear. It's trying to address the unexpected access that you might get to PMRs from different orgs when you use a user token instead of a team token, but readers are expecting more information about all token types.
- The authentication section doesn't warn users about the SAML user token timeout, so they might get a 401 Unauthorized error because their token is expired and not know why.

These changes:

- Reorder the information in both the Using Private Modules and Running Configurations with Private Modules sections to help the information flow more clearly and make it easier for users to identify what information is relevant to Terraform Cloud vs. Terraform Enterprise
- Creates clearer section titles that will help users understand what each section is about and when it applies to them.
- Revises text throughout the page for concision and active voice. 
- Add text in the token permissions section to acknowledge that users could use both a user or a team token for authentication and explain the differences in permissions granted by each type. This includes an example.
- Adds a note to warn users about the SAML user token timeout. 

I have:

- [x] Tested these changes locally
- [x] Added at least one descriptive label
- [x] Added at least one reviewer