### PR TITLE
Update API Show Workspace sample response

### DIFF
--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -1802,38 +1802,110 @@ $ curl \
 {
   "data": {
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-02T23:24:05.997Z",
-      "description": null,
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T19:44:45.241Z",
+      "description": "Example workspace for documentation.",
       "environment": "default",
-      "file-triggers-enabled": true,
+      "execution-mode": "agent",
+      "file-triggers-enabled": false,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T19:44:45.241Z",
       "locked": false,
-      "name": "workspace-2",
+      "name": "workspace-1",
+      "operations": true,
+      "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
+        "can-update": true,
+        "can-update-variable": true
+      },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
-      "resource-count": 5,
+      "resource-count": 0,
+      "run-failures": null,
       "source": "tfe-ui",
       "source-name": null,
       "source-url": null,
-      "tag-names": [],
-      "terraform-version": "0.10.8",
+      "speculative-enabled": false,
+      "structured-run-output-enabled": true,
+      "tag-names": [
+        "tag1",
+        "tag2"
+      ],
+      "terraform-version": "1.0.4",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T23:06:08.609Z",
       "vcs-repo": {
         "branch": "",
-        "ingress-submodules": false
+        "display-identifier": "my-organization/my-workspace",
+        "identifier": "my-organization/my-workspace",
+        "ingress-submodules": false,
+        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "repository-http-url": "https://github.com/my-organization/my-workspace",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
+      "vcs-repo-identifier": "my-organization/my-workspace",
       "working-directory": "",
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "workspace-kpis-runs-count": null
     },
-    "id": "ws-erEAnPmgtm5mJr77",
+    "id": "ws-FFP9JcN4m6czSRBj",
     "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
     },
     "relationships": {
-      "latest-run": {
+      "agent-pool": {
+        "data": {
+          "id": "apool-QxGd2tRjympfMvQc",
+          "type": "agent-pools"
+        }
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-EpThx8RZdxt8a2mK",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-EpThx8RZdxt8a2mK"
+        }
+      },
+      "current-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "current-state-version": {
         "data": null
+      },
+      "latest-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
       },
       "organization": {
         "data": {
@@ -1841,13 +1913,25 @@ $ curl \
           "type": "organizations"
         }
       },
-      "ssh-key": {
-        "data": null
+      "outputs": {
+        "data": []
+      },
+      "readme": {
+        "data": {
+          "id": "227247",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers"
+        }
       }
     },
     "type": "workspaces"
   }
 }
+
 ```
 
 ## Get Remote State Consumers

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -174,59 +174,101 @@ _Without a VCS repository_
 ```json
 {
   "data": {
-    "id": "ws-YnyXLq9fy38afEeb",
-    "type": "workspaces",
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-18T00:43:59.384Z",
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T21:22:49.566Z",
+      "description": null,
       "environment": "default",
+      "execution-mode": "agent",
       "file-triggers-enabled": true,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T21:22:49.566Z",
       "locked": false,
       "name": "workspace-1",
+      "operations": true,
       "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
         "can-update": true,
-        "can-destroy": false,
-        "can-queue-destroy": false,
-        "can-queue-run": false,
-        "can-update-variable": false,
-        "can-lock": false,
-        "can-read-settings": true
+        "can-update-variable": true
       },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
       "resource-count": 0,
-      "terraform-version": "0.11.0",
+      "run-failures": null,
+      "source": "tfe-api",
+      "source-name": null,
+      "source-url": null,
+      "speculative-enabled": true,
+      "structured-run-output-enabled": true,
+      "tag-names": [],
+      "terraform-version": "1.0.4",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T21:22:49.566Z",
       "vcs-repo": null,
-      "working-directory": "",
-      "global-remote-state": true,
-      "execution-mode": "agent",
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "vcs-repo-identifier": null,
+      "working-directory": null,
+      "workspace-kpis-runs-count": null
+    },
+    "id": "ws-6jrRyVDv1J8zQMB5",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
     },
     "relationships": {
+      "agent-pool": {
+        "data": {
+          "id": "apool-QxGd2tRjympfMvQc",
+          "type": "agent-pools"
+        }
+      },
+      "current-configuration-version": {
+        "data": null
+      },
+      "current-run": {
+        "data": null
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": null
+      },
       "organization": {
         "data": {
           "id": "my-organization",
           "type": "organizations"
         }
       },
-      "ssh-key": {
+      "outputs": {
+        "data": []
+      },
+      "readme": {
         "data": null
       },
-      "latest-run": {
-        "data": null
-      },
-      "agent-pool": {
-        "data": {
-          "id": "apool-ZjT6A7mVFm5WHT5a",
-          "type": "agent-pools"
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-6jrRyVDv1J8zQMB5/relationships/remote-state-consumers"
         }
       }
     },
-    "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
-    }
+    "type": "workspaces"
   }
 }
 ```

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -623,102 +623,216 @@ $ curl \
 
 ```json
 {
-  "data": [
-    {
-      "id": "ws-SihZTyXKfNXUWuUa",
-      "type": "workspaces",
-      "attributes": {
-        "auto-apply": false,
-        "allow-destroy-plan": false,
-        "can-queue-destroy-plan": false,
-        "created-at": "2017-11-02T23:24:05.997Z",
-        "description": null,
-        "environment": "default",
-        "file-triggers-enabled": true,
-        "locked": false,
-        "name": "workspace-2",
-        "queue-all-runs": false,
-        "resource-count": 5,
-        "source": "tfe-ui",
-        "source-name": null,
-        "source-url": null,
-        "tag-names": [],
-        "terraform-version": "0.10.8",
-        "trigger-prefixes": [],
-        "vcs-repo": {
-          "branch": "",
-          "ingress-submodules": false
-        },
-        "working-directory": "",
-        "global-remote-state": true,
-        "updated-at": "2017-11-29T19:18:09.976Z"
+  "data": {
+    "attributes": {
+      "actions": {
+        "is-destroyable": true
       },
-      "relationships": {
-        "organization": {
-          "data": {
-            "id": "my-organization",
-            "type": "organizations"
-          }
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
+      "auto-apply": false,
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T21:50:58.726Z",
+      "description": null,
+      "environment": "default",
+      "execution-mode": "remote",
+      "file-triggers-enabled": true,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T21:50:58.726Z",
+      "locked": false,
+      "name": "workspace-2",
+      "operations": true,
+      "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
+        "can-update": true,
+        "can-update-variable": true
+      },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
+      "queue-all-runs": false,
+      "resource-count": 0,
+      "run-failures": null,
+      "source": "tfe-api",
+      "source-name": null,
+      "source-url": null,
+      "speculative-enabled": true,
+      "structured-run-output-enabled": true,
+      "tag-names": [],
+      "terraform-version": "0.11.1",
+      "trigger-prefixes": [],
+      "updated-at": "2021-08-16T21:50:58.726Z",
+      "vcs-repo": {
+        "branch": "",
+        "display-identifier": "skierkowski/terraform-test-proj",
+        "identifier": "skierkowski/terraform-test-proj",
+        "ingress-submodules": false,
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
+        "repository-http-url": "https://github.com/skierkowski/terraform-test-proj",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
+      },
+      "vcs-repo-identifier": "skierkowski/terraform-test-proj",
+      "working-directory": "",
+      "workspace-kpis-runs-count": null
+    },
+    "id": "ws-KTuq99JSzgmDSvYj",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
+    },
+    "relationships": {
+      "agent-pool": {
+        "data": null
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-9WgU5LYoTq3rrnG6",
+          "type": "configuration-versions"
         },
-        "ssh-key": {
-          "data": null
-        },
-        "latest-run": {
-          "data": null
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-9WgU5LYoTq3rrnG6"
         }
       },
-      "links": {
-        "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
+      "current-run": {
+        "data": null
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": null
+      },
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "outputs": {
+        "data": []
+      },
+      "readme": {
+        "data": {
+          "id": "227347",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-KTuq99JSzgmDSvYj/relationships/remote-state-consumers"
+        }
       }
     },
-    {
-      "id": "ws-YnyXLq9fy38afEeb",
-      "type": "workspaces",
+    "type": "workspaces"
+  },
+  {
+    "data": {
       "attributes": {
+        "actions": {
+          "is-destroyable": true
+        },
+        "allow-destroy-plan": true,
+        "apply-duration-average": null,
         "auto-apply": false,
-        "allow-destroy-plan":false,
-        "can-queue-destroy-plan": false,
-        "created-at": "2017-11-02T23:23:53.765Z",
+        "auto-destroy-at": null,
+        "created-at": "2021-08-16T21:22:49.566Z",
         "description": null,
         "environment": "default",
+        "execution-mode": "agent",
         "file-triggers-enabled": true,
+        "global-remote-state": false,
+        "latest-change-at": "2021-08-16T21:22:49.566Z",
         "locked": false,
         "name": "workspace-1",
+        "operations": true,
+        "permissions": {
+          "can-create-state-versions": true,
+          "can-destroy": true,
+          "can-force-unlock": true,
+          "can-lock": true,
+          "can-manage-tags": true,
+          "can-queue-apply": true,
+          "can-queue-destroy": true,
+          "can-queue-run": true,
+          "can-read-settings": true,
+          "can-read-state-versions": true,
+          "can-read-variable": true,
+          "can-unlock": true,
+          "can-update": true,
+          "can-update-variable": true
+        },
+        "plan-duration-average": null,
+        "policy-check-failures": null,
         "queue-all-runs": false,
-        "resource-count": 5,
-        "source": "tfe-ui",
+        "resource-count": 0,
+        "run-failures": null,
+        "source": "tfe-api",
         "source-name": null,
         "source-url": null,
+        "speculative-enabled": true,
+        "structured-run-output-enabled": true,
         "tag-names": [],
-        "terraform-version": "0.10.8",
+        "terraform-version": "1.0.4",
         "trigger-prefixes": [],
-        "vcs-repo": {
-          "branch": "",
-          "ingress-submodules": false
-        },
-        "working-directory": "",
-        "global-remote-state": true,
-        "updated-at": "2017-11-29T19:18:09.976Z"
+        "updated-at": "2021-08-16T21:22:49.566Z",
+        "vcs-repo": null,
+        "vcs-repo-identifier": null,
+        "working-directory": null,
+        "workspace-kpis-runs-count": null
+      },
+      "id": "ws-6jrRyVDv1J8zQMB5",
+      "links": {
+        "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
       },
       "relationships": {
+        "agent-pool": {
+          "data": {
+            "id": "apool-QxGd2tRjympfMvQc",
+            "type": "agent-pools"
+          }
+        },
+        "current-configuration-version": {
+          "data": null
+        },
+        "current-run": {
+          "data": null
+        },
+        "current-state-version": {
+          "data": null
+        },
+        "latest-run": {
+          "data": null
+        },
         "organization": {
           "data": {
             "id": "my-organization",
             "type": "organizations"
           }
         },
-        "ssh-key": {
+        "outputs": {
+          "data": []
+        },
+        "readme": {
           "data": null
         },
-        "latest-run": {
-          "data": null
+        "remote-state-consumers": {
+          "links": {
+            "related": "/api/v2/workspaces/ws-6jrRyVDv1J8zQMB5/relationships/remote-state-consumers"
+          }
         }
       },
-      "links": {
-        "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
-      }
+      "type": "workspaces"
     }
-  ]
 }
 ```
 
@@ -896,7 +1010,6 @@ $ curl \
     "type": "workspaces"
   }
 }
-
 ```
 
 ## Delete a workspace
@@ -978,50 +1091,138 @@ $ curl \
 {
   "data": {
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-02T23:23:53.765Z",
-      "description": null,
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T19:44:45.241Z",
+      "description": "Example workspace for documentation.",
       "environment": "default",
-      "file-triggers-enabled": true,
+      "execution-mode": "agent",
+      "file-triggers-enabled": false,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T19:44:45.241Z",
       "locked": true,
-      "name": "workspace-2",
+      "name": "workspace-1",
+      "operations": true,
       "permissions": {
+        "can-create-state-versions": true,
         "can-destroy": true,
+        "can-force-unlock": true,
         "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
         "can-queue-destroy": true,
         "can-queue-run": true,
         "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
         "can-update": true,
         "can-update-variable": true
       },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
-      "resource-count": 5,
+      "resource-count": 0,
+      "run-failures": null,
       "source": "tfe-ui",
       "source-name": null,
       "source-url": null,
-      "terraform-version": "0.10.8",
+      "speculative-enabled": false,
+      "structured-run-output-enabled": true,
+      "tag-names": [
+        "tag1",
+        "tag2"
+      ],
+      "terraform-version": "1.0.4",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T22:39:15.912Z",
       "vcs-repo": {
         "branch": "",
+        "display-identifier": "my-organization/my-repository",
         "identifier": "my-organization/my-repository",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ"
+        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "repository-http-url": "https://github.com/my-organization/my-repository",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
-      "working-directory": null,
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "vcs-repo-identifier": "my-organization/my-repository",
+      "working-directory": "",
+      "workspace-kpis-runs-count": null
     },
-    "id": "ws-SihZTyXKfNXUWuUa",
+    "id": "ws-FFP9JcN4m6czSRBj",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
+    },
     "relationships": {
+      "agent-pool": {
+        "data": {
+          "id": "apool-QxGd2tRjympfMvQc",
+          "type": "agent-pools"
+        }
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-EpThx8RZdxt8a2mK",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-EpThx8RZdxt8a2mK"
+        }
+      },
+      "current-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
       "locked-by": {
         "data": {
-          "id": "my-user",
+          "id": "user-mGUNNJBeTrTYgxmv",
           "type": "users"
         },
         "links": {
-          "related": "/api/v2/users/my-user"
+          "related": "/api/v2/users/user-mGUNNJBeTrTYgxmv"
+        }
+      },
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "outputs": {
+        "data": []
+      },
+      "readme": {
+        "data": {
+          "id": "227247",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers"
         }
       }
     },
@@ -1063,43 +1264,132 @@ $ curl \
 {
   "data": {
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-02T23:23:53.765Z",
-      "description": null,
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T19:44:45.241Z",
+      "description": "Example workspace for documentation.",
       "environment": "default",
-      "file-triggers-enabled": true,
+      "execution-mode": "agent",
+      "file-triggers-enabled": false,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T19:44:45.241Z",
       "locked": false,
-      "name": "workspace-2",
+      "name": "workspace-1",
+      "operations": true,
       "permissions": {
+        "can-create-state-versions": true,
         "can-destroy": true,
+        "can-force-unlock": true,
         "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
         "can-queue-destroy": true,
         "can-queue-run": true,
         "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
         "can-update": true,
         "can-update-variable": true
       },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
-      "resource-count": 5,
+      "resource-count": 0,
+      "run-failures": null,
       "source": "tfe-ui",
       "source-name": null,
       "source-url": null,
-      "tag-names": [],
-      "terraform-version": "0.10.8",
+      "speculative-enabled": false,
+      "structured-run-output-enabled": true,
+      "tag-names": [
+        "tag1",
+        "tag2"
+      ],
+      "terraform-version": "1.0.4",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T22:36:43.666Z",
       "vcs-repo": {
         "branch": "",
+        "display-identifier": "my-organization/my-repository",
         "identifier": "my-organization/my-repository",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ"
+        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "repository-http-url": "https://github.com/my-organization/my-repository",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
-      "working-directory": null,
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "vcs-repo-identifier": "my-organization/my-repository",
+      "working-directory": "",
+      "workspace-kpis-runs-count": null
     },
-    "id": "ws-SihZTyXKfNXUWuUa",
+    "id": "ws-FFP9JcN4m6czSRBj",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
+    },
+    "relationships": {
+      "agent-pool": {
+        "data": {
+          "id": "apool-QxGd2tRjympfMvQc",
+          "type": "agent-pools"
+        }
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-EpThx8RZdxt8a2mK",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-EpThx8RZdxt8a2mK"
+        }
+      },
+      "current-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "outputs": {
+        "data": []
+      },
+      "readme": {
+        "data": {
+          "id": "227247",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers"
+        }
+      }
+    },
     "type": "workspaces"
   }
 }

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -619,66 +619,80 @@ $ curl \
 ```json
 {
   "data": {
-    "id": "ws-qPhan8kDLymzv2uS",
-    "type": "workspaces",
     "attributes": {
-      "allow-destroy-plan": true,
-      "auto-apply": false,
-      "auto-destroy-at": null,
-      "created-at": "2021-06-03T17:50:20.307Z",
-      "environment": "default",
-      "locked": false,
-      "name": "workspace-1",
-      "queue-all-runs": false,
-      "speculative-enabled": true,
-      "structured-run-output-enabled": false,
-      "terraform-version": "0.15.3",
-      "working-directory": null,
-      "global-remote-state": false,
-      "updated-at": "2021-06-24T13:38:03.407Z",
-      "resource-count": 0,
-      "apply-duration-average": 158000,
-      "plan-duration-average": 20000,
-      "policy-check-failures": null,
-      "run-failures": 6,
-      "workspace-kpis-runs-count": 7,
-      "latest-change-at": "2021-06-23T17:50:48.815Z",
-      "operations": true,
-      "execution-mode": "remote",
-      "vcs-repo": null,
-      "vcs-repo-identifier": null,
-      "permissions": {
-        "can-update": true,
-        "can-destroy": true,
-        "can-queue-destroy": true,
-        "can-queue-run": true,
-        "can-queue-apply": true,
-        "can-read-state-versions": true,
-        "can-create-state-versions": true,
-        "can-read-variable": true,
-        "can-update-variable": true,
-        "can-lock": true,
-        "can-unlock": true,
-        "can-force-unlock": true,
-        "can-read-settings": true,
-        "can-manage-tags": true
-      },
       "actions": {
         "is-destroyable": true
       },
-      "description": null,
+      "allow-destroy-plan": true,
+      "apply-duration-average": 158000,
+      "auto-apply": false,
+      "auto-destroy-at": null,
+      "created-at": "2021-06-03T17:50:20.307Z",
+      "description": "An example workspace for documentation.",
+      "environment": "default",
+      "execution-mode": "remote",
       "file-triggers-enabled": true,
-      "trigger-prefixes": [],
+      "global-remote-state": false,
+      "latest-change-at": "2021-06-23T17:50:48.815Z",
+      "locked": false,
+      "name": "workspace-1",
+      "operations": true,
+      "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
+        "can-update": true,
+        "can-update-variable": true
+      },
+      "plan-duration-average": 20000,
+      "policy-check-failures": null,
+      "queue-all-runs": false,
+      "resource-count": 0,
+      "run-failures": 6,
       "source": "terraform",
       "source-name": null,
       "source-url": null,
-      "tag-names": []
+      "speculative-enabled": true,
+      "structured-run-output-enabled": false,
+      "tag-names": [
+        "tag1"
+      ],
+      "terraform-version": "0.15.3",
+      "trigger-prefixes": [],
+      "updated-at": "2021-08-16T18:54:06.874Z",
+      "vcs-repo": null,
+      "vcs-repo-identifier": null,
+      "working-directory": null,
+      "workspace-kpis-runs-count": 7
+    },
+    "id": "ws-qPhan8kDLymzv2uS",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
     },
     "relationships": {
-      "organization": {
+         "agent-pool": {
+           "data": {
+             "id": "apool-QxGd2tRjympfMvQc",
+             "type": "agent-pools"
+           }
+         },
+      },
+      "current-configuration-version": {
         "data": {
-          "id": "org-MxtxBC6ihhU6u8AG",
-          "type": "organizations"
+          "id": "cv-sixaaRuRwutYg5fH",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-sixaaRuRwutYg5fH"
         }
       },
       "current-run": {
@@ -690,23 +704,6 @@ $ curl \
           "related": "/api/v2/runs/run-UyCw2TDCmxtfdjmy"
         }
       },
-      "latest-run": {
-        "data": {
-          "id": "run-UyCw2TDCmxtfdjmy",
-          "type": "runs"
-        },
-        "links": {
-          "related": "/api/v2/runs/run-UyCw2TDCmxtfdjmy"
-        }
-      },
-      "outputs": {
-        "data": []
-      },
-      "remote-state-consumers": {
-        "links": {
-          "related": "/api/v2/workspaces/ws-qPhan8kDLymzv2uS/relationships/remote-state-consumers"
-        }
-      },
       "current-state-version": {
         "data": {
           "id": "sv-TAjm2vFZqY396qY6",
@@ -716,27 +713,40 @@ $ curl \
           "related": "/api/v2/workspaces/ws-qPhan8kDLymzv2uS/current-state-version"
         }
       },
-      "current-configuration-version": {
+      "latest-run": {
         "data": {
-          "id": "cv-sixaaRuRwutYg5fH",
-          "type": "configuration-versions"
+          "id": "run-UyCw2TDCmxtfdjmy",
+          "type": "runs"
         },
         "links": {
-          "related": "/api/v2/configuration-versions/cv-sixaaRuRwutYg5fH"
+          "related": "/api/v2/runs/run-UyCw2TDCmxtfdjmy"
         }
       },
-      "agent-pool": {
-        "data": null
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "outputs": {
+        "data": []
       },
       "readme": {
-        "data": null
+          "data": {
+            "id": "227247",
+            "type": "workspace-readme"
+          }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-qPhan8kDLymzv2uS/relationships/remote-state-consumers"
+        }
       }
     },
-    "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
-    }
+    "type": "workspaces"
   }
 }
+
 ```
 
 ## Delete a workspace

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -278,68 +278,113 @@ _With a VCS repository_
 ```json
 {
   "data": {
-    "id": "ws-SihZTyXKfNXUWuUa",
-    "type": "workspaces",
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": true,
-      "created-at": "2017-11-02T23:55:16.142Z",
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T21:50:58.726Z",
       "description": null,
       "environment": "default",
+      "execution-mode": "remote",
       "file-triggers-enabled": true,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T21:50:58.726Z",
       "locked": false,
       "name": "workspace-2",
+      "operations": true,
       "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
         "can-update": true,
-        "can-destroy": false,
-        "can-queue-destroy": false,
-        "can-queue-run": false,
-        "can-update-variable": false,
-        "can-lock": false,
-        "can-read-settings": true
+        "can-update-variable": true
       },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
       "resource-count": 0,
-      "source": "tfe-ui",
+      "run-failures": null,
+      "source": "tfe-api",
       "source-name": null,
       "source-url": null,
-      "terraform-version": "0.10.8",
+      "speculative-enabled": true,
+      "structured-run-output-enabled": true,
+      "tag-names": [],
+      "terraform-version": "0.11.1",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T21:50:58.726Z",
       "vcs-repo": {
-        "identifier": "skierkowski/terraform-test-proj",
         "branch": "",
-        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
-        "ingress-submodules": false
+        "display-identifier": "skierkowski/terraform-test-proj",
+        "identifier": "skierkowski/terraform-test-proj",
+        "ingress-submodules": false,
+        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "repository-http-url": "https://github.com/skierkowski/terraform-test-proj",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
-      "working-directory": null,
-      "global-remote-state": true,
-      "execution-mode": "agent",
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "vcs-repo-identifier": "skierkowski/terraform-test-proj",
+      "working-directory": "",
+      "workspace-kpis-runs-count": null
+    },
+    "id": "ws-KTuq99JSzgmDSvYj",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
     },
     "relationships": {
+      "agent-pool": {
+        "data": null
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-9WgU5LYoTq3rrnG6",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-9WgU5LYoTq3rrnG6"
+        }
+      },
+      "current-run": {
+        "data": null
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": null
+      },
       "organization": {
         "data": {
           "id": "my-organization",
           "type": "organizations"
         }
       },
-      "ssh-key": {
+      "outputs": {
+        "data": []
+      },
+      "readme": {
         "data": null
       },
-      "latest-run": {
-        "data": null
-      },
-      "agent-pool": {
-        "data": {
-          "id": "apool-ZjT6A7mVFm5WHT5a",
-          "type": "agent-pools"
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-KTuq99JSzgmDSvYj/relationships/remote-state-consumers"
         }
       }
     },
-    "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
-    }
+    "type": "workspaces"
   }
 }
 ```

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -331,7 +331,7 @@ _With a VCS repository_
         "display-identifier": "skierkowski/terraform-test-proj",
         "identifier": "skierkowski/terraform-test-proj",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
         "repository-http-url": "https://github.com/skierkowski/terraform-test-proj",
         "service-provider": "github",
         "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
@@ -476,53 +476,116 @@ $ curl \
 ```json
 {
   "data": {
-    "id": "ws-SihZTyXKfNXUWuUa",
-    "type": "workspaces",
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-02T23:24:05.997Z",
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T21:50:58.726Z",
       "description": null,
       "environment": "default",
+      "execution-mode": "remote",
       "file-triggers-enabled": true,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T21:50:58.726Z",
       "locked": false,
       "name": "workspace-2",
+      "operations": true,
+      "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
+        "can-update": true,
+        "can-update-variable": true
+      },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
       "resource-count": 0,
-      "source": "tfe-ui",
+      "run-failures": null,
+      "source": "tfe-api",
       "source-name": null,
       "source-url": null,
+      "speculative-enabled": true,
+      "structured-run-output-enabled": true,
       "tag-names": [],
-      "terraform-version": "0.10.8",
+      "terraform-version": "0.11.1",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T21:50:58.726Z",
       "vcs-repo": {
-        "identifier": "skierkowski/terraform-test-proj",
         "branch": "",
+        "display-identifier": "skierkowski/terraform-test-proj",
+        "identifier": "skierkowski/terraform-test-proj",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ"
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
+        "repository-http-url": "https://github.com/skierkowski/terraform-test-proj",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
+      "vcs-repo-identifier": "skierkowski/terraform-test-proj",
       "working-directory": "",
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "workspace-kpis-runs-count": null
+    },
+    "id": "ws-KTuq99JSzgmDSvYj",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
     },
     "relationships": {
+      "agent-pool": {
+        "data": null
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-9WgU5LYoTq3rrnG6",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-9WgU5LYoTq3rrnG6"
+        }
+      },
+      "current-run": {
+        "data": null
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": null
+      },
       "organization": {
         "data": {
           "id": "my-organization",
           "type": "organizations"
         }
       },
-      "ssh-key": {
-        "data": null
+      "outputs": {
+        "data": []
       },
-      "latest-run": {
-        "data": null
+      "readme": {
+        "data": {
+          "id": "227347",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-KTuq99JSzgmDSvYj/relationships/remote-state-consumers"
+        }
       }
     },
-    "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
-    }
+    "type": "workspaces"
   }
 }
 ```

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -619,45 +619,60 @@ $ curl \
 ```json
 {
   "data": {
-    "id": "ws-mD5bmJ8ry3uTzuHi",
+    "id": "ws-qPhan8kDLymzv2uS",
     "type": "workspaces",
     "attributes": {
-      "actions": {
-        "is-destroyable": true
-      },
-      "apply-duration-average": 600000,
-      "auto-apply": false,
       "allow-destroy-plan": true,
-      "created-at": "2018-03-08T22:30:00.404Z",
-      "description": null,
+      "auto-apply": false,
+      "auto-destroy-at": null,
+      "created-at": "2021-06-03T17:50:20.307Z",
       "environment": "default",
-      "file-triggers-enabled": true,
       "locked": false,
       "name": "workspace-1",
+      "queue-all-runs": false,
+      "speculative-enabled": true,
+      "structured-run-output-enabled": false,
+      "terraform-version": "0.15.3",
+      "working-directory": null,
+      "global-remote-state": false,
+      "updated-at": "2021-06-24T13:38:03.407Z",
+      "resource-count": 0,
+      "apply-duration-average": 158000,
+      "plan-duration-average": 20000,
+      "policy-check-failures": null,
+      "run-failures": 6,
+      "workspace-kpis-runs-count": 7,
+      "latest-change-at": "2021-06-23T17:50:48.815Z",
+      "operations": true,
+      "execution-mode": "remote",
+      "vcs-repo": null,
+      "vcs-repo-identifier": null,
       "permissions": {
         "can-update": true,
         "can-destroy": true,
         "can-queue-destroy": true,
         "can-queue-run": true,
+        "can-queue-apply": true,
+        "can-read-state-versions": true,
+        "can-create-state-versions": true,
+        "can-read-variable": true,
         "can-update-variable": true,
         "can-lock": true,
-        "can-read-settings": true
+        "can-unlock": true,
+        "can-force-unlock": true,
+        "can-read-settings": true,
+        "can-manage-tags": true
       },
-      "plan-duration-average": 600000,
-      "policy-check-failures": 5,
-      "queue-all-runs": false,
-      "resource-count": 5,
-      "run-failures": 2,
-      "workspace-kpis-run-count": 10,
-      "source": "tfe-ui",
+      "actions": {
+        "is-destroyable": true
+      },
+      "description": null,
+      "file-triggers-enabled": true,
+      "trigger-prefixes": [],
+      "source": "terraform",
       "source-name": null,
       "source-url": null,
-      "tag-names": [],
-      "terraform-version": "0.11.3",
-      "trigger-prefixes": [],
-      "working-directory": null,
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "tag-names": []
     },
     "relationships": {
       "organization": {
@@ -668,47 +683,55 @@ $ curl \
       },
       "current-run": {
         "data": {
-          "id": "run-ZbX5Lb4n8Kdu4roV",
+          "id": "run-UyCw2TDCmxtfdjmy",
           "type": "runs"
         },
         "links": {
-          "related": "/api/v2/runs/run-ZbX5Lb4n8Kdu4roV"
+          "related": "/api/v2/runs/run-UyCw2TDCmxtfdjmy"
         }
       },
       "latest-run": {
         "data": {
-          "id": "run-ZbX5Lb4n8Kdu4roV",
+          "id": "run-UyCw2TDCmxtfdjmy",
           "type": "runs"
         },
         "links": {
-          "related": "/api/v2/runs/run-ZbX5Lb4n8Kdu4roV"
+          "related": "/api/v2/runs/run-UyCw2TDCmxtfdjmy"
         }
       },
       "outputs": {
-        "data": [{
-          "id": "wsout-tZ2bJSSeECSBkCiS",
-          "type": "workspace-outputs"
-        }]
+        "data": []
       },
-    },
-    "included": [{
-      "id": "wsout-tZ2bJSSeECSBkCiS",
-      "type": "workspace-outputs",
-      "attributes": {
-        "name": "random",
-        "sensitive": false,
-        "output-type": "string",
-        "workspace-attributes": {
-          "id": "ws-sKRZA6LNRdViecHa",
-          "name": "terraform-testing"
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-qPhan8kDLymzv2uS/relationships/remote-state-consumers"
+        }
+      },
+      "current-state-version": {
+        "data": {
+          "id": "sv-TAjm2vFZqY396qY6",
+          "type": "state-versions"
         },
-        "organization-attributes": {
-          "id": "org-MsM3mTFU49nX3Qbo",
-          "name": "jondavidjohn"
+        "links": {
+          "related": "/api/v2/workspaces/ws-qPhan8kDLymzv2uS/current-state-version"
+        }
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-sixaaRuRwutYg5fH",
+          "type": "configuration-versions"
         },
-        "value": "evenly-rapidly-noticeably-model-horse"
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-sixaaRuRwutYg5fH"
+        }
+      },
+      "agent-pool": {
+        "data": null
+      },
+      "readme": {
+        "data": null
       }
-    }],
+    },
     "links": {
       "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
     }

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -1973,108 +1973,142 @@ $ curl \
 {
   "data": [
     {
-      "id": "ws-kGUhmUEb5ep55auL",
-      "type": "workspaces",
       "attributes": {
-        "allow-destroy-plan": true,
-        "auto-apply": false,
-        "auto-destroy-at": null,
-        "created-at": "2021-04-16T14:02:30.116Z",
-        "environment": "default",
-        "locked": false,
-        "name": "SlothSpace-a6959312-555c-4b98-83ba-a5bb4eb5ea58",
-        "queue-all-runs": false,
-        "speculative-enabled": true,
-        "tag-names": [],
-        "terraform-version": "0.13.4",
-        "working-directory": "",
-        "global-remote-state": false,
-        "latest-change-at": "2021-04-16T14:02:30.116Z",
-        "operations": true,
-        "execution-mode": "remote",
-        "vcs-repo": null,
-        "vcs-repo-identifier": null,
-        "permissions": {
-          "can-update": true,
-          "can-destroy": true,
-          "can-queue-destroy": true,
-          "can-queue-run": true,
-          "can-queue-apply": true,
-          "can-read-state-versions": true,
-          "can-create-state-versions": true,
-          "can-read-variable": true,
-          "can-update-variable": true,
-          "can-lock": true,
-          "can-unlock": true,
-          "can-force-unlock": true,
-          "can-read-settings": true
-        },
         "actions": {
           "is-destroyable": true
         },
-        "description": "The workspace where we keep the sloths.",
+        "allow-destroy-plan": true,
+        "apply-duration-average": null,
+        "auto-apply": false,
+        "auto-destroy-at": null,
+        "created-at": "2021-08-16T21:50:58.726Z",
+        "description": null,
+        "environment": "default",
+        "execution-mode": "remote",
         "file-triggers-enabled": true,
-        "trigger-prefixes": [],
-        "source": null,
+        "global-remote-state": false,
+        "latest-change-at": "2021-08-16T21:50:58.726Z",
+        "locked": false,
+        "name": "workspace-2",
+        "operations": true,
+        "permissions": {
+          "can-create-state-versions": true,
+          "can-destroy": true,
+          "can-force-unlock": true,
+          "can-lock": true,
+          "can-manage-tags": true,
+          "can-queue-apply": true,
+          "can-queue-destroy": true,
+          "can-queue-run": true,
+          "can-read-settings": true,
+          "can-read-state-versions": true,
+          "can-read-variable": true,
+          "can-unlock": true,
+          "can-update": true,
+          "can-update-variable": true
+        },
+        "plan-duration-average": null,
+        "policy-check-failures": null,
+        "queue-all-runs": false,
+        "resource-count": 0,
+        "run-failures": null,
+        "source": "tfe-api",
         "source-name": null,
-        "source-url": null
+        "source-url": null,
+        "speculative-enabled": true,
+        "structured-run-output-enabled": true,
+        "tag-names": [],
+        "terraform-version": "0.11.1",
+        "trigger-prefixes": [],
+        "updated-at": "2021-08-16T22:57:28.163Z",
+        "vcs-repo": {
+          "branch": "",
+          "display-identifier": "my-organization/my-workspace",
+          "identifier": "my-organization/my-workspace",
+          "ingress-submodules": false,
+          "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
+          "repository-http-url": "https://github.com/my-organization/my-workspace",
+          "service-provider": "github",
+          "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
+        },
+        "vcs-repo-identifier": "my-organization/my-workspace",
+        "working-directory": "",
+        "workspace-kpis-runs-count": null
+      },
+      "id": "ws-KTuq99JSzgmDSvYj",
+      "links": {
+        "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
       },
       "relationships": {
-        "organization": {
-          "data": {
-            "id": "organization_1",
-            "type": "organizations"
-          }
+        "agent-pool": {
+          "data": null
         },
-        "ssh-key": {
+        "current-configuration-version": {
           "data": {
-            "id": "sshkey-dVK2FiBVcbeKfcPy",
-            "type": "ssh-keys"
+            "id": "cv-9WgU5LYoTq3rrnG6",
+            "type": "configuration-versions"
           },
           "links": {
-            "related": "/api/v2/ssh-keys/sshkey-dVK2FiBVcbeKfcPy"
+            "related": "/api/v2/configuration-versions/cv-9WgU5LYoTq3rrnG6"
           }
         },
         "current-run": {
           "data": null
         },
-        "latest-run": {
-          "data": null
-        },
-        "remote-state-consumers": {
-          "links": {
-            "related": "/api/v2/workspaces/ws-kGUhmUEb5ep55auL/relationships/remote-state-consumers"
-          }
-        },
         "current-state-version": {
           "data": null
         },
-        "current-configuration-version": {
+        "latest-run": {
           "data": null
         },
-        "agent-pool": {
-          "data": null
+        "organization": {
+          "data": {
+            "id": "my-organization",
+            "type": "organizations"
+          }
+        },
+        "outputs": {
+          "data": []
+        },
+        "readme": {
+          "data": {
+            "id": "227347",
+            "type": "workspace-readme"
+          }
+        },
+        "remote-state-consumers": {
+          "links": {
+            "related": "/api/v2/workspaces/ws-KTuq99JSzgmDSvYj/relationships/remote-state-consumers"
+          }
+        },
+        "ssh-key": {
+          "data": {
+            "id": "sshkey-WfPdX2GKwGkK5rsB",
+            "type": "ssh-keys"
+          },
+          "links": {
+            "related": "/api/v2/ssh-keys/sshkey-WfPdX2GKwGkK5rsB"
+          }
         }
       },
-      "links": {
-        "self": "/api/v2/organizations/organization_1/workspaces/SlothSpace-a6959312-555c-4b98-83ba-a5bb4eb5ea58"
-      }
+      "type": "workspaces"
     }
   ],
   "links": {
-    "self": "http://test.host/api/v2/workspaces/ws-Jp5DW3dPpCLmR3um/relationships/remote-state-consumers?page%5Bnumber%5D=1&page%5Bsize%5D=20&show_only_configured=true",
-    "first": "http://test.host/api/v2/workspaces/ws-Jp5DW3dPpCLmR3um/relationships/remote-state-consumers?page%5Bnumber%5D=1&page%5Bsize%5D=20&show_only_configured=true",
-    "prev": null,
+    "first": "https://app.terraform.io/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "last": "https://app.terraform.io/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers?page%5Bnumber%5D=1&page%5Bsize%5D=20",
     "next": null,
-    "last": "http://test.host/api/v2/workspaces/ws-Jp5DW3dPpCLmR3um/relationships/remote-state-consumers?page%5Bnumber%5D=1&page%5Bsize%5D=20&show_only_configured=true"
+    "prev": null,
+    "self": "https://app.terraform.io/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers?page%5Bnumber%5D=1&page%5Bsize%5D=20"
   },
   "meta": {
     "pagination": {
       "current-page": 1,
-      "prev-page": null,
       "next-page": null,
-      "total-pages": 1,
-      "total-count": 1
+      "page-size": 20,
+      "prev-page": null,
+      "total-count": 1,
+      "total-pages": 1
     }
   }
 }

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -1611,38 +1611,110 @@ $ curl \
 {
   "data": {
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-02T23:24:05.997Z",
-      "description": null,
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T19:44:45.241Z",
+      "description": "Example workspace for documentation.",
       "environment": "default",
-      "file-triggers-enabled": true,
+      "execution-mode": "agent",
+      "file-triggers-enabled": false,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T19:44:45.241Z",
       "locked": false,
-      "name": "workspace-2",
+      "name": "workspace-1",
+      "operations": true,
+      "permissions": {
+        "can-create-state-versions": true,
+        "can-destroy": true,
+        "can-force-unlock": true,
+        "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
+        "can-queue-destroy": true,
+        "can-queue-run": true,
+        "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
+        "can-update": true,
+        "can-update-variable": true
+      },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
-      "resource-count": 5,
+      "resource-count": 0,
+      "run-failures": null,
       "source": "tfe-ui",
       "source-name": null,
       "source-url": null,
-      "tag-names": [],
-      "terraform-version": "0.10.8",
+      "speculative-enabled": false,
+      "structured-run-output-enabled": true,
+      "tag-names": [
+        "tag1",
+        "tag2"
+      ],
+      "terraform-version": "1.0.4",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T22:59:56.631Z",
       "vcs-repo": {
         "branch": "",
-        "ingress-submodules": false
+        "display-identifier": "my-organization/my-repository",
+        "identifier": "my-organization/my-repository",
+        "ingress-submodules": false,
+        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "repository-http-url": "https://github.com/my-organization/my-repository",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
+      "vcs-repo-identifier": "my-organization/my-repository",
       "working-directory": "",
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "workspace-kpis-runs-count": null
     },
-    "id": "ws-SihZTyXKfNXUWuUa",
+    "id": "ws-FFP9JcN4m6czSRBj",
     "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
     },
     "relationships": {
-      "latest-run": {
+      "agent-pool": {
+        "data": {
+          "id": "apool-QxGd2tRjympfMvQc",
+          "type": "agent-pools"
+        }
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-EpThx8RZdxt8a2mK",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-EpThx8RZdxt8a2mK"
+        }
+      },
+      "current-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "current-state-version": {
         "data": null
+      },
+      "latest-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
       },
       "organization": {
         "data": {
@@ -1650,13 +1722,27 @@ $ curl \
           "type": "organizations"
         }
       },
+      "outputs": {
+        "data": []
+      },
+      "readme": {
+        "data": {
+          "id": "227247",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers"
+        }
+      },
       "ssh-key": {
         "data": {
-          "id": "sshkey-GxrePWre1Ezug7aM",
+          "id": "sshkey-WfPdX2GKwGkK5rsB",
           "type": "ssh-keys"
         },
         "links": {
-          "related": "/api/v2/ssh-keys/sshkey-GxrePWre1Ezug7aM"
+          "related": "/api/v2/ssh-keys/sshkey-WfPdX2GKwGkK5rsB"
         }
       }
     },

--- a/content/source/docs/cloud/api/workspaces.html.md
+++ b/content/source/docs/cloud/api/workspaces.html.md
@@ -1146,7 +1146,7 @@ $ curl \
         "display-identifier": "my-organization/my-repository",
         "identifier": "my-organization/my-repository",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
         "repository-http-url": "https://github.com/my-organization/my-repository",
         "service-provider": "github",
         "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
@@ -1319,7 +1319,7 @@ $ curl \
         "display-identifier": "my-organization/my-repository",
         "identifier": "my-organization/my-repository",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-4ecWLF8W8gfxxNXP",
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
         "repository-http-url": "https://github.com/my-organization/my-repository",
         "service-provider": "github",
         "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
@@ -1428,43 +1428,132 @@ $ curl \
 {
   "data": {
     "attributes": {
+      "actions": {
+        "is-destroyable": true
+      },
+      "allow-destroy-plan": true,
+      "apply-duration-average": null,
       "auto-apply": false,
-      "allow-destroy-plan": false,
-      "can-queue-destroy-plan": false,
-      "created-at": "2017-11-02T23:23:53.765Z",
-      "description": null,
+      "auto-destroy-at": null,
+      "created-at": "2021-08-16T19:44:45.241Z",
+      "description": "Example workspace for documentation.",
       "environment": "default",
-      "file-triggers-enabled": true,
+      "execution-mode": "agent",
+      "file-triggers-enabled": false,
+      "global-remote-state": false,
+      "latest-change-at": "2021-08-16T19:44:45.241Z",
       "locked": false,
-      "name": "workspace-2",
+      "name": "workspace-1",
+      "operations": true,
       "permissions": {
+        "can-create-state-versions": true,
         "can-destroy": true,
+        "can-force-unlock": true,
         "can-lock": true,
+        "can-manage-tags": true,
+        "can-queue-apply": true,
         "can-queue-destroy": true,
         "can-queue-run": true,
         "can-read-settings": true,
+        "can-read-state-versions": true,
+        "can-read-variable": true,
+        "can-unlock": true,
         "can-update": true,
         "can-update-variable": true
       },
+      "plan-duration-average": null,
+      "policy-check-failures": null,
       "queue-all-runs": false,
-      "resource-count": 5,
+      "resource-count": 0,
+      "run-failures": null,
       "source": "tfe-ui",
       "source-name": null,
       "source-url": null,
-      "tag-names": [],
-      "terraform-version": "0.10.8",
+      "speculative-enabled": false,
+      "structured-run-output-enabled": true,
+      "tag-names": [
+        "tag1",
+        "tag2"
+      ],
+      "terraform-version": "1.0.4",
       "trigger-prefixes": [],
+      "updated-at": "2021-08-16T22:42:06.143Z",
       "vcs-repo": {
         "branch": "",
+        "display-identifier": "my-organization/my-repository",
         "identifier": "my-organization/my-repository",
         "ingress-submodules": false,
-        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ"
+        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
+        "repository-http-url": "https://github.com/my-organization/my-repository",
+        "service-provider": "github",
+        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
       },
-      "working-directory": null,
-      "global-remote-state": true,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "vcs-repo-identifier": "my-organization/my-repository",
+      "working-directory": "",
+      "workspace-kpis-runs-count": null
     },
-    "id": "ws-SihZTyXKfNXUWuUa",
+    "id": "ws-FFP9JcN4m6czSRBj",
+    "links": {
+      "self": "/api/v2/organizations/my-organization/workspaces/workspace-1"
+    },
+    "relationships": {
+      "agent-pool": {
+        "data": {
+          "id": "apool-QxGd2tRjympfMvQc",
+          "type": "agent-pools"
+        }
+      },
+      "current-configuration-version": {
+        "data": {
+          "id": "cv-EpThx8RZdxt8a2mK",
+          "type": "configuration-versions"
+        },
+        "links": {
+          "related": "/api/v2/configuration-versions/cv-EpThx8RZdxt8a2mK"
+        }
+      },
+      "current-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "current-state-version": {
+        "data": null
+      },
+      "latest-run": {
+        "data": {
+          "id": "run-kWrpCVo79eTzmW7y",
+          "type": "runs"
+        },
+        "links": {
+          "related": "/api/v2/runs/run-kWrpCVo79eTzmW7y"
+        }
+      },
+      "organization": {
+        "data": {
+          "id": "my-organization",
+          "type": "organizations"
+        }
+      },
+      "outputs": {
+        "data": []
+      },
+      "readme": {
+        "data": {
+          "id": "227247",
+          "type": "workspace-readme"
+        }
+      },
+      "remote-state-consumers": {
+        "links": {
+          "related": "/api/v2/workspaces/ws-FFP9JcN4m6czSRBj/relationships/remote-state-consumers"
+        }
+      }
+    },
     "type": "workspaces"
   }
 }


### PR DESCRIPTION
This is in response to [this ticket](https://github.com/hashicorp/terraform-website/issues/1669) which said that the show workspace sample response on [this page](https://www.terraform.io/docs/cloud/api/workspaces.html#sample-response-3) was out-of-date (the latest response includes agent-pools, among other things).

- [x] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
