### PR TITLE
Fix typos in docs

### DIFF
--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -84,7 +84,7 @@ mock-tfplan-v2.sentinel   # tfplan/v2 mock data
 mock-tfstate.sentinel     # tfstate mock data
 mock-tfstate-v2.sentinel  # tfstate/v2 mock data
 mock-tfrun.sentinel       # tfrun mock data
-sentinel.hcl              # sample configruation file
+sentinel.hcl              # sample configuration file
 ```
 
 The sample `sentinel.hcl` file contains mappings to the mocks so that you

--- a/content/source/docs/extend/guides/v2-upgrade-guide.html.md
+++ b/content/source/docs/extend/guides/v2-upgrade-guide.html.md
@@ -400,7 +400,7 @@ func (m *MutexKV) get(key string) *sync.Mutex {
     return mutex
 }
 
-// Returns a properly initalized MutexKV
+// Returns a properly initialized MutexKV
 func NewMutexKV() *MutexKV {
     return &MutexKV{
         store: make(map[string]*sync.Mutex),


### PR DESCRIPTION
## Summary

made corrections to the typos i have found in the documentations.

## Labels

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
