### PR TITLE
Add Terraform Enterprise releases

### DIFF
--- a/content/source/docs/enterprise/release/index.html.md
+++ b/content/source/docs/enterprise/release/index.html.md
@@ -1,0 +1,25 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# Terraform Enterprise Releases
+
+A new Terraform Enterprise release is shipped each month. The releases from the current calendar year are listed in the table below. The complete list is on [github](https://github.com/hashicorp/terraform-enterprise-release-notes).
+
+~> The next release `v202109-1` is scheduled for September 14th, 2021.
+
+|Version                        | Release Sequence  |  Recommended<br> Replicated CLI    | Latest <br>Terraform CLI | Sentinel |
+|---                            |---                |---                                 |---                    |---              |
+| [v202108-1](./v202108-1.html) |  557              | [2.52.0](https://release-notes.replicated.com/release-notes/2.52.0/)   |[1.0.3](https://github.com/hashicorp/terraform/releases/tag/v1.0.3)     | [0.18.3](https://docs.hashicorp.com/sentinel/changelog#0-18-3-june-1-2021)     |
+| [v202107-1](./v202107-1.html) |  550              | [2.50.0](https://release-notes.replicated.com/release-notes/2.50.0/)   |[1.0.1](https://github.com/hashicorp/terraform/releases/tag/v1.0.1)     | [0.18.3](https://docs.hashicorp.com/sentinel/changelog#0-18-3-june-1-2021)     |
+| [v202106-1](./v202106-1.html) |  544              | [2.50.0](https://release-notes.replicated.com/release-notes/2.50.0/)   |[1.0.0](https://github.com/hashicorp/terraform/releases/tag/v1.0.0)     | [0.18.3](https://docs.hashicorp.com/sentinel/changelog#0-18-3-june-1-2021)     |
+| [v202105-1](./v202105-1.html) |  534              | [2.50.0](https://release-notes.replicated.com/release-notes/2.50.0/)   |[0.15.3](https://github.com/hashicorp/terraform/releases/tag/v0.15.3)   | [0.18.1](https://docs.hashicorp.com/sentinel/changelog#0-18-1-may-11-2021)     |
+| [v202104-1](./v202104-1.html) |  528              | [2.50.0](https://release-notes.replicated.com/release-notes/2.50.0/)   |[0.15.0](https://github.com/hashicorp/terraform/releases/tag/v0.15.0)   | [0.18.0](https://docs.hashicorp.com/sentinel/changelog#0-18-0-march-25-2021)   |
+| [v202103-3](./v202103-3.html) |  523              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/)   |[0.14.7](https://github.com/hashicorp/terraform/releases/tag/v0.14.7)   | [0.17.4](https://docs.hashicorp.com/sentinel/changelog#0-17-4-february-2-2021) |
+| [v202103-2](./v202103-2.html) |  520              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/)   |[0.14.7](https://github.com/hashicorp/terraform/releases/tag/v0.14.7)   | [0.17.4](https://docs.hashicorp.com/sentinel/changelog#0-17-4-february-2-2021) |
+| [v202102-2](./v202102-2.html) |  509              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/)   |[0.13.5](https://github.com/hashicorp/terraform/releases/tag/v0.13.5)   | [0.16.1](https://docs.hashicorp.com/sentinel/changelog#0-16-1-october-21-2020) |
+| [v202102-1](./v202102-1.html) |  507              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/)   |[0.13.5](https://github.com/hashicorp/terraform/releases/tag/v0.13.5)   | [0.16.1](https://docs.hashicorp.com/sentinel/changelog#0-16-1-october-21-2020) |
+| [v202101-1](./v202101-1.html) |  504              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/)   |[0.13.5](https://github.com/hashicorp/terraform/releases/tag/v0.13.5)   | [0.16.1](https://docs.hashicorp.com/sentinel/changelog#0-16-1-october-21-2020) |
+
+\*  Release v202103-1 is a required release. All online upgrades will install this version before proceeding automatically, however airgap customers must upgrade to this version before proceeding to later releases.

--- a/content/source/docs/enterprise/release/v202101-1.html.md
+++ b/content/source/docs/enterprise/release/v202101-1.html.md
@@ -1,0 +1,21 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202101-1 (504)
+
+### UPCOMING DEPRECATION NOTIFICATIONS:
+* The AWS CLI that ships with Terraform Enterprise will be upgraded to AWS CLI version 2 in the next Terraform Enterprise release (v202102-1). [Version 2 of the AWS CLI contains breaking changes](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html) that could cause disruptions in custom builds. If you are currently using any AWS CLI features in your workspaces please prepare for the deprecation or migrate to a custom build image to continue using version AWS CLI version 1.
+
+### APPLICATION LEVEL BREAKING CHANGES:
+* The encryption password is no longer automatically generated and must be explicitly set by the user during installation. The encryption password can be set via the "Encryption Password" field for a manual installation and via the `enc_password` setting for an automated installation. Loss of the encryption password can lead to application data loss. To retrieve an installation's current encryption password, execute `replicatedctl app-config export --template '{{.enc_password.Value}}'`.
+
+### APPLICATION LEVEL FEATURES:
+* Enables the ability to run Terraform Enterprise in Active/Active configuration for increased reliability. If you’re interested in scaling your existing installation to two nodes, please reach out your Technical Account Manager for more information.
+
+### APPLICATION LEVEL BUG FIXES:
+* Fixed issue where Forgot Password emails would not send.
+* Updated the error message shown when the encryption password is empty.
+
+### APPLICATION LEVEL SECURITY FIXES:

--- a/content/source/docs/enterprise/release/v202102-1.html.md
+++ b/content/source/docs/enterprise/release/v202102-1.html.md
@@ -1,0 +1,18 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202102-1 (507)
+
+### APPLICATION LEVEL BREAKING CHANGES:
+* The AWS CLI that ships with Terraform Enterprise will be upgraded to AWS CLI version 2. [Version 2 of the AWS CLI contains breaking changes](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html) that could cause disruptions in custom builds. If you are currently using any AWS CLI features in your workspaces please prepare for the deprecation or migrate to a custom build image to continue using version AWS CLI version 1.
+
+### APPLICATION LEVEL FEATURES:
+
+### APPLICATION LEVEL BUG FIXES:
+* Fixed an issue where the `tfe-admin app-config` command would not accept empty configuration values.
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+* Fixed issue where password reset URLs could be seen in logs on server.

--- a/content/source/docs/enterprise/release/v202102-2.html.md
+++ b/content/source/docs/enterprise/release/v202102-2.html.md
@@ -1,0 +1,22 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202102-2 (509)
+
+### BUG FIXES SINCE v202102-1:
+
+* Fixed issue initializing plugins properly during Terraform Apply in certain upgrade scenarios (eg Terraform 0.12 to 0.13).
+
+### APPLICATION LEVEL BREAKING CHANGES:
+* The AWS CLI that ships with Terraform Enterprise will be upgraded to AWS CLI version 2. [Version 2 of the AWS CLI contains breaking changes](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html) that could cause disruptions in custom builds. If you are currently using any AWS CLI features in your workspaces please prepare for the deprecation or migrate to a custom build image to continue using version AWS CLI version 1.
+
+### APPLICATION LEVEL FEATURES:
+
+### APPLICATION LEVEL BUG FIXES:
+* Fixed an issue where the `tfe-admin app-config` command would not accept empty configuration values.
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+* Fixed issue where password reset URLs could be seen in logs on server.

--- a/content/source/docs/enterprise/release/v202103-1.html.md
+++ b/content/source/docs/enterprise/release/v202103-1.html.md
@@ -1,0 +1,96 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202103-1 (519 Required)
+
+
+### APPLICATION LEVEL BREAKING CHANGES:
+* The internally-managed PostgreSQL server has been upgraded from PostgreSQL 9.5 to PostgreSQL 12. Operators should back up their Terraform Enterprise data before upgrading to v202103-* This change only affects mounted disk and proof of concept installations. Please refer to the "PostgreSQL Upgrade" section for more information.
+* Changed organization name requirements to not be ambiguous with organization ID format. Although very unlikely, if an existing organization name matches a pattern `org-<16 base58 chars>`, it must be renamed.
+
+
+### UPCOMING DEPRECATION NOTIFICATIONS:
+* The Admin API endpoint to list an organization's module consumers has been deprecated, and will be removed in Terraform Enterprise v202106-* Clients should transition to the new JSON:API compliant endpoint: [List Module Consumers for an Organization](https://www.terraform.io/docs/cloud/api/admin/organizations.html#list-module-consumers-for-an-organization).
+* The Admin API endpoint to update an organization's module consumers has been deprecated, and will be removed in Terraform Enterprise v202106-* Clients should transition to the new JSON:API compliant endpoint: [Update an Organization's Module Consumers](https://www.terraform.io/docs/cloud/api/admin/organizations.html#update-an-organization-39-s-module-consumers)
+
+
+### APPLICATION LEVEL FEATURES:
+
+* Added support for PostgreSQL SCRAM-SHA-256 password authentication.
+* Added `db-backup-poc`, `db-restore-poc`, and `db-reindex-poc` admin commands to allow proof of concept installations to backup, restore, and reindex the PostgreSQL database.
+* Changes how TBW handles initialization during the apply phase, removing the `-backend=false` reinitialization in favor of persisting the entire filesystem between plan and apply.
+* Adds Sensitive Variable Override File, which will mark TFE sensitive variables as sensitive in Terraform during runs.
+* Support IMDSv2 when configuring object storage with S3 and Use Instance Profile for Access.
+* Update the base OS image to Ubuntu Bionic (18.04) for the default Terraform worker image.
+* Add support for forcing TLS via HSTS response headers and `Secure` cookie flags.
+* Added a link to an example Terraform config repo when creating a VCS workspace.
+* Added the `hostname` argument to example commands in the UI where applicable
+* Added Terraform CLI versions up through 0.15.0-beta1 to Terraform Enterprise.
+ * Added run relationship to policy-checks API responses.
+* Added ability to rename organizations in organization settings.
+* Added the ability to filter JSON results in select places where JSON data is available (such as the state viewer). The filter language is a jq subset; see the documentation for more details.
+* Added the ability to see the JSON response for policy checks within the run viewer, along with a shortcut to quickly see the results for all "main" rules within a policy check.
+* Added the workspace name to the page title
+* Fixed streamed log undefined waiting text
+* Fixed log viewer printing "undefined" for empty logs
+* Added Additional VCS Info to Workspace API Response
+* Added ability to view module submodules in the private registry
+* Added ability to view module examples in the private registry.
+* Added JSON:API compliant endpoint to fetch an organization's module consumers.
+* Added JSON:API compliant endpoint to update an organization's module consumers.
+* Added ability to filter module producing organizations to the admin/organizations API endpoint.
+* Added the ability to include the related run and workspace to the policy checks API endpoint.
+* Changed team access API to only use pagination when requested.
+
+
+### APPLICATION LEVEL BUG FIXES:
+
+* Upgrades go-isolation to pick up bug fix for directories with spaces in the name.
+* Adjust container permissions to support running `tfe-admin` commands in environments where SELinux operates in `enforcing` mode.
+* Fix a race condition in Active/Active deployments that would potentially result in transient Vault authentication failures when using an internal Vault deployment.
+* Fixed an issue where the footer did not display for logged-in users.
+* Fixed a bug where a workspace would think it had a working configuration version after someone ran `terraform plan`, but it wouldn't be able to queue new runs.
+* Fixed keyboard accessibility for modules in the private registry
+* Changed admin organizations api returns 422 if global_module_sharing: null passed in
+* Fixed an issue with the reliability of copying text from log output in the Google Chrome browser
+* Fixed an inconsistency of icon colors within certain button types.
+* Fixed alignment and icon issues on Notifications page
+* Added ability to keyboard-navigate into streamed logs on a run and provisioning instructions on a module
+* Fixed pagination params for page size and number for audit trail endpoint
+* Fixed sourceable run trigger dropdown when there are more than 50 workspaces available
+* Changed instructions to add a new GitHub.com (custom) provider to align with a change to the GitHub UI/UX
+* Fixed email logos not rendering if `ASSET_HOST` is not set in a TFE instance
+* Fixed GitHub icon rendering in Firefox
+* Added keyboard-only navigation to workspace heading links
+* Added keyboard-only navigation for accordion elements such as run phase expanding boxes.
+* Fixed accessibility of heading order for screen readers
+* Fixed price error for certain AWS Elasticache node types during Cost Estimation.
+* Fixed a potential issue where some cost estimates might be off by 1-2%
+* Fixed the user invitation modal list of teams, ensuring teams are correctly paginated to include all of them.
+* Fixed an issue where working directories were having their leading and trailing slashes stripped during updating.
+* Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.
+* Fixed an issue where custom CA certificates were not being passed to the `telegraf` container.
+* Fixed API issue where includable resource parameters were required to be underscored, even as the API is generally hyphenated.
+* Fixed workspace variables API to require the correct workspace in URL
+* Fixed issue not showing all teams when adding team access to a workspace.
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Enforce organization-level setting that requires users within an organization to have two-factor authentication enabled (CVE-2021-3153).
+* Reduce exposure by proactively revoking per-run tokens on run completion.
+* Update go-slug to v0.5.0 to pick up security fixes for maliciously crafted tarballs.
+* Update Rails to 6.0.3.5, addressing security vulnerabilities.
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+
+### PostgreSQL Upgrade:
+
+The [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/) states that PostgreSQL 9.5 had its final release on February 11, 202* As such, the internally-managed PostgreSQL server has been upgraded from PostgreSQL 9.5 to PostgreSQL 12. This change only affects mounted disk and proof of concept installations. It does not affect external services installations.
+
+The first time a Terraform Enterprise installation is upgraded to v202103-1, a program will be executed that will upgrade the PostgreSQL 9.5 data to PostgreSQL 12. This program takes a backup of the PostgreSQL data before upgrading. Regardless, operators should back up their Terraform Enterprise data before upgrading to Terraform Enterprise v202103-*
+
+Additionally, operators should familiarize themselves with the following knowledge base articles.
+
+
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)

--- a/content/source/docs/enterprise/release/v202103-2.html.md
+++ b/content/source/docs/enterprise/release/v202103-2.html.md
@@ -1,0 +1,98 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202103-2 (520)
+
+### BUG FIXES SINCE v202103-1:
+
+* Fixed an issue where runs would fail to plan when using Terraform 0.13.x versions created with `terraform-bundle`.
+
+### APPLICATION LEVEL BREAKING CHANGES:
+* The internally-managed PostgreSQL server has been upgraded from PostgreSQL 9.5 to PostgreSQL 12. Operators should back up their Terraform Enterprise data before upgrading to v202103-1. This change only affects mounted disk and proof of concept installations. Please refer to the "PostgreSQL Upgrade" section for more information.
+* Changed organization name requirements to not be ambiguous with organization ID format. Although very unlikely, if an existing organization name matches a pattern `org-<16 base58 chars>`, it must be renamed.
+
+
+### UPCOMING DEPRECATION NOTIFICATIONS:
+* The Admin API endpoint to list an organization's module consumers has been deprecated, and will be removed in Terraform Enterprise v202106-1. Clients should transition to the new JSON:API compliant endpoint: [List Module Consumers for an Organization](https://www.terraform.io/docs/cloud/api/admin/organizations.html#list-module-consumers-for-an-organization).
+* The Admin API endpoint to update an organization's module consumers has been deprecated, and will be removed in Terraform Enterprise v202106-1. Clients should transition to the new JSON:API compliant endpoint: [Update an Organization's Module Consumers](https://www.terraform.io/docs/cloud/api/admin/organizations.html#update-an-organization-39-s-module-consumers)
+
+
+### APPLICATION LEVEL FEATURES:
+
+* Added support for PostgreSQL SCRAM-SHA-256 password authentication.
+* Added `db-backup-poc`, `db-restore-poc`, and `db-reindex-poc` admin commands to allow proof of concept installations to backup, restore, and reindex the PostgreSQL database.
+* Changes how TBW handles initialization during the apply phase, removing the `-backend=false` reinitialization in favor of persisting the entire filesystem between plan and apply.
+* Adds Sensitive Variable Override File, which will mark TFE sensitive variables as sensitive in Terraform during runs.
+* Support IMDSv2 when configuring object storage with S3 and Use Instance Profile for Access.
+* Update the base OS image to Ubuntu Bionic (18.04) for the default Terraform worker image.
+* Add support for forcing TLS via HSTS response headers and `Secure` cookie flags.
+* Added a link to an example Terraform config repo when creating a VCS workspace.
+* Added the `hostname` argument to example commands in the UI where applicable
+* Added Terraform CLI versions up through 0.15.0-beta1 to Terraform Enterprise.
+* Added run relationship to policy-checks API responses.
+* Added ability to rename organizations in organization settings.
+* Added the ability to filter JSON results in select places where JSON data is available (such as the state viewer). The filter language is a jq subset; see the documentation for more details.
+* Added the ability to see the JSON response for policy checks within the run viewer, along with a shortcut to quickly see the results for all "main" rules within a policy check.
+* Added the workspace name to the page title
+* Fixed streamed log undefined waiting text
+* Fixed log viewer printing "undefined" for empty logs
+* Added Additional VCS Info to Workspace API Response
+* Added ability to view module submodules in the private registry
+* Added ability to view module examples in the private registry.
+* Added JSON:API compliant endpoint to fetch an organization's module consumers.
+* Added JSON:API compliant endpoint to update an organization's module consumers.
+* Added ability to filter module producing organizations to the admin/organizations API endpoint.
+* Added the ability to include the related run and workspace to the policy checks API endpoint.
+* Changed team access API to only use pagination when requested.
+
+
+### APPLICATION LEVEL BUG FIXES:
+
+* Upgrades go-isolation to pick up bug fix for directories with spaces in the name.
+* Adjust container permissions to support running `tfe-admin` commands in environments where SELinux operates in `enforcing` mode.
+* Fix a race condition in Active/Active deployments that would potentially result in transient Vault authentication failures when using an internal Vault deployment.
+* Fixed an issue where the footer did not display for logged-in users.
+* Fixed a bug where a workspace would think it had a working configuration version after someone ran `terraform plan`, but it wouldn't be able to queue new runs.
+* Fixed keyboard accessibility for modules in the private registry
+* Changed admin organizations api returns 422 if global_module_sharing: null passed in
+* Fixed an issue with the reliability of copying text from log output in the Google Chrome browser
+* Fixed an inconsistency of icon colors within certain button types.
+* Fixed alignment and icon issues on Notifications page
+* Added ability to keyboard-navigate into streamed logs on a run and provisioning instructions on a module
+* Fixed pagination params for page size and number for audit trail endpoint
+* Fixed sourceable run trigger dropdown when there are more than 50 workspaces available
+* Changed instructions to add a new GitHub.com (custom) provider to align with a change to the GitHub UI/UX
+* Fixed email logos not rendering if `ASSET_HOST` is not set in a TFE instance
+* Fixed GitHub icon rendering in Firefox
+* Added keyboard-only navigation to workspace heading links
+* Added keyboard-only navigation for accordion elements such as run phase expanding boxes.
+* Fixed accessibility of heading order for screen readers
+* Fixed price error for certain AWS Elasticache node types during Cost Estimation.
+* Fixed a potential issue where some cost estimates might be off by 1-2%
+* Fixed the user invitation modal list of teams, ensuring teams are correctly paginated to include all of them.
+* Fixed an issue where working directories were having their leading and trailing slashes stripped during updating.
+* Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.
+* Fixed an issue where custom CA certificates were not being passed to the `telegraf` container.
+* Fixed API issue where includable resource parameters were required to be underscored, even as the API is generally hyphenated.
+* Fixed workspace variables API to require the correct workspace in URL
+* Fixed issue not showing all teams when adding team access to a workspace.
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Enforce organization-level setting that requires users within an organization to have two-factor authentication enabled (CVE-2021-3153).
+* Reduce exposure by proactively revoking per-run tokens on run completion.
+* Update go-slug to v0.5.0 to pick up security fixes for maliciously crafted tarballs.
+* Update Rails to 6.0.3.5, addressing security vulnerabilities.
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+
+### PostgreSQL Upgrade:
+
+The [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/) states that PostgreSQL 9.5 had its final release on February 11, 2021. As such, the internally-managed PostgreSQL server has been upgraded from PostgreSQL 9.5 to PostgreSQL 12. This change only affects mounted disk and proof of concept installations. It does not affect external services installations.
+
+The first time a Terraform Enterprise installation is upgraded to v202103-1, a program will be executed that will upgrade the PostgreSQL 9.5 data to PostgreSQL 12. This program takes a backup of the PostgreSQL data before upgrading. Regardless, operators should back up their Terraform Enterprise data before upgrading to Terraform Enterprise v202103-1.
+
+Additionally, operators should familiarize themselves with the following knowledge base articles.
+
+- [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
+- [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)

--- a/content/source/docs/enterprise/release/v202103-3.html.md
+++ b/content/source/docs/enterprise/release/v202103-3.html.md
@@ -1,0 +1,103 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202103-3 (523)
+
+### BUG FIXES SINCE v202103-2:
+
+* Fixed an issue where certain ephemeral Docker volumes were inadvertently included in Replicated snapshots, leading to snapshot timeouts.
+
+### BUG FIXES SINCE v202103-1:
+
+* Fixed an issue where runs would fail to plan when using Terraform 0.13.x versions created with `terraform-bundle`.
+
+### APPLICATION LEVEL BREAKING CHANGES:
+* The internally-managed PostgreSQL server has been upgraded from PostgreSQL 9.5 to PostgreSQL 12. Operators should back up their Terraform Enterprise data before upgrading to v202103-1. This change only affects mounted disk and proof of concept installations. Please refer to the "PostgreSQL Upgrade" section for more information.
+* Changed organization name requirements to not be ambiguous with organization ID format. Although very unlikely, if an existing organization name matches a pattern `org-<16 base58 chars>`, it must be renamed.
+
+
+### UPCOMING DEPRECATION NOTIFICATIONS:
+
+* The Admin API endpoint to list an organization's module consumers has been deprecated, and will be removed in Terraform Enterprise v202106-1. Clients should transition to the new JSON:API compliant endpoint: [List Module Consumers for an Organization](https://www.terraform.io/docs/cloud/api/admin/organizations.html#list-module-consumers-for-an-organization).
+* The Admin API endpoint to update an organization's module consumers has been deprecated, and will be removed in Terraform Enterprise v202106-1. Clients should transition to the new JSON:API compliant endpoint: [Update an Organization's Module Consumers](https://www.terraform.io/docs/cloud/api/admin/organizations.html#update-an-organization-39-s-module-consumers)
+
+
+### APPLICATION LEVEL FEATURES:
+
+* Added support for PostgreSQL SCRAM-SHA-256 password authentication.
+* Added `db-backup-poc`, `db-restore-poc`, and `db-reindex-poc` admin commands to allow proof of concept installations to backup, restore, and reindex the PostgreSQL database.
+* Changes how TBW handles initialization during the apply phase, removing the `-backend=false` reinitialization in favor of persisting the entire filesystem between plan and apply.
+* Adds Sensitive Variable Override File, which will mark TFE sensitive variables as sensitive in Terraform during runs.
+* Support IMDSv2 when configuring object storage with S3 and Use Instance Profile for Access.
+* Update the base OS image to Ubuntu Bionic (18.04) for the default Terraform worker image.
+* Add support for forcing TLS via HSTS response headers and `Secure` cookie flags.
+* Added a link to an example Terraform config repo when creating a VCS workspace.
+* Added the `hostname` argument to example commands in the UI where applicable
+* Added Terraform CLI versions up through 0.15.0-beta1 to Terraform Enterprise.
+* Added run relationship to policy-checks API responses.
+* Added ability to rename organizations in organization settings.
+* Added the ability to filter JSON results in select places where JSON data is available (such as the state viewer). The filter language is a jq subset; see the documentation for more details.
+* Added the ability to see the JSON response for policy checks within the run viewer, along with a shortcut to quickly see the results for all "main" rules within a policy check.
+* Added the workspace name to the page title
+* Fixed streamed log undefined waiting text
+* Fixed log viewer printing "undefined" for empty logs
+* Added Additional VCS Info to Workspace API Response
+* Added ability to view module submodules in the private registry
+* Added ability to view module examples in the private registry.
+* Added JSON:API compliant endpoint to fetch an organization's module consumers.
+* Added JSON:API compliant endpoint to update an organization's module consumers.
+* Added ability to filter module producing organizations to the admin/organizations API endpoint.
+* Added the ability to include the related run and workspace to the policy checks API endpoint.
+* Changed team access API to only use pagination when requested.
+
+
+### APPLICATION LEVEL BUG FIXES:
+
+* Upgrades go-isolation to pick up bug fix for directories with spaces in the name.
+* Adjust container permissions to support running `tfe-admin` commands in environments where SELinux operates in `enforcing` mode.
+* Fix a race condition in Active/Active deployments that would potentially result in transient Vault authentication failures when using an internal Vault deployment.
+* Fixed an issue where the footer did not display for logged-in users.
+* Fixed a bug where a workspace would think it had a working configuration version after someone ran `terraform plan`, but it wouldn't be able to queue new runs.
+* Fixed keyboard accessibility for modules in the private registry
+* Changed admin organizations api returns 422 if global_module_sharing: null passed in
+* Fixed an issue with the reliability of copying text from log output in the Google Chrome browser
+* Fixed an inconsistency of icon colors within certain button types.
+* Fixed alignment and icon issues on Notifications page
+* Added ability to keyboard-navigate into streamed logs on a run and provisioning instructions on a module
+* Fixed pagination params for page size and number for audit trail endpoint
+* Fixed sourceable run trigger dropdown when there are more than 50 workspaces available
+* Changed instructions to add a new GitHub.com (custom) provider to align with a change to the GitHub UI/UX
+* Fixed email logos not rendering if `ASSET_HOST` is not set in a TFE instance
+* Fixed GitHub icon rendering in Firefox
+* Added keyboard-only navigation to workspace heading links
+* Added keyboard-only navigation for accordion elements such as run phase expanding boxes.
+* Fixed accessibility of heading order for screen readers
+* Fixed price error for certain AWS Elasticache node types during Cost Estimation.
+* Fixed a potential issue where some cost estimates might be off by 1-2%
+* Fixed the user invitation modal list of teams, ensuring teams are correctly paginated to include all of them.
+* Fixed an issue where working directories were having their leading and trailing slashes stripped during updating.
+* Fixed Modules ingress for Bitbucket Webhook events containing multiple changes.
+* Fixed an issue where custom CA certificates were not being passed to the `telegraf` container.
+* Fixed API issue where includable resource parameters were required to be underscored, even as the API is generally hyphenated.
+* Fixed workspace variables API to require the correct workspace in URL
+* Fixed issue not showing all teams when adding team access to a workspace.
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Enforce organization-level setting that requires users within an organization to have two-factor authentication enabled (CVE-2021-3153).
+* Reduce exposure by proactively revoking per-run tokens on run completion.
+* Update go-slug to v0.5.0 to pick up security fixes for maliciously crafted tarballs.
+* Update Rails to 6.0.3.5, addressing security vulnerabilities.
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+
+### PostgreSQL Upgrade:
+
+The [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/) states that PostgreSQL 9.5 had its final release on February 11, 2021. As such, the internally-managed PostgreSQL server has been upgraded from PostgreSQL 9.5 to PostgreSQL 12. This change only affects mounted disk and proof of concept installations. It does not affect external services installations.
+
+The first time a Terraform Enterprise installation is upgraded to v202103-1, a program will be executed that will upgrade the PostgreSQL 9.5 data to PostgreSQL 12. This program takes a backup of the PostgreSQL data before upgrading. Regardless, operators should back up their Terraform Enterprise data before upgrading to Terraform Enterprise v202103-1.
+
+Additionally, operators should familiarize themselves with the following knowledge base articles.
+
+- [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
+- [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)

--- a/content/source/docs/enterprise/release/v202104-1.html.md
+++ b/content/source/docs/enterprise/release/v202104-1.html.md
@@ -1,0 +1,41 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202104-1 (528)
+
+
+### APPLICATION LEVEL BREAKING CHANGES:
+
+* Added a new organization permission, "Manage Policy Overrides", to isolate the permission for allowing overrides of `soft-mandatory` policy checks. The existing "Manage Policies" permission will no longer allow for `soft-mandatory` overrides.
+* Increased minimim required Replicated version to 2.50.0.
+
+### APPLICATION LEVEL FEATURES:
+
+* Added policy check events to the audit log and audit trail APIs.
+* Added ability to define working directory while changing a workspace's VCS source
+* Changed the Sentinel runtime to version 0.18.0. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog). 
+* Changed Modules page to be Registry and updated urls
+* Added Terraform CLI versions up through 0.15.0 to Terraform Enterprise.
+* Added the ability to restrict state access (usually performed via the `terraform_remote_state` data source) to specific workspaces within an organization, along with an admin setting to configure the default setting for new workspaces and a command line migration assistant.
+* Added UI for disabling automatic speculative plans in VCS-connected workspaces. (This already existed in the API, and is now also available in each workspace's VCS settings page.)
+* Added Firefox ESR and older Chrome/Firefox/Safari/Edge versions (latest 2) to browser support list
+* Added Replicated configuration to restrict Terraform run environments from being able to reach cloud provider metadata endpoints, e.g., http://169.254.169.254.
+* Active/Active configurations now require fewer tokens during install, only needing `enc_password` across all nodes (previously required tokens such as `cookie_hash`, `install_id` etc) See [documentation for more details](https://www.terraform.io/docs/enterprise/install/active-active.html).
+
+
+### APPLICATION LEVEL BUG FIXES:
+* Fixed an issue where `tfe-admin support-bundle` would fail to upload support bundles to S3 due to permissions issues.
+* Fixed an issue where the Backup and Restore API would restore files to the root of the Azure storage account instead of inside the configured Azure blob container.
+* Changed GitHub token validation to accept new formats
+* Changed maximum displayable teams to 500 from 250 on team access selection wizard
+* Fixed an issue in JSON filtering where unknown keys were not being handled as expected by jq (missing keys should render null values).
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Removed the logic to upgrade the internally-managed PostgreSQL server from PostgreSQL 9.5 to PostgreSQL 12. Installations running a release of Terraform Enterprise prior to v202103-1 must upgrade to required release v202103-1 in order to upgrade the internally-managed PostgreSQL server. This change only affects mounted disk and proof of concept installations.
+* Rotated the secret used to generate password reset tokens and account unlock tokens. Existing password reset tokens and account unlock tokens generated before this change is deployed will be rendered invalid.
+* Removed the ability for run tokens used in build workers to list all workspaces in the organization, a permission that is not required for the run token's intended purpose of reading workspaces to share state across workspaces using the terraform_remote_state data source.
+* Removed the ability for Terraform code in a run environment to initiate network communication with internal TFE services.
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+* Introduced additional security controls to prevent SSRF attacks in various TFE components.

--- a/content/source/docs/enterprise/release/v202105-1.html.md
+++ b/content/source/docs/enterprise/release/v202105-1.html.md
@@ -1,0 +1,44 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202105-1 (534)
+
+### APPLICATION LEVEL BREAKING CHANGES:
+
+
+
+### APPLICATION LEVEL FEATURES:
+
+* Changed run page to keep apply logs open after an active run completes.
+* Added "Created via" to the sidebar
+* Added Link as the Run Triggers header
+* Changed count display for run triggers
+* Changed submodule and examples UI
+* Added Terraform CLI versions up through 0.15.3 to Terraform Enterprise.
+* Changed the maximum Sentinel job execution time to 1 hour.
+* Changed the Sentinel runtime to version 0.18.1. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog).
+* Changed mock generation so that: 1) best efforts are made to obfuscate sensitive values, and 2) generate the sample configuration file as HCL instead of legacy JSON.
+
+### APPLICATION LEVEL BUG FIXES:
+
+* Fixed plan logs upload expiration to match the actual maximum plan runtime.
+* Reduce Terraform State Parser maximum memory usage on small states.
+* Fixed error when deleting workspaces
+* Fixed OOM errors when deleting large workspaces
+* Fixed run trigger scrollbars when overflow is present
+* Fixed module view published date bug.
+* Fixed an issue where a user couldn't accept an invitation if they'd ever had an expired invite.
+* Fixed an issue preventing users who had an invalid invitation token from clicking through to the sign up form.
+* Fixed some communication components between the Sentinel worker and TFE internal API to ensure the worker does not execute a policy check before it is ready.
+* Fixed an issue where policy check results were being submitted for already completed checks, causing confusing results (passing results for failed checks, for example).
+* Changed refresh interval for GitLab.com OAuth Token refreshes.
+* Fixed unpacking custom provider binaries when using Terraform 0.14.x and 0.15.x.
+* Changed frontend route params for organization and workspace names case insensitive
+* Changed retry behavior to not retry HTTP basic auth failures when ingressing configurations
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Added `autocomplete=off` attribute to password fields
+* Updated the Ruby version used by the application to 2.7.3.
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.

--- a/content/source/docs/enterprise/release/v202106-1.html.md
+++ b/content/source/docs/enterprise/release/v202106-1.html.md
@@ -1,0 +1,45 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202106-1 (544)
+
+
+### APPLICATION LEVEL BREAKING CHANGES:
+
+
+
+### APPLICATION LEVEL FEATURES:
+
+* Added support for several new capabilities in remote runs triggered via the CLI and API: `-refresh=false`, `-refresh-only`, and `-replace=ADDRESS`. See [the documentation](https://www.terraform.io/docs/cloud/run/modes-and-options.html) for more details on each of these options.
+* Added Terraform CLI versions up through 0.15.5 to Terraform Enterprise.
+* Changed Terraform Cost Estimation to use the new, free Azure pricing API. This changes the [Azure egress hostname](https://www.terraform.io/docs/enterprise/before-installing/network-requirements.html#prices-azure-com) to `prices.azure.com`.
+* Updated the UX for the Registry
+* Changed the Sentinel runtime to version 0.18.3. For the latest changes, see the [release notes](https://docs.hashicorp.com/sentinel/changelog).
+
+### APPLICATION LEVEL BUG FIXES:
+
+* Upgrade Golang 1.14.0 => 1.16.4
+* Fixed unexpected exceptions when accessing a JSON plan that was created before April 2019.
+* Fix issue where runs might get stuck in cost estimating
+* Fixed an authorisation check for service accounts and SSO, which prevented service account created runs from being auto applied.
+* Fixed an issue that prevented commenting on runs by certain users who otherwise should be permissed.
+* Fixed support for Azure appservice v2/V2 tiers with spaces
+* Fixed an issue where Sentinel VCS status checks were not receiving a response from speculative plans.
+* Fixed a potential conflict condition when starting multiple TFE instances simultaneously.
+
+
+### APPLICATION LEVEL SECURITY FIXES:
+* The Vault unseal key and root token are no longer persisted to disk in the Vault container.
+* The PostgreSQL 9.5 to 12 upgrade container has been removed.
+* The PostgreSQL default password migration container has been removed.
+
+
+### API:
+* Updated [Registry Module APIs](https://www.terraform.io/docs/cloud/api/modules.html).
+    * added `registry_name` scoped APIs.
+    * added `organization_name` scoped APIs.
+    * added [Module List API](https://www.terraform.io/docs/cloud/api/modules.html#list-registry-modules-for-an-organization).
+    * updated [Module Delete APIs](https://www.terraform.io/docs/cloud/api/modules.html#delete-a-module).
+* [Runs](https://www.terraform.io/docs/cloud/api/run.html): added `refresh`, `refresh-only`, and `replace-addrs` attributes.

--- a/content/source/docs/enterprise/release/v202107-1.html.md
+++ b/content/source/docs/enterprise/release/v202107-1.html.md
@@ -1,0 +1,34 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202107-1 (550)
+
+
+### APPLICATION LEVEL BREAKING CHANGES:
+
+* Changed default run messages to no longer include detailed information about the run (destroy run, resource targets, etc.). Instead, destroy runs and refresh-only runs are now clearly labeled wherever they're displayed.
+
+### APPLICATION LEVEL FEATURES:
+
+* Added labels for destroy runs and refresh-only runs in workspace run lists.
+* Modified preflight checks to use HTTP and the system HTTP proxy when verifying connectivity to releases.hashicorp.com.
+* Added structured run output for the apply phase of a run. New Apply User Interface
+* Changed the organization settings left navigation sidebar into thematic groups, with settings in alphabetical order within a group.
+
+
+### APPLICATION LEVEL BUG FIXES:
+* Fixed icon rendering on workspace overviews in safari
+* Fixed typo in policy sets UI
+* Fixed slow module search API endpoint which could cause performance issues for terraform-registry.
+* Fixed creating apply-able Runs for Bitbucket Server
+* Fixed error running Cost Estimation on Terraform 1.0.1 plans
+* Fixed extra border on run phases expandable boxes
+* Fixed modal dialog focus trap issues
+* Fixed module change version drop down with only one version
+
+
+### APPLICATION LEVEL SECURITY FIXES:
+* Addressed authorization flaw that allowed privilege escalation via the TFE run token (HCSEC-2021-18 / CVE-2021-36230).
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.

--- a/content/source/docs/enterprise/release/v202108-1.html.md
+++ b/content/source/docs/enterprise/release/v202108-1.html.md
@@ -1,0 +1,48 @@
+---
+layout: "enterprise"
+page_title: "Releases - Terraform Enterprise"
+---
+
+# TFE Release v202108-1 (557)
+
+
+### APPLICATION LEVEL BREAKING CHANGES:
+
+### APPLICATION LEVEL FEATURES:
+
+* Added run metadata to Docker containers performing Terraform operations
+* Added Terraform CLI versions up through 1.0.3 to Terraform Enterprise.
+* Added `locked_by` as an includable resource in the workspaces API.
+* Added ability for organization tokens to manage workspace notification configurations.
+* Updated run status badges and filtering options
+* Added the [Workspace Overview to Terraform Cloud](https://www.hashicorp.com/blog/new-workspace-overview-for-terraform-cloud) capability for Enterprise environments, including the newly released resource grid.
+* Added the ability to group and filter workspaces using singleton tags.
+
+
+### APPLICATION LEVEL BUG FIXES:
+
+* Fixed broken GitLab.com OAuth Application registration link.
+* Fixed handling Oauth Token refresh on failed workspace updates.
+* Fixed incorrect display of apply logs for canceled runs.
+* Fixed bug where JSON plan output was only kept for a week after run completion.
+* Fixed broken API token copy buttons in some browsers.
+* Fixed workspace relationship ID in state version API
+* Fixed organization settings navigation by hiding sections and switching to sentence case
+
+### APPLICATION LEVEL SECURITY FIXES:
+
+* Removed the ability for new users to change two-factor authentication settings without first confirming their email.
+* Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
+
+### API:
+
+* Introduced Workspace Tagging
+    * Updated [Workspaces](https://www.terraform.io/docs/cloud/api/workspaces.html):
+        * added `tag_names` attribute.
+        * added `POST /workspaces/:workspace_id/relationships/tags`
+        * added `DELETE /workspaces/workspace-2/relationships/tags`
+    * Added [Organization Tags](https://www.terraform.io/docs/cloud/api/organization-tags.html).
+    * Added `tags` attribute to [`tfrun`](https://www.terraform.io/docs/cloud/sentinel/import/tfrun.html)
+* [Notification configurations](https://www.terraform.io/docs/cloud/api/notification-configurations.html): Gave organization tokens permission to create and manage notification configurations.
+* [State versions](https://www.terraform.io/docs/cloud/api/state-versions.html): Fixed the ID format for the workspace relationship of a state version. Previously, the reported ID was unusable due to a bug.
+* [Workspaces](https://www.terraform.io/docs/cloud/api/workspaces.html): Added `locked_by` as an includable related resource.

--- a/content/source/layouts/_enterprise_content.erb
+++ b/content/source/layouts/_enterprise_content.erb
@@ -252,7 +252,48 @@
       </li>
 
       <li>
-        <a href="/docs/enterprise/support/index.html">Support</a>
+        <a href="#">Release</a>
+        <ul class="nav">
+          <li>
+            <a href="/docs/enterprise/release/index.html">Overview</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202108-1.html">v202108-1 (LATEST)</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202107-1.html">v202107-1</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202106-1.html">v202106-1</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202105-1.html">v202105-1</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202104-1.html">v202104-1</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202103-3.html">v202103-3</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202103-2.html">v202103-2</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202103-1.html">v202103-1</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202102-2.html">v202102-2</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202102-1.html">v202102-1</a>
+          </li>
+          <li>
+            <a href="/docs/enterprise/release/v202101-1.html">v202101-1</a>
+          </li>
+        </ul>
       </li>
 
+      <li>
+        <a href="/docs/enterprise/support/index.html">Support</a>
+      </li>
     </ul>


### PR DESCRIPTION
This PR adds a new `Release` section to the Terraform Enterprise documentation. The individual release pages are copies of the [Terraform Enterprise Release Notes](https://github.com/hashicorp/terraform-enterprise-release-notes). There are bigger stylistic changes that we want to make to the release note structure (headings, more descriptive feature language, etc.) that are out of scope of this addition. This change is to make the current public release notes more approachable. 🌵 

![Screen Shot 2021-08-24 at 9 15 15 PM](https://user-images.githubusercontent.com/5195704/130726246-b7f63bcf-063f-4e8a-aab7-287ae24481ab.png)

![Screen Shot 2021-08-24 at 9 15 30 PM](https://user-images.githubusercontent.com/5195704/130726267-348d5ac9-e88b-467f-b702-55c0506df09b.png)


## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
