### PR TITLE
Update planned state description

### DIFF
--- a/content/source/docs/cloud/run/states.html.md
+++ b/content/source/docs/cloud/run/states.html.md
@@ -32,7 +32,7 @@ _Leaving this stage:_
 
 - If the `terraform plan` command failed, the run skips to completion (**Plan Errored** state).
 - If a user canceled the plan by pressing the "Cancel Run" button, the run skips to completion (**Canceled** state).
-- If the plan succeeded and doesn't require any changes (since it already matches the current infrastructure state), the run skips to completion (**Planned** state).
+- If the plan succeeded and neither cost estimatation nor Sentinel policy checks are will be done, the run skips to completion (**Planned** state).
 - If the plan succeeded and requires changes:
     - If cost estimation is enabled, the run proceeds automatically to the cost estimation stage.
     - If cost estimation is disabled and [Sentinel policies][] are enabled, the run proceeds automatically to the policy check stage.

--- a/content/source/docs/cloud/run/states.html.md
+++ b/content/source/docs/cloud/run/states.html.md
@@ -32,7 +32,7 @@ _Leaving this stage:_
 
 - If the `terraform plan` command failed, the run skips to completion (**Plan Errored** state).
 - If a user canceled the plan by pressing the "Cancel Run" button, the run skips to completion (**Canceled** state).
-- If the plan succeeded and neither cost estimatation nor Sentinel policy checks are will be done, the run skips to completion (**Planned** state).
+- If the plan succeeded and neither cost estimation nor Sentinel policy checks will be done, the run skips to completion (**Planned** state).
 - If the plan succeeded and requires changes:
     - If cost estimation is enabled, the run proceeds automatically to the cost estimation stage.
     - If cost estimation is disabled and [Sentinel policies][] are enabled, the run proceeds automatically to the policy check stage.


### PR DESCRIPTION
I think a run only enters the planned state if neither cost estimates nor Sentinel policy checks will be done.  But Sentinel policy checks can definitely be done even if a plan has no changes.  And the same might be true of cost estimates.  But my proposed change should be validated with engineering.


## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
