### PR TITLE
Fix typo in the payload example making JSON invalid

### DIFF
--- a/content/source/docs/cloud/api/organization-memberships.html.md
+++ b/content/source/docs/cloud/api/organization-memberships.html.md
@@ -75,7 +75,7 @@ Key path                                      | Type            | Default   | De
             "id": "team-GeLZkdnK6xAVjA5H"
           }
         ]
-      },
+      }
     },
     "type": "organization-memberships"
   }


### PR DESCRIPTION
There is a typo within the documentation in the payload example of `Invite a User to an Organization` endpoint where there is an extra "," in the JSON which makes it invalid.
