### PR TITLE
Add vcs webhook note

### DIFF
--- a/content/source/docs/cloud/vcs/troubleshooting.html.md
+++ b/content/source/docs/cloud/vcs/troubleshooting.html.md
@@ -84,6 +84,10 @@ The domain name for Terraform Cloud's SaaS release changed on 02/22 at 9AM from 
 
 The fix is to update the OAuth Callback URL in your VCS provider to use app.terraform.io instead of atlas.hashicorp.com.
 
+### Can't trigger workspace runs from VCS webhook
+
+A workspace with no runs will not accept new runs from a VCS webhook. You must queue at least one run manually.
+
 ### Changing the URL for a VCS provider
 
 On rare occasions, you might need Terraform Cloud to change the URL it uses to reach your VCS provider. This usually only happens if you move your VCS server or the VCS vendor changes their supported API versions.

--- a/content/source/docs/cloud/workspaces/creating.html.md
+++ b/content/source/docs/cloud/workspaces/creating.html.md
@@ -70,7 +70,7 @@ When you create a new workspace, a few things happen:
 
 - If you connected a VCS repository to the workspace, Terraform Cloud automatically registers a webhook with your VCS provider. The next time new commits appear in the selected branch of that repo or a PR is opened to that branch, Terraform Cloud will automatically queue a Terraform plan for the workspace. For more information, see [VCS Connections: Webhooks](../vcs/index.html#webhooks).
 
-    ~> **Important**: A workspace with no runs will not accept new runs via VCS webhook. You must manually queue at least one run to confirm that the workspace is ready for further runs.
+    ~> **Note:** A workspace with no runs will not accept new runs via VCS webhook. You must manually queue at least one run to confirm that the workspace is ready for further runs.
 
 Most of the time, you'll want to do one or more of the following after creating a workspace:
 

--- a/content/source/docs/cloud/workspaces/creating.html.md
+++ b/content/source/docs/cloud/workspaces/creating.html.md
@@ -70,7 +70,7 @@ When you create a new workspace, a few things happen:
 
 - If you connected a VCS repository to the workspace, Terraform Cloud automatically registers a webhook with your VCS provider. The next time new commits appear in the selected branch of that repo or a PR is opened to that branch, Terraform Cloud will automatically queue a Terraform plan for the workspace. For more information, see [VCS Connections: Webhooks](../vcs/index.html#webhooks).
 
-A workspace with no runs will not accept new runs via VCS webhook; at least one run must be manually queued to confirm that the workspace is ready for further runs.
+    ~> **Important**: A workspace with no runs will not accept new runs via VCS webhook. You must manually queue at least one run to confirm that the workspace is ready for further runs.
 
 Most of the time, you'll want to do one or more of the following after creating a workspace:
 

--- a/content/source/docs/cloud/workspaces/creating.html.md
+++ b/content/source/docs/cloud/workspaces/creating.html.md
@@ -62,18 +62,19 @@ To create a new workspace:
 
 ## After Creating a Workspace
 
-When you create a new workspace, a few things happen:
+Terraform Cloud presents a dialog with shortcut links to either queue a plan or edit variables. If you don't need to edit variables, [manually queue a run](/docs/cloud/run/ui.html#manually-starting-runs) to prepare your workspace.
 
-- Terraform Cloud doesn't immediately queue a plan for the workspace. Instead, it presents a dialog with shortcut links to either queue a plan or edit variables.
+You may also want to:
 
-    If you don't need to edit variables, confirm that the workspace is ready to run by manually queuing a plan.
+- [Edit input or environment variables](./variables.html): Input variables define the parameters of a Terraform configuration, and shell environment variables store credentials and customize Terraform's behavior.
+- [Edit additional workspace settings](./settings.html): This includes notifications, permissions, and "Run Triggers" to queue runs automatically.
+- [Learn more about running Terraform in your workspace](../run/index.html): You can use the UI, API, or CLI to manage infrastructure.
 
-- If you connected a VCS repository to the workspace, Terraform Cloud automatically registers a webhook with your VCS provider. The next time new commits appear in the selected branch of that repo or a PR is opened to that branch, Terraform Cloud will automatically queue a Terraform plan for the workspace. For more information, see [VCS Connections: Webhooks](../vcs/index.html#webhooks).
+### VCS Connection
+If you connected a VCS repository to the workspace, Terraform Cloud automatically registers a webhook with your VCS provider. A workspace with no runs will not accept new runs from a VCS webhook, so you must [manually queue at least one run](/docs/cloud/run/ui.html#manually-starting-runs).
 
-    ~> **Note:** A workspace with no runs will not accept new runs via VCS webhook. You must manually queue at least one run to confirm that the workspace is ready for further runs.
+After you have manually queued a run, Terraform Cloud will automatically queue a plan for the workspace when new commits appear in the selected branch of the linked repository or someone opens a pull request on that branch. [Learn more about VCS webhooks](../vcs/index.html#webhooks).
 
-Most of the time, you'll want to do one or more of the following after creating a workspace:
 
-- [Edit variables](./variables.html)
-- [Edit additional workspace settings](./settings.html)
-- [Work with runs](../run/index.html)
+
+


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-website/issues/1454

A user let us know that a gotcha, whereby a new workspace without any runs won't accept new runs from a VCS webhook could be made more salient and easier to find. This PR makes a note about this on the "Creating Workspaces" page more salient by putting it into a callout box and it also adds a topic to the "VCS Troubleshooting" page.

Requested review scope:
- [x] Content touched by the PR only (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

Review urgency:
- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [x] 1 week (default)
- [ ] Best effort (very non-urgent)

I have:
- [x] Verified that all status checks have passed
- [x] Verified that preview environment has successfully deployed.
- [x] Assigned an appropriate label (either Platform or a product name)
- [x] Requested at least one review
