### PR TITLE
Fix broken link on users page

### DIFF
--- a/content/source/docs/cloud/users-teams-organizations/users.html.md
+++ b/content/source/docs/cloud/users-teams-organizations/users.html.md
@@ -98,7 +98,7 @@ API tokens are necessary for:
 
 - Authenticating with the [Terraform Cloud API](../api/index.html). API calls require an `Authorization: Bearer <TOKEN>` HTTP header.
 - Authenticating with the [Terraform `remote` backend](/docs/language/settings/backends/remote.html), which requires a token in the CLI config file or in the backend configuration.
-- Using [private modules](../registry/using.html) in command-line Terraform runs on local machines requires [a token in the CLI config file](../registry/using.html#configuration).
+- Using [private modules](../registry/using.html) in command-line Terraform runs on local machines requires [a token in the CLI config file](../registry/using.html#authentication).
 
 Terraform Cloud has three kinds of API tokens: user, team, and organization. For more information about team and organization tokens, see [API Tokens](./api-tokens.html).
 


### PR DESCRIPTION
There was a link that was pointing to an anchor that no longer exists. This changes that link to the right subheading.

P.S. ignoring this link checker because the signup link is not actually broken in real life.