### PR TITLE
Docs: added changes specific to private modules

### DIFF
--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -361,7 +361,7 @@ Key path                        | Type   | Default | Description
 `data.type`                     | string |         | Must be `"registry-modules"`.
 `data.attributes.name`          | string |         | The name of this module. May contain alphanumeric characters, with dashes and underscores allowed in non-leading or trailing positions. Maximum length is 64 characters.
 `data.attributes.provider`      | string |         | Specifies the Terraform provider that this module is used for. May contain alphanumeric characters. Maximum length is 64 characters.
-`data.attributes.namespace`     | string |         | The namespace of this module. The organization name for private modules. The namespace for public modules. May contain alphanumeric characters, with dashes and underscores allowed in non-leading or trailing positions. Maximum length is 64 characters.
+`data.attributes.namespace`     | string |         | The namespace of this module. Cannot be set for private modules. May contain alphanumeric characters, with dashes and underscores allowed in non-leading or trailing positions. Maximum length is 64 characters.
 `data.attributes.registry-name` | string |         | Indicates whether this is a publicly maintained module or private. Must be either `public` or `private`.
 
 ### Sample Payload (private module)


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->
Namespace cannot be set for a private module, this value is no longer required as per my testing on TFE v202106-1. I was getting the below error when uploading the module via API
b'{"errors":[{"status":"422","title":"unprocessable entity","detail":"Validation failed: Namespace cannot be set for a private module"}]}'
Not 100% sure if the namespace attribute is still required for public
## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [X] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [X] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
