### PR TITLE
Add auto-apply docs to Run API

### DIFF
--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -81,7 +81,7 @@ Properties without a default value are required.
 
 Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
-`data.attributes.auto-apply` | bool | false | Whether to automatically apply changes when a Terraform plan is successful. Defaults to the [Workspace auto-apply](https://www.terraform.io/docs/cloud/workspaces/settings.html#auto-apply-and-manual-apply).
+`data.attributes.auto-apply` | bool | (The current Auto Apply option of the workspace) | Whether to automatically apply changes when a Terraform plan is successful. Defaults to the [workspace Auto Apply](https://www.terraform.io/docs/cloud/workspaces/settings.html#auto-apply-and-manual-apply) setting.
 `data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources. Mutually exclusive with `refresh-only`.
 `data.attributes.message` | string | "Queued manually via the Terraform Enterprise API" | Specifies the message to be associated with this run.
 `data.attributes.refresh` | bool | true | Specifies whether or not to refresh the state before a plan.

--- a/content/source/docs/cloud/api/run.html.md
+++ b/content/source/docs/cloud/api/run.html.md
@@ -81,6 +81,7 @@ Properties without a default value are required.
 
 Key path                    | Type   | Default | Description
 ----------------------------|--------|---------|------------
+`data.attributes.auto-apply` | bool | false | Whether to automatically apply changes when a Terraform plan is successful. Defaults to the [Workspace auto-apply](https://www.terraform.io/docs/cloud/workspaces/settings.html#auto-apply-and-manual-apply).
 `data.attributes.is-destroy` | bool | false | Specifies if this plan is a destroy plan, which will destroy all provisioned resources. Mutually exclusive with `refresh-only`.
 `data.attributes.message` | string | "Queued manually via the Terraform Enterprise API" | Specifies the message to be associated with this run.
 `data.attributes.refresh` | bool | true | Specifies whether or not to refresh the state before a plan.
@@ -153,6 +154,7 @@ curl \
       "canceled-at": null,
       "created-at": "2021-05-24T07:38:04.171Z",
       "has-changes": false,
+      "auto-apply": false,
       "is-destroy": false,
       "message": "Custom message",
       "plan-only": false,
@@ -306,6 +308,7 @@ curl \
         "canceled-at": null,
         "created-at": "2021-05-24T07:38:04.171Z",
         "has-changes": false,
+        "auto-apply": false,
         "is-destroy": false,
         "message": "Custom message",
         "plan-only": false,
@@ -392,6 +395,7 @@ curl \
       "canceled-at": null,
       "created-at": "2021-05-24T07:38:04.171Z",
       "has-changes": false,
+      "auto-apply": false,
       "is-destroy": false,
       "message": "Custom message",
       "plan-only": false,


### PR DESCRIPTION
## Description

A new API attribute `auto-apply` on a Run has been deployed to Terraform Cloud, and this PR updates a few things.


#### Run API

![image](https://user-images.githubusercontent.com/4130121/133124245-e28258e9-5157-453e-850d-83ca3c24321e.png)

![image](https://user-images.githubusercontent.com/4130121/133124274-904623c9-62c7-490b-9bd7-6a6a2322f44b.png)


#### Changelog

![image](https://user-images.githubusercontent.com/4130121/133124146-5e46da3b-b22e-4d9c-bc78-5a3ad7737ada.png)


## Labels
- [ ] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
