### PR TITLE
Remove providers index symlink

### DIFF
--- a/content/source/docs/providers/index.html.markdown
+++ b/content/source/docs/providers/index.html.markdown
@@ -1,1 +1,0 @@
-../../../../ext/terraform/website/docs/providers/index.html.markdown


### PR DESCRIPTION
This PR removes the symlink at `./content/source/docs/providers/index.html.markdown`.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
