### PR TITLE
Make old version of TFE logging page available.

### DIFF
--- a/content/source/docs/enterprise/admin/logging-old.html.md
+++ b/content/source/docs/enterprise/admin/logging-old.html.md
@@ -1,0 +1,88 @@
+---
+layout: "enterprise"
+page_title: "Logging (Pre-v202109-1) - Infrastructure Administration - Terraform Enterprise"
+---
+
+# Terraform Enterprise Logs
+
+This document contains information about interacting with Terraform Enterprise logs previous to release v202109-1. If you have updated to v202109-1 or later, please refer to the [latest version of this page[(/docs/enterprise/install/logging.html).
+
+There are two types of logs, application logs and audit logs. Application logs emit information about the services that comprise Terraform Enterprise. Audit logs emit information whenever any resource managed by Terraform Enterprise is changed.
+
+## Application Logs
+
+Terraform Enterprise runs in a set of Docker containers. As such, any tooling that can interact with Docker logs can read the logs. This includes the command `docker logs`, as well as access via the [Docker API](https://docs.docker.com/engine/api/v1.36/#operation/ContainerLogs).
+
+An example of a tool that can automatically pull logs for all docker containers is [logspout](https://github.com/gliderlabs/logspout).
+Logspout can be configured to take the Docker logs and send them to a syslog endpoint. Here's an example invocation:
+
+```shell
+$ docker run --name="logspout" \
+  --volume=/var/run/docker.sock:/var/run/docker.sock \
+  gliderlabs/logspout \
+  syslog+tls://logs.mycompany.com:55555
+```
+
+The logspout container uses the Docker API internally to find other running containers and ingress their logs, then send them to `logs.mycompany.com` on port 55555 using syslog with TCP/TLS.
+
+~> **NOTE:** While docker has support for daemon-wide log drivers that can send all logs for all containers to various services,
+   Terraform Enterprise only supports having the Docker `log-driver` configured to either `json-file` or `journald`.
+   All other log drivers prevent the support bundle functionality from gathering logs, making it
+   impossible to provide product support. **DO NOT** change the log driver of an installation to anything other than `json-file` or `journald`.
+
+## Audit Logs
+
+The audit logs are emitted along with other logs by the `ptfe_atlas` container. To distinguish audit log entries from other log entries, the JSON is prefixed with `[Audit Log]`. For example:
+
+```
+2018-03-27 21:55:29 [INFO] [Audit Log] {"resource":"oauth_client","action":"create","resource_id":"oc-FErAhnuHHwcad3Kx","actor":"atlasint","timestamp":"2018-03-27T21:55:29Z","actor_ip":"11.22.33.44"}
+```
+
+### Log Contents
+
+The audit log will be updated when any resource managed by Terraform Enterprise is changed. Read requests will be logged for resources deemed sensitive. These include:
+
+  * Authentication Tokens
+  * Configuration Versions
+  * Policy Versions
+  * OAuth Tokens
+  * SSH Keys
+  * State Versions
+  * Users
+  * Variables
+
+When requests occur, these pieces of information will be logged:
+
+  1. The actor
+    * Users (including IP address)
+    * Version Control System users (identified in webhooks)
+    * Service accounts
+    * Terraform Enterprise
+  2. The action
+    * Reading sensitive resources
+    * Creation of new resources
+    * Updating existing resources
+    * Deletion of existing resources
+    * Additional actions as defined in /actions/* namespaces
+    * Webhook API calls
+  3. The target of the action (any resource exposed by the V2 API)
+  4. The time that the action occurred
+  5. Where the action was taken (web/API request, background job, etc.)
+
+### Log Format
+
+Log entries are in JSON, just like other Terraform Enterprise logs. Most audit log entries are formatted like this:
+
+``` json
+{
+  "timestamp": "2017-12-19T15:23:45.148Z",
+  "resource": "workspace",
+  "action": "destroy",
+  "resource_id": "ws-9a3hrbYfFsTzg2FZ",
+  "actor": "jsmith",
+  "actor_ip": "94.122.17.37"
+}
+```
+
+Certain entries will contain additional information in the payload, but all audit log entries will contain the above keys.
+

--- a/content/source/docs/enterprise/admin/logging-old.html.md
+++ b/content/source/docs/enterprise/admin/logging-old.html.md
@@ -5,7 +5,7 @@ page_title: "Logging (Pre-v202109-1) - Infrastructure Administration - Terraform
 
 # Terraform Enterprise Logs
 
-This document contains information about interacting with Terraform Enterprise logs previous to release v202109-1. If you have updated to v202109-1 or later, please refer to the [latest version of this page[(/docs/enterprise/install/logging.html).
+This document contains information about interacting with Terraform Enterprise logs previous to release v202109-1. If you have updated to v202109-1 or later, please refer to the [latest version of this page[(/docs/enterprise/admin/logging.html).
 
 There are two types of logs, application logs and audit logs. Application logs emit information about the services that comprise Terraform Enterprise. Audit logs emit information whenever any resource managed by Terraform Enterprise is changed.
 

--- a/content/source/docs/enterprise/admin/logging.html.md
+++ b/content/source/docs/enterprise/admin/logging.html.md
@@ -316,4 +316,4 @@ recommend forwarding all Terraform Enterprise logs to a log aggregation system,
 filtering the audit logs based on the `[Audit Log]` string, and forwarding just
 the audit logs to the desired destination.
 
--> **Note:** You can find the previous version of this webpage with logspout information (for releases prior to v202109-1), [here](/docs/enterprise/admin/logging-old.html). 
+-> **Note:** You can find documentation for versions of Terraform Enterprise prior to v202109-1 on the [previous version of this webpage](/docs/enterprise/admin/logging-old.html). 

--- a/content/source/docs/enterprise/admin/logging.html.md
+++ b/content/source/docs/enterprise/admin/logging.html.md
@@ -316,4 +316,4 @@ recommend forwarding all Terraform Enterprise logs to a log aggregation system,
 filtering the audit logs based on the `[Audit Log]` string, and forwarding just
 the audit logs to the desired destination.
 
--> **Note:** You can find the previous version of this webpage with logspout information (for releases prior to v202109-1), [here](/docs/enterprise/install/logging-old.html). 
+-> **Note:** You can find the previous version of this webpage with logspout information (for releases prior to v202109-1), [here](/docs/enterprise/admin/logging-old.html). 

--- a/content/source/docs/enterprise/admin/logging.html.md
+++ b/content/source/docs/enterprise/admin/logging.html.md
@@ -316,4 +316,4 @@ recommend forwarding all Terraform Enterprise logs to a log aggregation system,
 filtering the audit logs based on the `[Audit Log]` string, and forwarding just
 the audit logs to the desired destination.
 
--> **Note:** You can find documentation for versions of Terraform Enterprise prior to v202109-1 on the [previous version of this webpage](/docs/enterprise/admin/logging-old.html). 
+-> **Note:** -> **Note:** If you are using a version of Terraform Enterprise prior to v202109-1, please refer to the [previous version of this page](/docs/enterprise/admin/logging-old.html) with logspout information.

--- a/content/source/docs/enterprise/admin/logging.html.md
+++ b/content/source/docs/enterprise/admin/logging.html.md
@@ -315,3 +315,5 @@ If you have a requirement to split audit logs from application logs, we
 recommend forwarding all Terraform Enterprise logs to a log aggregation system,
 filtering the audit logs based on the `[Audit Log]` string, and forwarding just
 the audit logs to the desired destination.
+
+-> **Note:** You can find the previous version of this webpage with logspout information (for releases prior to v202109-1), [here](/docs/enterprise/install/logging-old.html). 

--- a/content/source/docs/enterprise/install/uninstall.html.md
+++ b/content/source/docs/enterprise/install/uninstall.html.md
@@ -241,6 +241,6 @@ If the system cannot reach [install.terraform.io][install]:
 
 
 
-[install]: https://install.terraform.io
+[install]: https://install.terraform.io/tfe/uninstall
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 [support]: https://support.hashicorp.com


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)

Support requested the old logging documentation be restored for customers who have not updated to the latest version of TFE. This PR adds back the old page via a link on the new one, without adding it to the sidebar. This is a temporary addition. 