### PR TITLE
Update alert banner for HashiConf Global 2021

### DIFF
--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -54,7 +54,7 @@
   </head>
 
   <body id="<%= body_id_for(current_page) %>" class="<%= body_classes_for(current_page) %>">
-    <%= partial("layouts/alert_banner", locals: {show: true, theme: 'terraform', url:"https://hashiconf.com/europe/?utm_source=DocsBanner", tag:"Thank you", text:"HashiConf Europe is a wrap. Watch this year’s sessions on-demand.", cta:"Watch Now"}) %>
+    <%= partial("layouts/alert_banner", locals: {show: true, theme: 'terraform', url:"https://hashiconf.com/global/?utm_campaign=22Q3_WW_HASHICONFGLOBAL_EVENT-USER&utm_source=CorpBanner&utm_medium=EVT&utm_offer=EVENT-USER", tag:"Oct 19-21", text:"The countdown to HashiConf Global is on. View the full schedule now.", cta:"View Schedule"}) %>
 
     <header class="hashiStackMenuRoot hashiStackMenu">
             <nav class="nav g-container">


### PR DESCRIPTION
This PR adjusts the alert banner to link to the HashiConf Global 2021 site.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [x] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
