### PR TITLE
Fix typo

### DIFF
--- a/content/source/docs/cloud/workspaces/naming.html.md
+++ b/content/source/docs/cloud/workspaces/naming.html.md
@@ -23,7 +23,7 @@ A good strategy to start with is `<COMPONENT>-<ENVIRONMENT>-<REGION>`. For examp
 - networking-staging-eu-central
 - monitoring-prod-us-east
 - monitoring-staging-us-east
-- monitoring-prod-us-eu-central
+- monitoring-prod-eu-central
 - monitoring-staging-eu-central
 
 If those three attributes can't uniquely distinguish all of your workspaces, you might need to add another attribute; for example, the infrastructure provider (AWS, GCP, Azure), datacenter, or line of business.


### PR DESCRIPTION
Remove extra "us-" from example workspace name

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
