### PR TITLE
Correct headers for October release notes

### DIFF
--- a/content/source/docs/enterprise/release/v202110-1.html.md
+++ b/content/source/docs/enterprise/release/v202110-1.html.md
@@ -5,16 +5,15 @@ page_title: "Releases - Terraform Enterprise"
 
 # TFE Release v202110-1 (576)
 
-INSTALLER LEVEL FEATURES:
+## Installer Level Features
 
 1. RHEL 8 is now supported via the Replicated installer
 2. RHEL 7.9 is now supported as an Alternative Worker Image
-
-APPLICATION LEVEL FEATURES:
+## Application Level Features
 
 1. Added a clear filters link to private module search results
 
-APPLICATION LEVEL BUG FIXES:
+## Application Level Bug Fixes
 
 1. Updated Vault to version 1.8.4 to fix an issue where database connections were not properly being removed from the connection pool.
 1. Fixed an issue where fetching structured run output for a plan would result in a 500 status code.
@@ -27,6 +26,7 @@ APPLICATION LEVEL BUG FIXES:
 1. Fixed Cost Estimation failure when looking up Elastisearch costs when using deprecated instance names ending in `elastisearch`.
 1. Fixed issue where invalid UTF-8 characters in README can result in errors loading Workspaces.
 
-APPLICATION LEVEL SECURITY FIXES:
+## Application Level Security Fixes
+
 1. Ongoing container updates to address reported vulnerabilities in underlying packages / dependencies.
 


### PR DESCRIPTION
October release notes went out with incorrect markdown on the headers. This fixes that! 