### PR TITLE
adding docs link for infracost

### DIFF
--- a/content/source/docs/cloud/integrations/run-tasks/index.html.md
+++ b/content/source/docs/cloud/integrations/run-tasks/index.html.md
@@ -89,13 +89,15 @@ Bridgecrew helps teams address security and compliance errors in Terraform as pa
 
 To get started, sign up for an eligible [pricing](https://bridgecrew.io/pricing/) plan, and follow the instructions in the [Integration via Run Tasks](https://docs.bridgecrew.io/docs/integrate-with-terraform-cloud#integration-via-run-tasks) user documentation.
 
-### cloudtamer.io
-
-When using cloudtamer.io, customers can choose to focus on cost savings or compliance findings on an active account.
-
 ### Infracost
 
 Infracost allows for cloud infrastructure costing, initiated right from a PR or Terraform run.
+
+To get started, [sign up](https://dashboard.infracost.io/tfc-sign-up) for the Infracost Terraform Cloud integration, and follow the instructions in the [Terraform Cloud Run Tasks](https://www.infracost.io/docs/iac_tools/terraform_cloud_enterprise#terraform-cloud-run-tasks) user documentation.
+
+### cloudtamer.io
+
+When using cloudtamer.io, customers can choose to focus on cost savings or compliance findings on an active account.
 
 ### Lightlytics
 


### PR DESCRIPTION
Update to the Run Tasks Integration docs that includes instructions for the setup of the [Infracost](https://www.infracost.io/docs/iac_tools/terraform_cloud_enterprise) Terraform Cloud Run Task integration. 

## Labels

- [ ] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
