### PR TITLE
Add note that module provider must be lowercase

### DIFF
--- a/content/source/docs/cloud/api/modules.html.md
+++ b/content/source/docs/cloud/api/modules.html.md
@@ -360,7 +360,7 @@ Key path                        | Type   | Default | Description
 --------------------------------|--------|---------|------------
 `data.type`                     | string |         | Must be `"registry-modules"`.
 `data.attributes.name`          | string |         | The name of this module. May contain alphanumeric characters, with dashes and underscores allowed in non-leading or trailing positions. Maximum length is 64 characters.
-`data.attributes.provider`      | string |         | Specifies the Terraform provider that this module is used for. May contain alphanumeric characters. Maximum length is 64 characters.
+`data.attributes.provider`      | string |         | Specifies the Terraform provider that this module is used for. May contain lowercase alphanumeric characters. Maximum length is 64 characters.
 `data.attributes.namespace`     | string |         | The namespace of this module. Cannot be set for private modules. May contain alphanumeric characters, with dashes and underscores allowed in non-leading or trailing positions. Maximum length is 64 characters.
 `data.attributes.registry-name` | string |         | Indicates whether this is a publicly maintained module or private. Must be either `public` or `private`.
 
@@ -372,7 +372,6 @@ Key path                        | Type   | Default | Description
     "type": "registry-modules",
     "attributes": {
       "name": "my-module",
-      "namespace": "my-organization",
       "provider": "aws",
       "registry-name": "private"
     }
@@ -619,7 +618,7 @@ curl \
 
 After the registry module version is successfully parsed, its status will become `"ok"`.
 
-## GET a Module
+## Get a Module
 
 ~> **Deprecation warning**: the following endpoint `GET /registry-modules/show/:organization_name/:name/:provider` is replaced by the below endpoint and will be removed from future versions of the API!
 
@@ -633,7 +632,7 @@ Parameter            | Description
 `:organization_name` | The name of the organization the module belongs to.
 `:namespace`         | The namespace of the module. For private modules this is the name of the organization that owns the module.
 `:name`              | The module name.
-`:provider`          | The module provider.
+`:provider`          | The module provider. Must be lowercase alphanumeric.
 `:registry-name`     | Either `public` or `private`.
 
 Status  | Response                                           | Reason

--- a/content/source/docs/cloud/registry/publish.html.md
+++ b/content/source/docs/cloud/registry/publish.html.md
@@ -31,10 +31,11 @@ A module repository must meet all of the following requirements before you can a
   your configured [VCS providers][vcs], and Terraform Cloud's VCS user account must have admin access to the repository. The registry needs admin access to create the webhooks to import new module versions. GitLab repositories must be in the main organization or group, and not in any subgroups.
 
 - **Named `terraform-<PROVIDER>-<NAME>`:** Module repositories must use this
-  three-part name format, where `<NAME>` reflects the type of infrastructure the
-  module manages and `<PROVIDER>` is the main provider where it creates that
-  infrastructure. The `<NAME>` segment can contain additional hyphens. Examples:
-  `terraform-google-vault` or `terraform-aws-ec2-instance`.
+  three-part name format, where `<NAME>` reflects the type of infrastructure
+  the module manages and `<PROVIDER>` is the main provider where it creates that
+  infrastructure. The `<PROVIDER>` segment must be all lowercase. The `<NAME>`
+  segment can contain additional hyphens. Examples: `terraform-google-vault` or
+  `terraform-aws-ec2-instance`.
 
 - **Standard module structure:** The module must adhere to the
   [standard module structure](/docs/language/modules/develop/structure.html).


### PR DESCRIPTION
This PR adds some clarification that module providers must be lowercase. It also fixes an inaccuracy with the sample payload for creating a private registry module.