### PR TITLE
Bump json gem to 1.8.5

### DIFF
--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       uber (~> 0.0.14)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    json (1.8.3.1)
+    json (1.8.5)
     kramdown (1.17.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
This PR updates the `json` gem to version 1.8.5.

### Why?

If you want to run the link checker locally, you may see this error installing the dependencies in ./content/Gemfile:

```
Your bundle is locked to json (1.8.3.1), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of json
(1.8.3.1) has removed it. You'll need to update your bundle to a version other than json (1.8.3.1) that hasn't been removed in order to install.
```

Indeed, this version is no longer available on [RubyGems.org](https://rubygems.org/gems/json/versions/).

### Testing

1. Checkout this branch
2. Run the link checker:

```shell
$ cd content
$ bundle install
$ git diff --name-only -z --diff-filter=AMRCT $(git merge-base HEAD origin/master)..HEAD | bundle exec ./scripts/check-pr-links.rb
```

Should see:

```
Checking URLs in the following pages:


Results:
=== No broken links! ===
```

For additional testing, change an existing page with links, commit it, and run the link checker again.