### PR TITLE
Add redirect for partner integration program

### DIFF
--- a/content/redirects.txt
+++ b/content/redirects.txt
@@ -152,6 +152,7 @@
 /docs/plugin                                             /docs/extend/index.html
 /docs/plugin/                                            /docs/extend/index.html
 /docs/plugin/index.html                                  /docs/extend/index.html
+/guides/terraform-provider-development-program.html       /guides/terraform-integration-program.html
 
 # Move the docs about TFE runs
 /docs/enterprise/workspaces/run-basics.html              /docs/enterprise/run/index.html


### PR DESCRIPTION
Adding a redirect from 
https://www.terraform.io/guides/terraform-provider-development-program.html 
to 
https://www.terraform.io/guides/terraform-integration-program.html