### PR TITLE
Update CDKTF place in dropdown and sidebar

### DIFF
--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -8,10 +8,10 @@
     "Terraform CLI" => "/docs/cli/index.html",
     "Terraform Cloud" => "/docs/cloud/index.html",
     "Terraform Enterprise" => "/docs/enterprise/index.html",
-    "CDK for Terraform" => "/docs/cdktf/index.html",
     "Provider Use" => "/docs/language/providers/index.html",
     "Plugin Development" => "/docs/extend/index.html",
     "Terraform Registry Publishing" => "/docs/registry/index.html",
+    "CDK for Terraform" => "/docs/cdktf/index.html",
     "Glossary" => "/docs/glossary.html"
   }
 -%>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -257,11 +257,11 @@
                 <li><a data-track='docs-cli' href="/docs/cli/index.html">Terraform CLI</a></li>
                 <li><a data-track='docs-cloud' href="/docs/cloud/index.html">Terraform Cloud</a></li>
                 <li><a data-track='docs-ent' href="/docs/enterprise/index.html">Terraform Enterprise</a></li>
-                <li><a data-track='docs-cdktf' href="/docs/cdktf/index.html">CDK for Terraform</a></li>
                 <li><a data-track='docs-providers' href="/docs/language/providers/index.html">Provider Use</a></li>
                 <li><a data-track='docs-extending' href="/docs/extend/index.html">Plugin Development</a></li>
                 <li><a data-track='docs-registry' href="/docs/registry/index.html">Terraform Registry Publishing</a></li>
                 <li><a data-track='docs-registry' href="/guides/terraform-integration-program.html">Terraform Integration Program</a></li>
+                <li><a data-track='docs-cdktf' href="/docs/cdktf/index.html">CDK for Terraform</a></li>
                 <li><a data-track='docs-glossary' href="/docs/glossary.html">Glossary</a></li>
               EOT
             %>


### PR DESCRIPTION
Per conversations with the team, moving CDKTF docs to be right above glossary in the docs dropdown and docs sidebar. 
