### PR TITLE
Remove broken link from guides page

### DIFF
--- a/content/source/docs/cloud/guides/recommended-practices/part3.2.html.md
+++ b/content/source/docs/cloud/guides/recommended-practices/part3.2.html.md
@@ -65,7 +65,7 @@ If your organization already has a configuration management tool, then it’s ti
 
 If your organization doesn't use a configuration management tool yet, and the configuration of the infrastructure being managed is mutable, you should consider adopting a configuration management tool. This might be a large task, but it supports the same goals that drove you to infrastructure as code, by making application configuration more controllable, understandable, and repeatable across teams.
 
-If you’re just getting started, try this tutorial on how to [create a Chef cookbook](https://www.vagrantup.com/docs/provisioning/chef_solo.html) and test it locally with Vagrant. We also recommend this article about how to decide what [configuration management tool](https://www.edureka.co/blog/chef-vs-puppet-vs-ansible-vs-saltstack/) is best suited for your organization.
+If you’re just getting started, try this tutorial on how to [create a Chef cookbook](https://www.vagrantup.com/docs/provisioning/chef_solo.html) and test it locally with Vagrant. We also recommend this article about how to decide which [configuration management tool](https://www.edureka.co/blog/chef-vs-puppet-vs-ansible-vs-saltstack/) is best suited for your organization.
 
 ## 7. Manage Secrets
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-website/issues/1895

Removes a broken link from the recommended practices guide and fixes one typo. A user pointed out the broken link in the issue linked above. We added an alternative article to help users choose between configuration management tools, since it appears the original no longer exists. 