### PR TITLE
Zisom change permission statements

### DIFF
--- a/content/source/docs/cloud/api/configuration-versions.html.md
+++ b/content/source/docs/cloud/api/configuration-versions.html.md
@@ -26,7 +26,7 @@ page_title: "Configuration Versions - API Docs - Terraform Cloud and Terraform E
 
 A configuration version (`configuration-version`) is a resource used to reference the uploaded configuration files. It is associated with the run to use the uploaded configuration files for performing the plan and apply.
 
-Listing and viewing configuration versions for a workspace requires permission to read runs; creating new configuration versions requires permission to apply runs. ([More about permissions.](../users-teams-organizations/permissions.html))
+You need read runs permission to list and view configuration versions for a workspace, and you need apply runs permission to create new configuration versions. Refer to the [permissions](../users-teams-organizations/permissions.html##general-workspace-permissions) documentation for more details.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/api/configuration-versions.html.md
+++ b/content/source/docs/cloud/api/configuration-versions.html.md
@@ -26,7 +26,7 @@ page_title: "Configuration Versions - API Docs - Terraform Cloud and Terraform E
 
 A configuration version (`configuration-version`) is a resource used to reference the uploaded configuration files. It is associated with the run to use the uploaded configuration files for performing the plan and apply.
 
-Listing and viewing configuration versions for a workspace requires permission to read runs; creating new configuration versions requires permission to queue plans. ([More about permissions.](../users-teams-organizations/permissions.html))
+Listing and viewing configuration versions for a workspace requires permission to read runs; creating new configuration versions requires permission to apply runs. ([More about permissions.](../users-teams-organizations/permissions.html))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/run/api.html.md
+++ b/content/source/docs/cloud/run/api.html.md
@@ -29,7 +29,7 @@ The most significant difference in this workflow is that Terraform Cloud _does n
 
 Pushing a new configuration to an existing workspace is a multi-step process. This section walks through each step in detail, using an example bash script to illustrate.
 
-Creating new configuration versions requires permission to apply runs for the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+You need apply runs permission to create new configuration versions for the workspace. Refer to the [permissions](../users-teams-organizations/permissions.html##general-workspace-permissions) documentation for more details.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/run/api.html.md
+++ b/content/source/docs/cloud/run/api.html.md
@@ -29,7 +29,7 @@ The most significant difference in this workflow is that Terraform Cloud _does n
 
 Pushing a new configuration to an existing workspace is a multi-step process. This section walks through each step in detail, using an example bash script to illustrate.
 
-Creating new configuration versions requires permission to queue plans for the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+Creating new configuration versions requires permission to apply runs for the workspace. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 


### PR DESCRIPTION
A customer uncovered some incorrect statements within our documentation about what permissions are required for creating a configuration version. I've correct the two statements they noted were incorrect below and we confirmed this was the case internally.

Associated Zendesk ticket: https://hashicorp.zendesk.com/agent/tickets/58107
Associated Slack channel: #ticket-58107-

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [X] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
