### PR TITLE
Update RHEL worker section with UBI and envdir

### DIFF
--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -212,7 +212,7 @@ and apply operations will fail.
 FROM registry.access.redhat.com/ubi7/ubi-minimal:7.9-503
 
 # Update installed packages and clear cache
-RUN microdnf --assumeyes  update && rm --recursive --force /var/cache/yum
+RUN microdnf --assumeyes update && rm --recursive --force /var/cache/yum
 
 # Include all necessary CA certificates.
 ADD example-root-ca.crt /usr/share/pki/ca-trust-source/anchors

--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -179,7 +179,7 @@ TFE runs `terraform plan` and `terraform apply` operations in a disposable Docke
 - The image must exist on the Terraform Enterprise host. You can add it by running `docker pull` from a local registry or any other similar method.
 - The software packages defined in the examples below must be installed on the image.
 - All necessary PEM-encoded CA certificates must be placed within the `/usr/local/share/ca-certificates` directory. Each file added to this directory must end with the `.crt` extension. The CA certificates configured in the [CA Bundle settings](#certificate-authority-ca-bundle) will not be automatically added to this image at runtime.
-- Terraform must not be installed on the image. Terraform Enterprise will take care of that at runtime.
+- Terraform must not be installed on the image. Terraform Enterprise installs Terraform at runtime.
 
 Below are several example `Dockerfile` definitions you can use to start building your own image:
 

--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -203,10 +203,7 @@ RUN update-ca-certificates
 
 #### RHEL 7
 
-Note that in addition to the packages installed by yum, the Python port
-of the `envdir` tool is also installed as it is used by TFE. If this
-tool is not installed on the alternative worker image, Terraform plan
-and apply operations will fail.
+In addition to the packages that yum installs, curl installs the envdir tool Python port because it is a dependency of the Terraform Build Worker service. If the envdir tool is not installed on the alternative worker image, Terraform runs will fail within Terraform Enterprise.
 
 ```docker
 FROM registry.access.redhat.com/ubi7/ubi-minimal:7.9-503

--- a/content/source/docs/enterprise/install/installer.html.md
+++ b/content/source/docs/enterprise/install/installer.html.md
@@ -176,7 +176,7 @@ TFE runs `terraform plan` and `terraform apply` operations in a disposable Docke
 
 - The base image must be `ubuntu:bionic` or an [offical RHEL7 image](https://catalog.redhat.com/software/containers/search?p=1&vendor_name=Red%20Hat%2C%20Inc.&rows=60&product_listings_names=Red%20Hat%20Universal%20Base%20Image%207|Red%20Hat%20Enterprise%20Linux%207&build_categories_list=Base%20Image)
   (e.g., `registry.access.redhat.com/ubi7/ubi-minimal`).
-- The image must exist on the Terraform Enterprise host. It can be added by running `docker pull` from a local registry or any other similar method.
+- The image must exist on the Terraform Enterprise host. You can add it by running `docker pull` from a local registry or any other similar method.
 - The software packages defined in the examples below must be installed on the image.
 - All necessary PEM-encoded CA certificates must be placed within the `/usr/local/share/ca-certificates` directory. Each file added to this directory must end with the `.crt` extension. The CA certificates configured in the [CA Bundle settings](#certificate-authority-ca-bundle) will not be automatically added to this image at runtime.
 - Terraform must not be installed on the image. Terraform Enterprise will take care of that at runtime.


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)

This branch updates *Interactive Terraform Enterprise Installation: Alternative Terraform worker image*, specifically the instructions for building a RHEL image.

Red Hat's Universal Base Images are very small, and installing the envdir port is much simpler than involving a RedHat subscription just to build daemontools for its own version of envdir. These instructions have been validated within Terraform Enterprise's integration testing pipeline.