### PR TITLE
clean up indentation on the v202110-1 release notes

### DIFF
--- a/content/source/docs/enterprise/release/v202110-1.html.md
+++ b/content/source/docs/enterprise/release/v202110-1.html.md
@@ -9,8 +9,8 @@ page_title: "Releases - Terraform Enterprise"
 
 1. RHEL 8 is now supported via the Replicated installer
 2. RHEL 7.9 is now supported as an Alternative Worker Image
-## Application Level Features
 
+## Application Level Features
 1. Added a clear filters link to private module search results
 
 ## Application Level Bug Fixes


### PR DESCRIPTION
Fixed the indentation on the Terraform Enterprise `v202110-1` [release notes](https://www.terraform.io/docs/enterprise/release/v202110-1.html) (`Application Level Features` is indented under the `Installer Level Features` section).

Before:

![Screen Shot 2021-10-28 at 12 19 15 PM](https://user-images.githubusercontent.com/5195704/139321820-dd1176b3-23fb-45b7-9a32-b7af3e7c082e.png)


After:

![Screen Shot 2021-10-28 at 12 19 08 PM](https://user-images.githubusercontent.com/5195704/139321850-523d5f67-9092-49d4-92ed-51ac288dcf4c.png)


- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [x] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
