### PR TITLE
Add Terraform Integration Program to sidebar

### DIFF
--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -11,6 +11,7 @@
     "Provider Use" => "/docs/language/providers/index.html",
     "Plugin Development" => "/docs/extend/index.html",
     "Terraform Registry Publishing" => "/docs/registry/index.html",
+    "Terraform Integration Program" => "/guides/terraform-integration-program.html",
     "CDK for Terraform" => "/docs/cdktf/index.html",
     "Glossary" => "/docs/glossary.html"
   }


### PR DESCRIPTION
Add the Terraform Integration Program page to the sidebar - it's already in the main site dropdown :-) 
