### PR TITLE
Various improvements to Enforce and Override page

### DIFF
--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -11,16 +11,16 @@ description: |-
 
 > **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
-Once a policy is added to an organization it is enforced on all runs.
+Policies are defined within policy sets which can be applied to selected or to all workspaces in an organization. Once a policy set is added to an organization, all of its policies are enforced on all runs in those workspaces to which the policy set is applied.
 
-The policy check will occur immediately after a plan is successfully executed in the run. If the plan fails, the policy check will not be performed. The policy check uses the generated tfplan file, [simulated apply object](./import/tfplan.html#value-applied), state and configuration to verify the rules in each of the policies.
+The policy checks will occur after a plan is successfully executed in the run. However, if cost estimates are enabled on the workspace, then the policy checks occur after the cost estimates are executed. This allows the policies to restrict costs based on the data in the cost estimates. If the plan fails, the policy checks will not be performed. The policy checks use data provided to Sentinel from the plan, state, configuration, workspace, and run to verify the rules in each of the policies.
 
 Enforcement level details can be found in the [Managing Policies](./manage-policies.html) documentation.
 
-All `hard mandatory` and `soft mandatory` policies must pass in order for the run to continue to the "Confirm & Apply" state.
+All `hard-mandatory` must pass in order for the run to continue to the "Confirm & Apply" state. All `soft-mandatory` policies must pass or be overridden for the run to contineu to the "Confirm & Apply" state.
 
-If a `soft mandatory` policy fails, users with permission to override policies will be presented with an "Override & Continue" button in the run. They have the ability to override the failed check and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html))
+If any `soft-mandatory` policies fail and no `hard-mandatory` policies fail, users with permission to override policies will be presented with an "Override & Continue" button in the run in the Terraform Cloud workspace. They have the ability to override the failed `soft-mandatory` policy checks and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html)) Those same users can also override `soft-mandatory` policies when running the `terrform apply` command with the Terraform CLI by typing "override" when promoted to override failed `soft-mandatory` policies for the run.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-If an `advisory` fails, it will show the warning state in the run; however, the execution of the run will continue to the "Confirm & Apply" state. No user action is required to override or continue the run execution.
+If an `advisory` policy check fails, it will show the warning state in the run; however, the execution of the run will continue to the "Confirm & Apply" state. No user action is required to override or continue the run execution.

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -11,7 +11,7 @@ description: |-
 
 > **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
 
-Policies are defined within policy sets which can be applied to selected or to all workspaces in an organization. Once a policy set is added to an organization, all of its policies are enforced on all runs in those workspaces to which the policy set is applied.
+You can define individual policies within larger policy sets and apply those policy sets to all or a subset of workspaces in an organization. Terraform Cloud then enforces all of those policies on every workspace run.  
 
 The policy checks will occur after a plan is successfully executed in the run. However, if cost estimates are enabled on the workspace, then the policy checks occur after the cost estimates are executed. This allows the policies to restrict costs based on the data in the cost estimates. If the plan fails, the policy checks will not be performed. The policy checks use data provided to Sentinel from the plan, state, configuration, workspace, and run to verify the rules in each of the policies.
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -15,7 +15,7 @@ You can define individual policies within larger policy sets and apply those pol
 
 Policy checks occur after a plan and any enabled cost estimates are successfully executed in the run. This allows policies to restrict costs based on the data in the cost estimates. If the plan fails, Sentinel does not perform policy checks. The policy checks use data from the plan, state, configuration, workspace, and run to verify and enforce the rules in each policy.
 
-Enforcement level details can be found in the [Managing Policies](./manage-policies.html) documentation.
+Refer to the [Managing Policies](./manage-policies.html) documentation for more detail about enforcement.
 
 All `hard-mandatory` must pass in order for the run to continue to the "Confirm & Apply" state. All `soft-mandatory` policies must pass or be overridden for the run to continue to the "Confirm & Apply" state.
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -19,7 +19,9 @@ Refer to the [Managing Policies](./manage-policies.html) documentation for more 
 
 All `hard-mandatory` must pass in order for the run to continue to the "Confirm & Apply" state. All `soft-mandatory` policies must pass or be overridden for the run to continue to the "Confirm & Apply" state.
 
-If any `soft-mandatory` policies fail and no `hard-mandatory` policies fail, users with permission to override policies will be presented with an "Override & Continue" button in the run in the Terraform Cloud workspace. They have the ability to override the failed `soft-mandatory` policy checks and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html)) Those same users can also override `soft-mandatory` policies when running the `terrform apply` command with the Terraform CLI by typing "override" when promoted to override failed `soft-mandatory` policies for the run.
+If any `soft-mandatory` policies fail and no `hard-mandatory` policies fail, users with [permission to override policies](/docs/cloud/users-teams-organizations/permissions.html#manage-policy-overrides) will be presented with an **Override & Continue** button in the run in the Terraform Cloud workspace. This allows them to override the failed `soft-mandatory` policy checks and continue the execution of the run. This will not have any impact on future runs. 
+
+These users can also override `soft-mandatory` policies by running the `terraform apply` command and then entering "override" when prompted to override failed `soft-mandatory` policies for the run.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -17,7 +17,7 @@ The policy checks will occur after a plan is successfully executed in the run. H
 
 Enforcement level details can be found in the [Managing Policies](./manage-policies.html) documentation.
 
-All `hard-mandatory` must pass in order for the run to continue to the "Confirm & Apply" state. All `soft-mandatory` policies must pass or be overridden for the run to contineu to the "Confirm & Apply" state.
+All `hard-mandatory` must pass in order for the run to continue to the "Confirm & Apply" state. All `soft-mandatory` policies must pass or be overridden for the run to continue to the "Confirm & Apply" state.
 
 If any `soft-mandatory` policies fail and no `hard-mandatory` policies fail, users with permission to override policies will be presented with an "Override & Continue" button in the run in the Terraform Cloud workspace. They have the ability to override the failed `soft-mandatory` policy checks and continue the execution of the run. This will not have any impact on future runs. ([More about permissions.](/docs/cloud/users-teams-organizations/permissions.html)) Those same users can also override `soft-mandatory` policies when running the `terrform apply` command with the Terraform CLI by typing "override" when promoted to override failed `soft-mandatory` policies for the run.
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -13,7 +13,7 @@ description: |-
 
 You can define individual policies within larger policy sets and apply those policy sets to all or a subset of workspaces in an organization. Terraform Cloud then enforces all of those policies on every workspace run.  
 
-The policy checks will occur after a plan is successfully executed in the run. However, if cost estimates are enabled on the workspace, then the policy checks occur after the cost estimates are executed. This allows the policies to restrict costs based on the data in the cost estimates. If the plan fails, the policy checks will not be performed. The policy checks use data provided to Sentinel from the plan, state, configuration, workspace, and run to verify the rules in each of the policies.
+Policy checks occur after a plan and any enabled cost estimates are successfully executed in the run. This allows policies to restrict costs based on the data in the cost estimates. If the plan fails, Sentinel does not perform policy checks. The policy checks use data from the plan, state, configuration, workspace, and run to verify and enforce the rules in each policy.
 
 Enforcement level details can be found in the [Managing Policies](./manage-policies.html) documentation.
 

--- a/content/source/docs/cloud/sentinel/enforce.html.md
+++ b/content/source/docs/cloud/sentinel/enforce.html.md
@@ -25,4 +25,4 @@ These users can also override `soft-mandatory` policies by running the `terrafor
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-If an `advisory` policy check fails, it will show the warning state in the run; however, the execution of the run will continue to the "Confirm & Apply" state. No user action is required to override or continue the run execution.
+If an `advisory` policy check fails, it will show the warning state in the run, and the execution of the run will continue to the "Confirm & Apply" state. No user action is required to override or continue the run execution.


### PR DESCRIPTION
I added reference to overriding soft-mandatory policies in the Terraform CLI.
I use "soft-mandatory" and "hard-mandatory" to better confirm to what is used in sentinel.hcl policy set definition files.
I clarified the logic of when overriding is allowed.
I refer to multiple policy checks rather than singular ones.