### PR TITLE
Update docs sidebar and dropdown

### DIFF
--- a/content/source/layouts/_otherdocs.erb
+++ b/content/source/layouts/_otherdocs.erb
@@ -10,8 +10,8 @@
     "Terraform Enterprise" => "/docs/enterprise/index.html",
     "Provider Use" => "/docs/language/providers/index.html",
     "Plugin Development" => "/docs/extend/index.html",
-    "Terraform Registry Publishing" => "/docs/registry/index.html",
-    "Terraform Integration Program" => "/guides/terraform-integration-program.html",
+    "Registry Publishing" => "/docs/registry/index.html",
+    "Integration Program" => "/guides/terraform-integration-program.html",
     "CDK for Terraform" => "/docs/cdktf/index.html",
     "Glossary" => "/docs/glossary.html"
   }

--- a/content/source/layouts/extend.erb
+++ b/content/source/layouts/extend.erb
@@ -176,7 +176,7 @@
       </li>
 
       <li>
-        <a href="/guides/terraform-integration-program.html">Partner Integration Program</a>
+        <a href="/guides/terraform-integration-program.html">Terraform Integration Program</a>
       </li>
 
       <li>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -259,8 +259,8 @@
                 <li><a data-track='docs-ent' href="/docs/enterprise/index.html">Terraform Enterprise</a></li>
                 <li><a data-track='docs-providers' href="/docs/language/providers/index.html">Provider Use</a></li>
                 <li><a data-track='docs-extending' href="/docs/extend/index.html">Plugin Development</a></li>
-                <li><a data-track='docs-registry' href="/docs/registry/index.html">Terraform Registry Publishing</a></li>
-                <li><a data-track='docs-registry' href="/guides/terraform-integration-program.html">Terraform Integration Program</a></li>
+                <li><a data-track='docs-registry' href="/docs/registry/index.html">Registry Publishing</a></li>
+                <li><a data-track='docs-registry' href="/guides/terraform-integration-program.html">Integration Program</a></li>
                 <li><a data-track='docs-cdktf' href="/docs/cdktf/index.html">CDK for Terraform</a></li>
                 <li><a data-track='docs-glossary' href="/docs/glossary.html">Glossary</a></li>
               EOT


### PR DESCRIPTION
Recently, we added the [Terraform Integration Program](https://www.terraform.io/guides/terraform-integration-program.html#terraform-cloud-integrations) page to the documentation site. It helps our integration partners understand what types of integrations they can create and how to work with HashiCorp to get their integrations verified.

Currently, the integration program is listed at the highest level of the documentation, meaning that it is specifically linked in the documentation dropdown menu and the main sidebar. The addition of this page made the dropdown very long and also harder to parse because there are so many items that start with "Terraform." We understand that these are official programs and products (with Terraform being a part of the official name), but we think that in these specific cases, users will be scanning for the keywords "integration" and "registry." Removing "Terraform" from in front of these two items makes it easier for users to see those keywords and also makes these menu items fit on one line, making the dropdown and sidebar shorter and less overwhelming. We will absolutely refer to the integration program and the Terraform Registry by their official names on their respective pages, but we think that this change is necessary to improver user experience. 

We also made one small change to the  plugin sidebar - previously the listing said "Partner  Integration Program" but the official program name is "Terraform Integration Program", so the sidebar listing has been updated to reflect this.

Here is a before and after shot of the dropdown menu, demonstrating the impact of this change:

**Before**
<img width="215" alt="before" src="https://user-images.githubusercontent.com/83350965/140572195-1281a88a-e3a5-4632-9bf3-d90420a1f495.png">

**After**
<img width="199" alt="after" src="https://user-images.githubusercontent.com/83350965/140572203-ccadc261-b587-4515-98c0-77f6dfef62bd.png">

blocked by: https://github.com/hashicorp/terraform-website-next/pull/101 