### PR TITLE
Sentinel mocks are available indefinitely

### DIFF
--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -276,5 +276,3 @@ If a plan cannot have its mock data exported due to any of these reasons, the
 not be visible.
 
 -> **Note:** Only a successful plan is required for mock generation. Sentinel can still generate the data if apply or policy checks fail.
-mock generation - if the apply or the policy checks fail, the data can still be
-generated.

--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -267,7 +267,7 @@ The following factors can prevent you from generating mock data:
   produced via mock generation.
 * The run has not progressed past the planning stage, or did not create a plan
   successfully.
-* The run had progressed past the planning stage prior to July 23, 2021. Prior to this date, JSON plans were only kept for 7 days.
+* The run progressed past the planning stage prior to July 23, 2021. Prior to this date, Terraform Cloud only kept JSON plans for 7 days.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -267,9 +267,7 @@ The following factors can prevent you from generating mock data:
   produced via mock generation.
 * The run has not progressed past the planning stage, or did not create a plan
   successfully.
-* The run has been in a terminal state, such as applied or discarded, longer
-  than seven days. At this point, the data necessary to generate the mocks is no
-  longer available.
+* The run had progressed past the planning stage prior to July 23, 2021. Prior to this date, JSON plans were only kept for 7 days.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -279,4 +277,4 @@ not be visible.
 
 -> **Note:** Only the plan needs to be successful for a run to be eligible for
 mock generation - if the apply or the policy checks fail, the data can still be
-generated, as long as it's within the 7 day expiration period.
+generated.

--- a/content/source/docs/cloud/sentinel/mock.html.md
+++ b/content/source/docs/cloud/sentinel/mock.html.md
@@ -275,6 +275,6 @@ If a plan cannot have its mock data exported due to any of these reasons, the
 **Download Sentinel mocks** button within the plan status section of the UI will
 not be visible.
 
--> **Note:** Only the plan needs to be successful for a run to be eligible for
+-> **Note:** Only a successful plan is required for mock generation. Sentinel can still generate the data if apply or policy checks fail.
 mock generation - if the apply or the policy checks fail, the data can still be
 generated.


### PR DESCRIPTION
Prior to July 23, 2021, the JSON plan output was deleted 7 days after it was generated. This limited Sentinel mock generation to that time period as it relies on the JSON plan output. They are now available longer than 7 days, which makes mock generation available for longer too.

<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
