### PR TITLE
Migrate Event Hooks to Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ This repository contains the build infrastructure and some of the content for [t
 
 - Fastly handles all the traffic.
 - The following paths (all marketing content, at the moment) are proxied to a Next.js app running on Vercel:
-    - `/` (the front page)
-    - `/community`
-    - `/cloud` (and all sub-paths under `/cloud`)
 
-    For help with these pages, talk to the Web Platform team!
+  - `/` (the front page)
+  - `/community`
+  - `/cloud` (and all sub-paths under `/cloud`)
+
+  For help with these pages, talk to the Web Platform team!
+
 - The rest of the site falls through to static pages built with [Middleman][]. That's what this repository manages!
 
 ## Where the Docs Live
@@ -43,17 +45,21 @@ This repository contains the build infrastructure and some of the content for [t
 Docs live in a couple different repos. (**To find a page the easy way:** view it on [terraform.io][] and click the "Edit this page" link at the bottom.)
 
 - This repository, under `content/source/docs/`:
-    - Terraform Cloud docs
-    - Terraform Enterprise docs
-    - Plugin Development
-    - Terraform Registry Publishing
 
-    **Notable branches:** `master` is the "live" content that gets deployed to terraform.io. The site gets redeployed for new commits to master.
+  - Terraform Cloud docs
+  - Terraform Enterprise docs
+  - Plugin Development
+  - Terraform Registry Publishing
+
+  **Notable branches:** `master` is the "live" content that gets deployed to terraform.io. The site gets redeployed for new commits to master.
+
 - [hashicorp/terraform][tf-repo], under `website/docs`:
-    - Terraform CLI docs
-    - Terraform Language docs
 
-    **Notable branches:** `stable-website` is the "live" content that gets deployed to terraform.io, but docs changes should get merged to master (and/or one of the long-lived version branches) first. See [More About `stable-website`][inpage-stable] below for more details.
+  - Terraform CLI docs
+  - Terraform Language docs
+
+  **Notable branches:** `stable-website` is the "live" content that gets deployed to terraform.io, but docs changes should get merged to `master` (and/or one of the long-lived version branches) first. See [More About `stable-website`][inpage-stable] below for more details.
+
 - A few remaining provider repos... but those won't be here for long! All but a few have migrated to [the Registry](https://registry.terraform.io), and the rest are leaving soon.
 
 ## Deploying Changes to [terraform.io][]
@@ -65,21 +71,27 @@ Docs live in a couple different repos. (**To find a page the easy way:** view it
 Merge the PR to master, and the site will automatically deploy in about 20m. 🙌
 
 ### For changes in `hashicorp/terraform`
+
 Merge the PR to main. The changes will appear in the next major Terraform release.
 
 If you need your changes to be deployed sooner, cherry-pick them to:
+
 - the current release branch (e.g. `v1.0`) and push. They will be deployed in the next minor version release (once every two weeks).
 - the `stable-website` branch and push. They will be included in the next site deploy (see below). Note that the release process resets `stable-website` to match the release tag, removing any additional commits. So, we recommend always cherry-picking to the version branch first and then to `stable-website` when needed.
 
-### Deployment
-Currently, HashiCorp uses a CircleCI job to deploy the [terraform.io](terraform.io) site. This job can be run manually by many people within HashiCorp, and also runs automatically whenever a user in the HashiCorp GitHub org merges changes to master in this repository. Note that Terraform releases create sync commits to `terraform-website`, which will trigger a deploy.
+#### Backport Tags
 
+Instead of cherry-picking your commits to a specific version branch, you can add the associated backport tag (e.g., "1.1-backport") to your pull request before merging. After you merge, a bot automatically creates a pull request to add your commits to the version branch (linked in your original PR). You must manually merge the auto-generated PR into the version branch.
+
+### Deployment
+
+Currently, HashiCorp uses a CircleCI job to deploy the [terraform.io](terraform.io) site. Many people within HashiCorp can run this job manually, and it also runs automatically whenever a user in the HashiCorp GitHub org merges changes to `master` in this repository. Note that Terraform releases create sync commits to `terraform-website`, which will trigger a deploy.
 
 New commits in `hashicorp/terraform` don't automatically deploy the site, but an unrelated site deploy will usually happen within a day. If you can't wait that long, you can trigger a manual CircleCI build or ask someone in the #proj-terraform-docs channel to do so:
-- Log in to circleci.com, and  make sure you're viewing the HashiCorp organization.
+
+- Log in to circleci.com, and make sure you're viewing the HashiCorp organization.
 - Go to the terraform-website project's list of workflows.
 - Find the most recent "website-deploy" workflow, and click the "Rerun workflow from start" button (which looks like a refresh button with a numeral "1" inside).
-
 
 ## Running the Site Locally
 
@@ -111,7 +123,7 @@ To preview changes from a fork of Terraform core, you need to first make sure th
 1. **Init:** Run `git submodule init ext/terraform`.
 2. **Update:** Run `git submodule update`.
 
-    The init command doesn't actually init things all the way, so if you forget to run update, you might have a bad afternoon. (For more information, see [Living With Submodules][inpage-submodules] below.)
+   The init command doesn't actually init things all the way, so if you forget to run update, you might have a bad afternoon. (For more information, see [Living With Submodules][inpage-submodules] below.)
 
 #### Changing
 
@@ -136,8 +148,8 @@ Once you finish testing your changes, you can reset the submodule to its normal 
 
 **Note:** If you're updating a nav sidebar `.erb` file in a provider or in Terraform core, the Middleman preview server might not automatically refresh the affected pages. The easiest way to deal with it is to stop and restart the preview server.
 
-
 ### From the `terraform` repository
+
 The build includes content from the `terraform` repository and the `terraform-website` repository, allowing you to preview the entire Terraform documentation site. You can find instructions in [terraform/website/README.md](https://github.com/hashicorp/terraform/tree/main/website).
 
 ## Writing Normal Docs Content
@@ -189,11 +201,11 @@ Content is in Markdown, with a few local syntax additions described below. Try t
 
 If you start a paragraph with a special arrow-like sigil, it will become a colored callout box. You can't make multi-paragraph callouts. For colorblind users (and for clarity in general), we try to start callouts with a strong-emphasized word to indicate their function.
 
-Sigil | Start text with  | Color
-------|------------------|-------
-`->`  | `**Note:**`      | blue
-`~>`  | `**Important:**` | yellow
-`!>`  | `**Warning:**`   | red
+| Sigil | Start text with  | Color  |
+| ----- | ---------------- | ------ |
+| `->`  | `**Note:**`      | blue   |
+| `~>`  | `**Important:**` | yellow |
+| `!>`  | `**Warning:**`   | red    |
 
 #### Learn Tutorial Crosslink Callouts
 

--- a/content/source/docs/cloud/api/run-tasks.html.md
+++ b/content/source/docs/cloud/api/run-tasks.html.md
@@ -140,7 +140,7 @@ This endpoint supports pagination [with standard URL query parameters](./index.h
 
 Parameter           | Description
 --------------------|------------
-`include`           | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `workspace-tasks` or `workspace-tasks.workspace`.
+`include`           | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `workspace_tasks` or `workspace_tasks.workspace`.
 `page[number]`      | **Optional.** If omitted, the endpoint will return the first page.
 `page[size]`        | **Optional.** If omitted, the endpoint will return 20 policy sets per page.
 
@@ -218,7 +218,7 @@ Status  | Response                                      | Reason
 
 Parameter | Description
 ----------|------------
-`include` | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `workspace-tasks` or `workspace-tasks.workspace`.
+`include` | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `workspace_tasks` or `workspace_tasks.workspace`.
 
 ### Sample Request
 

--- a/content/source/docs/cloud/api/run-tasks.html.md
+++ b/content/source/docs/cloud/api/run-tasks.html.md
@@ -24,27 +24,27 @@ page_title: "Run Tasks - API Docs - Terraform Cloud and Terraform Enterprise"
 
 -> Note: As of September 2021, Run Tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
 
-[Run tasks](../workspaces/run-tasks.html) allow Terraform Cloud to execute tasks in external systems at specific points in the Terraform Cloud run lifecycle. Event hooks are reusable configurations that you can attach to any workspace in an organization as a run task. This page lists the API endpoints for event hooks in an organization and explains how to attach event hooks as run tasks to workspaces.
+[Run tasks](../workspaces/run-tasks.html) allow Terraform Cloud to execute tasks in external systems at specific points in the Terraform Cloud run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization. This page lists the API endpoints for run tasks in an organization and explains how to attach run tasks to workspaces.
 
-## Required Permissions 
+## Required Permissions
 
-You need organization owner [permissions](../users-teams-organizations/permissions.html) to interact with event hooks and workspace administrator permissions to connect event hooks to workspaces.
+You need organization owner [permissions](../users-teams-organizations/permissions.html) to interact with run tasks and workspace administrator permissions to connect run tasks to workspaces.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## Create an Event Hook
+## Create a Run Task
 
-`POST /organizations/:organization_name/event-hooks`
+`POST /organizations/:organization_name/tasks`
 
 Parameter            | Description
 ---------------------|------------
-`:organization_name` | The organization to create an event hook in. The organization must already exist in Terraform Cloud, and the token authenticating the API request must have [owner permission](/docs/cloud/users-teams-organizations/permissions.html).
+`:organization_name` | The organization to create a run task in. The organization must already exist in Terraform Cloud, and the token authenticating the API request must have [owner permission](/docs/cloud/users-teams-organizations/permissions.html).
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 Status  | Response                                      | Reason
 --------|-----------------------------------------------|----------
-[201][] | [JSON API document][] (`type: "event-hooks"`) | Successfully created an event hook
+[201][] | [JSON API document][] (`type: "tasks"`) | Successfully created a run task
 [404][] | [JSON API error object][]                     | Organization not found, or user unauthorized to perform action
 [422][] | [JSON API error object][]                     | Malformed request body (missing attributes, wrong types, etc.)
 
@@ -57,18 +57,18 @@ Properties without a default value are required unless otherwise specified.
 
 Key path                                      | Type            | Default | Description
 ----------------------------------------------|-----------------|---------|------------
-`data.type`                                   | string          |         | Must be `"event-hooks"`.
-`data.attributes.name`                        | string          |         | The name of the event hook. Can include letters, numbers, `-`, and `_`.
+`data.type`                                   | string          |         | Must be `"tasks"`.
+`data.attributes.name`                        | string          |         | The name of the task. Can include letters, numbers, `-`, and `_`.
 `data.attributes.url`                         | string          |         | URL to send a run task payload.
 `data.attributes.category`                    | string          |         | Must be `"task"`.
-`data.attributes.hmac-key`                    | string          |         | (Optional) HMAC key to verify event hook.
+`data.attributes.hmac-key`                    | string          |         | (Optional) HMAC key to verify run task.
 
 ### Sample Payload
 
 ```json
 {
   "data": {
-    "type": "event-hooks",
+    "type": "tasks",
       "attributes": {
         "name": "example",
         "url": "http://example.com",
@@ -87,7 +87,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://app.terraform.io/api/v2/organizations/my-organization/event-hooks
+  https://app.terraform.io/api/v2/organizations/my-organization/tasks
 ```
 
 ### Sample Response
@@ -95,11 +95,11 @@ curl \
 ```json
 {
   "data": {
-    "id": "evhook-7oD7doVTQdAFnMLV",
-      "type": "event-hooks",
+    "id": "task-7oD7doVTQdAFnMLV",
+      "type": "tasks",
       "attributes": {
         "category": "task",
-        "name": "my-event-hook",
+        "name": "my-run-task",
         "url": "http://example.com",
         "hmac-key": null,
       },
@@ -115,23 +115,23 @@ curl \
         }
       },
       "links": {
-        "self": "/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV"
+        "self": "/api/v2/tasks/task-7oD7doVTQdAFnMLV"
       }
   }
 }
 ```
 
-## List Event Hooks
+## List Run Tasks
 
-`GET /organizations/:organization_name/event-hooks`
+`GET /organizations/:organization_name/tasks`
 
 Parameter            | Description
 ---------------------|------------
-`:organization_name` | The organization to list event hooks for.
+`:organization_name` | The organization to list tasks for.
 
 Status  | Response                                      | Reason
 --------|-----------------------------------------------|----------
-[200][] | [JSON API document][] (`type: "event-hooks"`) | Request was successful
+[200][] | [JSON API document][] (`type: "tasks"`)       | Request was successful
 [404][] | [JSON API error object][]                     | Organization not found, or user unauthorized to perform action
 
 ### Query Parameters
@@ -140,7 +140,7 @@ This endpoint supports pagination [with standard URL query parameters](./index.h
 
 Parameter           | Description
 --------------------|------------
-`include`           | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `tasks` or `tasks.workspace`.
+`include`           | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `workspace-tasks` or `workspace-tasks.workspace`.
 `page[number]`      | **Optional.** If omitted, the endpoint will return the first page.
 `page[size]`        | **Optional.** If omitted, the endpoint will return 20 policy sets per page.
 
@@ -150,7 +150,7 @@ Parameter           | Description
 ```shell
 curl \
   --header "Authorization: Bearer $TOKEN" \
-  https://app.terraform.io/api/v2/organizations/my-organization/event-hooks
+  https://app.terraform.io/api/v2/organizations/my-organization/tasks
 ```
 
 ### Sample Response
@@ -159,11 +159,11 @@ curl \
 {
     "data": [
         {
-            "id": "evhook-7oD7doVTQdAFnMLV",
-            "type": "event-hooks",
+            "id": "task-7oD7doVTQdAFnMLV",
+            "type": "tasks",
             "attributes": {
                 "category": "task",
-                "name": "my-event-hook",
+                "name": "my-task",
                 "url": "http://example.com",
                 "hmac-key": null,
             },
@@ -179,16 +179,16 @@ curl \
                 }
             },
             "links": {
-                "self": "/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV"
+                "self": "/api/v2/tasks/task-7oD7doVTQdAFnMLV"
             }
         }
     ],
     "links": {
-        "self": "https://app.terraform.io/api/v2/organizations/hashicorp/event-hooks?page%5Bnumber%5D=1&page%5Bsize%5D=20",
-        "first": "https://app.terraform.io/api/v2/organizations/hashicorp/event-hooks?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+        "self": "https://app.terraform.io/api/v2/organizations/hashicorp/tasks?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+        "first": "https://app.terraform.io/api/v2/organizations/hashicorp/tasks?page%5Bnumber%5D=1&page%5Bsize%5D=20",
         "prev": null,
         "next": null,
-        "last": "https://app.terraform.io/api/v2/organizations/hashicorp/event-hooks?page%5Bnumber%5D=1&page%5Bsize%5D=20"
+        "last": "https://app.terraform.io/api/v2/organizations/hashicorp/tasks?page%5Bnumber%5D=1&page%5Bsize%5D=20"
     },
     "meta": {
         "pagination": {
@@ -203,22 +203,22 @@ curl \
 }
 ```
 
-## Show an Event Hook
+## Show a Run Task
 
-`GET /event-hooks/:id`
+`GET /tasks/:id`
 
 Parameter | Description
 ----------|------------
-`:id`     | The ID of the event hook to show. Use the ["List Event Hooks"](#list-event-hooks) endpoint to find IDs.
+`:id`     | The ID of the task to show. Use the ["List Run Tasks"](#list-run-tasks) endpoint to find IDs.
 
 Status  | Response                                      | Reason
 --------|-----------------------------------------------|----------
-[200][] | [JSON API document][] (`type: "event-hooks"`) | The request was successful
-[404][] | [JSON API error object][]                     | Event hook not found or user unauthorized to perform action
+[200][] | [JSON API document][] (`type: "tasks"`)       | The request was successful
+[404][] | [JSON API error object][]                     | Run task not found or user unauthorized to perform action
 
 Parameter | Description
 ----------|------------
-`include` | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `tasks` or `tasks.workspace`.
+`include` | **Optional.** Allows including related resource data. Value must be a comma-separated list containing one or more of `workspace-tasks` or `workspace-tasks.workspace`.
 
 ### Sample Request
 
@@ -226,7 +226,7 @@ Parameter | Description
 curl --request GET \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
-  https://app.terraform.io/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV
+  https://app.terraform.io/api/v2/tasks/task-7oD7doVTQdAFnMLV
 ```
 
 ### Sample Response
@@ -234,11 +234,11 @@ curl --request GET \
 ```json
 {
   "data": {
-    "id": "evhook-7oD7doVTQdAFnMLV",
-      "type": "event-hooks",
+    "id": "task-7oD7doVTQdAFnMLV",
+      "type": "tasks",
       "attributes": {
         "category": "task",
-        "name": "my-event-hook",
+        "name": "my-task",
         "url": "http://example.com",
         "hmac-key": null,
       },
@@ -259,24 +259,24 @@ curl --request GET \
         }
       },
       "links": {
-        "self": "/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV"
+        "self": "/api/v2/tasks/task-7oD7doVTQdAFnMLV"
       }
   }
 }
 ```
 
-## Update an Event Hook
+## Update a Run Task
 
-`PATCH /event-hooks/:id`
+`PATCH /tasks/:id`
 
 Parameter | Description
 ----------|------------
-`:id`     | The ID of the event hook to update. Use the ["List Event Hooks"](#list-event-hooks) endpoint to find IDs.
+`:id`     | The ID of the task to update. Use the ["List Run Tasks"](#list-run-tasks) endpoint to find IDs.
 
 Status  | Response                                      | Reason
 --------|-----------------------------------------------|----------
-[200][] | [JSON API document][] (`type: "event-hooks"`) | The request was successful
-[404][] | [JSON API error object][]                     | Event hook not found or user unauthorized to perform action
+[200][] | [JSON API document][] (`type: "tasks"`)       | The request was successful
+[404][] | [JSON API error object][]                     | Run task not found or user unauthorized to perform action
 [422][] | [JSON API error object][]                     | Malformed request body (missing attributes, wrong types, etc.)
 
 ### Request Body
@@ -287,18 +287,18 @@ Properties without a default value are required unless otherwise specified.
 
 Key path                                      | Type    | Default          | Description
 ----------------------------------------------|-------- |------------------|------------
-`data.type`                                   | string  |                  | Must be `"event-hooks"`.
-`data.attributes.name`                        | string  | (previous value) | The name of the event hook. Can include letters, numbers, `-`, and `_`.
+`data.type`                                   | string  |                  | Must be `"tasks"`.
+`data.attributes.name`                        | string  | (previous value) | The name of the run task. Can include letters, numbers, `-`, and `_`.
 `data.attributes.url`                         | string  | (previous value) | URL to send a run task payload.
 `data.attributes.category`                    | string  | (previous value) | Must be `"task"`.
-`data.attributes.hmac-key`                    | string  | (previous value) | (Optional) HMAC key to verify event hook.
+`data.attributes.hmac-key`                    | string  | (previous value) | (Optional) HMAC key to verify run task.
 
 ### Sample Payload
 
 ```json
 {
   "data": {
-    "type": "event-hooks",
+    "type": "tasks",
       "attributes": {
         "name": "new-example",
         "url": "http://new-example.com",
@@ -317,7 +317,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
-  https://app.terraform.io/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV
+  https://app.terraform.io/api/v2/tasks/task-7oD7doVTQdAFnMLV
 ```
 
 ### Sample Response
@@ -325,8 +325,8 @@ curl \
 ```json
 {
   "data": {
-    "id": "evhook-7oD7doVTQdAFnMLV",
-      "type": "event-hooks",
+    "id": "task-7oD7doVTQdAFnMLV",
+      "type": "tasks",
       "attributes": {
         "category": "task",
         "name": "new-example",
@@ -343,31 +343,31 @@ curl \
         "tasks": {
           "data": [
           {
-            "id": "task-xjKZw9KaeXda61az",
-            "type": "tasks"
+            "id": "wstask-xjKZw9KaeXda61az",
+            "type": "workspace-tasks"
           }
           ]
         }
       },
       "links": {
-        "self": "/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV"
+        "self": "/api/v2/tasks/task-7oD7doVTQdAFnMLV"
       }
   }
 }
 ```
 
-## Delete an Event Hook
+## Delete a Run Task
 
-`DELETE /event-hooks/:id`
+`DELETE /tasks/:id`
 
 Parameter | Description
 ----------|------------
-`:id`     | The ID of the event hook to delete. Use the ["List Event Hooks"](#list-event-hooks) endpoint to find IDs.
+`:id`     | The ID of the run task to delete. Use the ["List Run Tasks"](#list-run-tasks) endpoint to find IDs.
 
 Status  | Response                  | Reason
 --------|---------------------------|-------
-[204][] | Nothing                   | Successfully deleted the event hook
-[404][] | [JSON API error object][] | Event hook not found, or user unauthorized to perform action
+[204][] | Nothing                   | Successfully deleted the run task
+[404][] | [JSON API error object][] | Run task not found, or user unauthorized to perform action
 
 
 ### Sample Request
@@ -377,10 +377,10 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://app.terraform.io/api/v2/event-hooks/evhook-7oD7doVTQdAFnMLV
+  https://app.terraform.io/api/v2/tasks/task-7oD7doVTQdAFnMLV
 ```
 
-## Attach an Event Hook to a Workspace as a Task
+## Attach a Run Task to a Workspace
 
 `POST /workspaces/:workspace_id/tasks`
 
@@ -391,7 +391,7 @@ Parameter | Description
 Status  | Response                  | Reason
 --------|---------------------------|----------
 [204][] | Nothing                   | The request was successful
-[404][] | [JSON API error object][] | Workspace or event hook not found or user unauthorized to perform action
+[404][] | [JSON API error object][] | Workspace or run task not found or user unauthorized to perform action
 [422][] | [JSON API error object][] | Malformed request body
 
 ### Request Body
@@ -402,25 +402,25 @@ Properties without a default value are required.
 
 Key path | Type            | Default | Description
 ---------|-----------------|---------|------------
-`data.type`                                   | string |  | Must be `"tasks"`.
-`data.attributes.enforcement-level`           | string |  | The enforcement level of the task. Must be `"advisory"` or `"mandatory"`.
-`data.relationships.event-hook.data.id`       | string |  | The ID of the event hook.
-`data.relationships.event-hook.data.type`     | string |  | Must be `"event-hooks"`.
+`data.type`                                   | string |  | Must be `"workspace-tasks"`.
+`data.attributes.enforcement-level`           | string |  | The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.
+`data.relationships.task.data.id`       | string |  | The ID of the run task.
+`data.relationships.task.data.type`     | string |  | Must be `"tasks"`.
 
 ### Sample Payload
 
 ```json
 {
   "data": {
-    "type": "tasks",
+    "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory"
       },
       "relationships": {
-        "event-hook": {
+        "task": {
           "data": {
-            "id": "evhook-7oD7doVTQdAFnMLV",
-            "type": "event-hooks"
+            "id": "task-7oD7doVTQdAFnMLV",
+            "type": "tasks"
           }
         }
       }
@@ -443,16 +443,16 @@ curl \
 ```json
 {
   "data": {
-    "id": "task-tBXYu8GVAFBpcmPm",
-      "type": "tasks",
+    "id": "wstask-tBXYu8GVAFBpcmPm",
+      "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory"
       },
       "relationships": {
-        "event-hook": {
+        "task": {
           "data": {
-            "id": "evhook-7oD7doVTQdAFnMLV",
-            "type": "event-hooks"
+            "id": "task-7oD7doVTQdAFnMLV",
+            "type": "tasks"
           }
         },
         "workspace": {
@@ -463,13 +463,13 @@ curl \
         }
       },
       "links": {
-        "self": "/api/v2/tasks/task-tBXYu8GVAFBpcmPm"
+        "self": "/api/v2/workspaces/ws-PphL7ix3yGasYGrq/tasks/task-tBXYu8GVAFBpcmPm"
       }
   }
 }
 ```
 
-## List Tasks
+## List Workspace Run Tasks
 
 `GET /workspaces/:workspace_id/tasks`
 
@@ -505,16 +505,16 @@ curl \
 {
   "data": [
   {
-    "id": "task-tBXYu8GVAFBpcmPm",
-      "type": "tasks",
+    "id": "wstask-tBXYu8GVAFBpcmPm",
+      "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory"
       },
       "relationships": {
-        "event-hook": {
+        "task": {
           "data": {
-            "id": "evhook-hu74ST39g566Q4m5",
-            "type": "event-hooks"
+            "id": "task-hu74ST39g566Q4m5",
+            "type": "tasks"
           }
         },
         "workspace": {
@@ -525,7 +525,7 @@ curl \
         }
       },
       "links": {
-        "self": "/api/v2/tasks/task-tBXYu8GVAFBpcmPm"
+        "self": "/api/v2/workspaces/ws-kRsDRPtTmtcEme4t/tasks/task-tBXYu8GVAFBpcmPm"
       }
   }
   ],
@@ -549,18 +549,18 @@ curl \
 }
 ```
 
-## Show a Task
+## Show Workspace Run Task
 
-`GET /tasks/:id`
+`GET /workspaces/:workspace_id/tasks/:id`
 
 Parameter | Description
 ----------|------------
-`:id`     | The ID of the task to show. Use the ["List Tasks"](#list-tasks) endpoint to find IDs.
+`:id`     | The ID of the workspace task to show. Use the ["List Workspace Run Tasks"](#list-workspace-run-tasks) endpoint to find IDs.
 
 Status  | Response                                      | Reason
 --------|-----------------------------------------------|----------
 [200][] | [JSON API document][] (`type: "tasks"`) | The request was successful
-[404][] | [JSON API error object][]               | Task not found or user unauthorized to perform action
+[404][] | [JSON API error object][]               | Workspace run task not found or user unauthorized to perform action
 
 ### Sample Request
 
@@ -568,7 +568,7 @@ Status  | Response                                      | Reason
 curl --request GET \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
-  https://app.terraform.io/api/v2/tasks/task-tBXYu8GVAFBpcmPm
+  https://app.terraform.io/api/v2/workspaces/ws-kRsDRPtTmtcEme4t/tasks/wstask-tBXYu8GVAFBpcmPm
 ```
 
 ### Sample Response
@@ -576,16 +576,16 @@ curl --request GET \
 ```json
 {
   "data": {
-    "id": "task-tBXYu8GVAFBpcmPm",
-      "type": "tasks",
+    "id": "wstask-tBXYu8GVAFBpcmPm",
+      "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory"
       },
       "relationships": {
-        "event-hook": {
+        "task": {
           "data": {
-            "id": "evhook-hu74ST39g566Q4m5",
-            "type": "event-hooks"
+            "id": "task-hu74ST39g566Q4m5",
+            "type": "tasks"
           }
         },
         "workspace": {
@@ -596,24 +596,24 @@ curl --request GET \
         }
       },
       "links": {
-        "self": "/api/v2/tasks/task-tBXYu8GVAFBpcmPm"
+        "self": "/api/v2/workspaces/ws-kRsDRPtTmtcEme4t/tasks/wstask-tBXYu8GVAFBpcmPm"
       }
   }
 }
 ```
 
-## Update a Task
+## Update Workspace Run Task
 
-`PATCH /tasks/:id`
+`PATCH /workspaces/:workspace_id/tasks/:id`
 
 Parameter | Description
 ----------|------------
-`:id`     | The ID of the task to update. Use the ["List Tasks"](#list-tasks) endpoint to find IDs.
+`:id`     | The ID of the task to update. Use the ["List Workspace Run Tasks"](#list-workspace-run-tasks) endpoint to find IDs.
 
 Status  | Response                                      | Reason
 --------|-----------------------------------------------|----------
 [200][] | [JSON API document][] (`type: "tasks"`) | The request was successful
-[404][] | [JSON API error object][]               | Task not found or user unauthorized to perform action
+[404][] | [JSON API error object][]               | Workspace run task not found or user unauthorized to perform action
 [422][] | [JSON API error object][]               | Malformed request body (missing attributes, wrong types, etc.)
 
 ### Request Body
@@ -624,15 +624,15 @@ Properties without a default value are required.
 
 Key path                                      | Type    | Default          | Description
 ----------------------------------------------|-------- |------------------|------------
-`data.type`                                   | string  | (previous value) | Must be `"tasks"`.
-`data.attributes.enforcement-level`           | string  | (previous value) | The enforcement level of the task. Must be `"advisory"` or `"mandatory"`.
+`data.type`                                   | string  | (previous value) | Must be `"workspace-tasks"`.
+`data.attributes.enforcement-level`           | string  | (previous value) | The enforcement level of the workspace run task. Must be `"advisory"` or `"mandatory"`.
 
 ### Sample Payload
 
 ```json
 {
   "data": {
-    "type": "tasks",
+    "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "mandatory"
       }
@@ -648,7 +648,7 @@ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request PATCH \
   --data @payload.json \
-  https://app.terraform.io/api/v2/tasks/task-tBXYu8GVAFBpcmPm
+  https://app.terraform.io/api/v2/workspaces/ws-kRsDRPtTmtcEme4t/tasks/wstask-tBXYu8GVAFBpcmPm
 ```
 
 ### Sample Response
@@ -656,16 +656,16 @@ curl \
 ```json
 {
   "data": {
-    "id": "task-tBXYu8GVAFBpcmPm",
-      "type": "tasks",
+    "id": "wstask-tBXYu8GVAFBpcmPm",
+      "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "mandatory"
       },
       "relationships": {
-        "event-hook": {
+        "task": {
           "data": {
-            "id": "evhook-hu74ST39g566Q4m5",
-            "type": "event-hooks"
+            "id": "task-hu74ST39g566Q4m5",
+            "type": "tasks"
           }
         },
         "workspace": {
@@ -676,24 +676,24 @@ curl \
         }
       },
       "links": {
-        "self": "/api/v2/tasks/task-tBXYu8GVAFBpcmPm"
+        "self": "/api/v2/workspaces/ws-kRsDRPtTmtcEme4t/tasks/task-tBXYu8GVAFBpcmPm"
       }
   }
 }
 ```
 
-## Delete a Task
+## Delete Workspace Task
 
-`DELETE /tasks/:id`
+`DELETE /workspaces/:workspace_id/tasks/:id`
 
 Parameter | Description
 ----------|------------
-`:id`     | The ID of the Task to delete. Use the ["List Tasks"](#list-tasks) endpoint to find IDs.
+`:id`     | The ID of the Workspace run task to delete. Use the ["List Workspace Run Tasks"](#list-workspace-run-tasks) endpoint to find IDs.
 
 Status  | Response                  | Reason
 --------|---------------------------|-------
-[204][] | Nothing                   | Successfully deleted the event hook
-[404][] | [JSON API error object][] | Task not found, or user unauthorized to perform action
+[204][] | Nothing                   | Successfully deleted the workspace run task
+[404][] | [JSON API error object][] | Workspace run task not found, or user unauthorized to perform action
 
 
 ### Sample Request
@@ -703,5 +703,5 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request DELETE \
-  https://app.terraform.io/api/v2/tasks/task-tBXYu8GVAFBpcmPm
+  https://app.terraform.io/api/v2/workspaces/ws-kRsDRPtTmtcEme4t/tasks/wstask-tBXYu8GVAFBpcmPm
 ```

--- a/content/source/docs/cloud/integrations/run-tasks/index.html.md
+++ b/content/source/docs/cloud/integrations/run-tasks/index.html.md
@@ -53,7 +53,8 @@ Once your server receives this payload, Terraform Cloud expects you to callback 
     "type": "task-results",
       "attributes": {
         "status": "passed",
-        "message": "Hello task"
+        "message": "Hello task",
+        "url": "https://example.com"
       }
   }
 }

--- a/content/source/docs/cloud/integrations/run-tasks/index.html.md
+++ b/content/source/docs/cloud/integrations/run-tasks/index.html.md
@@ -13,13 +13,13 @@ In addition to using existing technology partners integrations, HashiCorp Terraf
 
 ## Prerequisites
 
-To build a custom integration, you must have a server capable of receiving requests from Terraform Cloud and responding with a status update to a supplied callback URL. When creating an event hook, you supply an endpoint url to receive the hook. We send a test POST to the supplied URL, and it must respond with a 200 for the event hook to be created.
+To build a custom integration, you must have a server capable of receiving requests from Terraform Cloud and responding with a status update to a supplied callback URL. When creating a run task, you supply an endpoint url to receive the hook. We send a test POST to the supplied URL, and it must respond with a 200 for the run task to be created.
 
 This feature relies heavily on the proper parsing of [plan JSON output](../../../internals/json-format.html). When sending this output to an external system, be certain that system can properly interpret the information provided.
 
 ## Integration Details
 
-When a run reaches the pre-apply phase and an event hook is triggered, the supplied URL will receive details about the run in a payload similar to the one below. The server receiving the event hook should respond `200 OK`, or Terraform will retry to trigger the hook.
+When a run reaches the pre-apply phase and a run task is triggered, the supplied URL will receive details about the run in a payload similar to the one below. The server receiving the run task should respond `200 OK`, or Terraform will retry to trigger the run task.
 
 ```json
 {
@@ -65,9 +65,9 @@ Here's what the data flow looks like:
 
 ![Screenshot: a diagram of the user and data flow for a Terraform Cloud run task](./images/terraform-cloud-run-tasks-diagram.png)
 
-## Securing your Event Hook
+## Securing your Run Task
 
-When creating your event hook, you can supply an HMAC key which Terraform Cloud will use to create a signature of the payload in the `x-tfc-event-hook-signature` header when calling your service.
+When creating your run task, you can supply an HMAC key which Terraform Cloud will use to create a signature of the payload in the `x-tfc-run-task-signature` header when calling your service.
 
 The signature is a sha512 sum of the webhook body using the provided HMAC key. The generation of the signature depends on your implementation, however an example of how to generate a signature in bash is provided below.
 

--- a/content/source/docs/cloud/integrations/run-tasks/index.html.md
+++ b/content/source/docs/cloud/integrations/run-tasks/index.html.md
@@ -19,7 +19,7 @@ This feature relies heavily on the proper parsing of [plan JSON output](../../..
 
 ## Integration Details
 
-When a run reaches the pre-apply phase and a run task is triggered, the supplied URL will receive details about the run in a payload similar to the one below. The server receiving the run task should respond `200 OK`, or Terraform will retry to trigger the run task.
+When a run reaches the appropriate phase and a run task is triggered, the supplied URL will receive details about the run in a payload similar to the one below. The server receiving the run task should respond `200 OK`, or Terraform will retry to trigger the run task.
 
 ```json
 {


### PR DESCRIPTION
To help create a more consistent UX for run tasks, we are migrating Event Hooks to Tasks throughout the API. This PR updates all references of Event Hooks, whilst also updating the Workspace Task endpoints to match recent changes.

There is no changelog entry for the API changes, as Run Tasks is still a beta feature.

## Labels

- [ ] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [x] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
