### PR TITLE
Update guidance around RHEL installations

### DIFF
--- a/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
@@ -16,12 +16,6 @@ When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure y
   * Docker 1.13.1 installed via the RHEL Extras repository. Details on how to subscribe to the RHEL Extras repository can be found [here](https://access.redhat.com/solutions/912213).
 * Docker configured with the `overlay2` storage driver. This is the default storage driver for the latest Docker installations.
 
-~> **Note:** The `overlay2` storage driver requires kernel version 3.10.0-693 or greater and the `ftype=1` kernel option when using an XFS filesystem. More details regarding the `overlay2` storage driver can be found [here](https://docs.docker.com/storage/storagedriver/overlayfs-driver/).
-
-~> **Note:** The [Docker documentation] (https://docs.docker.com/storage/storagedriver/select-storage-driver/) states that the `devicemapper` storage driver is deprecated and will be removed in a future release. Users of the `devicemapper` storage driver must migrate to `overlay2`.
-
-~> **Note:** Using `docker-1.13.1-84.git07f3374.el7.x86_64` will result in an RPC error as well as 502 errors and inability to use the application.
-
 ### Pinning the Docker Version
 
 To pin the version of Docker and prevent an inadvertent upgrade, follow [this guide](https://access.redhat.com/solutions/98873) from RedHat.

--- a/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
@@ -20,17 +20,6 @@ When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure y
 
 To pin the version of Docker and prevent an inadvertent upgrade, follow [this guide](https://access.redhat.com/solutions/98873) from RedHat.
 
-### Downgrading the Docker Version
-
-The `yum downgrade` command can be used to downgrade the version of Docker that is installed.
-
-For example, to downgrade from `docker-1.13.1-84.git07f3374.el7.x86_64` to `docker-1.13.1-72.git6f36bd4el8.x86_64` stop the Docker service and execute the following.
-
-```
-sudo yum downgrade docker-1.13.1-72.git6f36bd4el7.x86_64 docker-client-1.13.1-72.git6f36bd4el7.x86_64 docker-common-1.13.1-72.git6f36bd4el7.x86_64 docker-rhel-push-plugin-1.13.1-72.git6f36bd4el7.x86_64
-```
-
-Afterwards, restart the Docker service and verify the newly installed version using `docker version`.
 
 ## Mandatory Configuration
 


### PR DESCRIPTION
At the moment the RHEL installation page for TFE has a number of notes concerning issues with RHEL that used to exist. Eg: certain versions of the RHEL package causing problems, usage of devicemapper storage drivers, etc. These issues have been resolved for some time and are no longer things that folks run into with RHEL and as such I am removing them to make the page clearer. 

To start I am opening this as a draft so we can follow up on some other guidance around Docker versions as well in this PR. 