### PR TITLE
Replace HTML tables with Markdown tables

### DIFF
--- a/content/source/docs/enterprise/install/active-active.html.md
+++ b/content/source/docs/enterprise/install/active-active.html.md
@@ -75,24 +75,9 @@ The existing settings for the installer and infrastructure (`replicated.conf`) a
 To upgrade to the  Active/Active functionality and for ongoing upgrades, you need to pin your installation to the appropriate  release by setting the following:
 
 
-<table>
-  <tr>
-   <td><strong>Key</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Specific Format Required</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ReleaseSequence
-   </td>
-   <td>Refers to a version of TFE ([v202101-1](https://github.com/hashicorp/terraform-enterprise-release-notes/blob/master/v202101-1.md))
-   </td>
-   <td><strong>Yes</strong>, integer.
-   </td>
-  </tr>
-</table>
+| **Key**         | **Description**                                                                                                                    | **Specific Format Required** |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| ReleaseSequence | Refers to a version of TFE ([v202101-1](https://github.com/hashicorp/terraform-enterprise-release-notes/blob/master/v202101-1.md)) | **Yes**, integer.            |
 
 
 The following example pins the deployment to the the ([v202101-1](https://github.com/hashicorp/terraform-enterprise-release-notes/blob/master/v202101-1.md)) release of TFE (which is the first to support multiple nodes):
@@ -115,24 +100,9 @@ The existing settings for the Terraform Enterprise application (`ptfe-settings.j
 ##### Enable Active/Active
 
 
-<table>
-  <tr>
-   <td><strong>Key</strong>
-   </td>
-   <td><strong>Required Value</strong>
-   </td>
-   <td><strong>Specific Format Required</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>enable_active_active
-   </td>
-   <td>“1”
-   </td>
-   <td><strong>Yes, </strong>string.
-   </td>
-  </tr>
-</table>
+| **Key**                | **Required Value** | **Specific Format Required** |
+| ---------------------- | ------------------ | ---------------------------- |
+| enable\_active\_active | “1”                | **Yes**, string.             |
 
 
 
@@ -152,56 +122,13 @@ The existing settings for the Terraform Enterprise application (`ptfe-settings.j
 The settings for the Terraform Enterprise application must also be expanded to support an external Redis instance:
 
 
-<table>
-  <tr>
-   <td><strong>Key</strong>
-   </td>
-   <td><strong>Required Value</strong>
-   </td>
-   <td><strong>Specific Format Required</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>redis_host
-   </td>
-   <td>Hostname of an external Redis instance which is resolvable from the TFE instance
-   </td>
-   <td><strong>Yes, </strong>string.
-   </td>
-  </tr>
-  <tr>
-   <td>redis_port
-   </td>
-   <td>Port number of your external Redis instance
-   </td>
-   <td><strong>Yes</strong>, string.
-   </td>
-  </tr>
-  <tr>
-   <td>redis_use_password_auth*
-   </td>
-   <td>Set to ”1”, if you are using a Redis service that requires a password.
-   </td>
-   <td><strong>Yes</strong>, string.
-   </td>
-  </tr>
-  <tr>
-   <td>redis_pass*
-   </td>
-   <td><em>Must be set to the password of an external Redis instance if the instance requires password authentication</em>
-   </td>
-   <td><strong>Yes</strong>, string.
-   </td>
-  </tr>
-  <tr>
-   <td>redis_use_tls*
-   </td>
-   <td>Set to “1” if you are using a Redis service that requires TLS
-   </td>
-   <td><strong>Yes</strong>, string.
-   </td>
-  </tr>
-</table>
+| **Key**                      | **Required Value**                                                                                           | **Specific Format Required** |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| redis\_host                  | Hostname of an external Redis instance which is resolvable from the TFE instance                             | **Yes**, string.             |
+| redis\_port                  | Port number of your external Redis instance                                                                  | **Yes**, string.             |
+| redis\_use\_password\_auth\* | Set to ”1”, if you are using a Redis service that requires a password.                                       | **Yes**, string.             |
+| redis\_pass\*                | _Must be set to the password of an external Redis instance if the instance requires password authentication_ | **Yes**, string.             |
+| redis\_use\_tls\*            | Set to “1” if you are using a Redis service that requires TLS                                                | **Yes**, string.             |
 
 
 _* Fields marked with an asterisk are only necessary if your particular external Redis instance requires them._
@@ -236,28 +163,9 @@ For example:
 
 !> The Encryption Password value must be added to the config and is **required to be identical between node instances** for the Active/Active architecture to function:
 
-<table>
-  <tr>
-   <td><strong>Key</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Value can change between deployments?</strong>
-   </td>
-   <td><strong>Specific Format Required</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>enc_password
-   </td>
-   <td>Used to encrypt sensitive data (<a href="https://www.terraform.io/docs/enterprise/install/encryption-password.html">docs</a>)
-   </td>
-   <td><strong>No. </strong>Changing will make decrypting existing data impossible. 
-   </td>
-   <td>No
-   </td>
-  </tr>
-</table>
+| **Key**       | **Description**                                                                                                    | **Value can change between deployments?**                       | **Specific Format Required** |
+| ------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- | ---------------------------- |
+| enc\_password | Used to encrypt sensitive data ([docs](https://www.terraform.io/docs/enterprise/install/encryption-password.html)) | **No.** Changing will make decrypting existing data impossible. | No                           |
 
 
 
@@ -456,28 +364,9 @@ You may consider using other options in the configuration depending on your requ
 The minimum instance size for Redis to be used with TFE is 6 GiB. For Azure, this allows for some minimum configurations across the three tiers using Cache Names for their different Tiers. Our recommendations on cache sizing for Azure Cache for Redis is in the table below:
 
 
-<table>
-  <tr>
-   <td> 
-   </td>
-   <td><strong>Basic</strong>
-   </td>
-   <td><strong>Standard</strong>
-   </td>
-   <td><strong>Premium</strong>
-   </td>
-  </tr>
-  <tr>
-   <td><strong>Cache</strong> <strong>Name</strong>
-   </td>
-   <td>C3
-   </td>
-   <td>C0
-   </td>
-   <td>P2
-   </td>
-  </tr>
-</table>
+|                    | **Basic**    | **Standard** | **Premium** |
+| ------------------ | ------------ | ------------ | ----------- |
+| **Cache** **Name** | C3           | C0           | P2          |
 
 
 Make sure you configure the minimum TLS version to the TFE supported version of 1.2 as the Azure resource defaults to 1.0. The default port for Azure Cache for Redis is 6380 and will need to be modified in the Application Settings `ptfe-replicated.conf` in order for TFE to connect to Azure Cache for Redis.


### PR DESCRIPTION
This PR replaces the HTML tables on the Terraform Enterprise Active/Active docs with their Markdown versions. This is to ensure that when we migrate the docs to MDX that they get nice table headers.