### PR TITLE
fix "target system" segment for module URLs in registry

### DIFF
--- a/content/source/docs/cloud/registry/publish.html.md
+++ b/content/source/docs/cloud/registry/publish.html.md
@@ -30,10 +30,10 @@ A module repository must meet all of the following requirements before you can a
 - **Location and permissions:** The repository must be in one of
   your configured [VCS providers][vcs], and Terraform Cloud's VCS user account must have admin access to the repository. The registry needs admin access to create the webhooks to import new module versions. GitLab repositories must be in the main organization or group, and not in any subgroups.
 
-- **Named `terraform-<PROVIDER>-<NAME>`:** Module repositories must use this
+- **Named `terraform-<SYSTEM>-<NAME>`:** Module repositories must use this
   three-part name format, where `<NAME>` reflects the type of infrastructure
-  the module manages and `<PROVIDER>` is the main provider where it creates that
-  infrastructure. The `<PROVIDER>` segment must be all lowercase. The `<NAME>`
+  the module manages and `<SYSTEM>` is the target system which is usually the main provider where it creates that
+  infrastructure. The `<SYSTEM>` segment must be lowercase letters or digits. The `<NAME>`
   segment can contain additional hyphens. Examples: `terraform-google-vault` or
   `terraform-aws-ec2-instance`.
 

--- a/content/source/docs/cloud/registry/using.html.md
+++ b/content/source/docs/cloud/registry/using.html.md
@@ -10,7 +10,7 @@ description: |-
 All users in an organization can view the Terraform Cloud private registry and use the available providers and modules. A private registry has a few key differences from the [public Terraform Registry](/docs/registry/index.html):
 
 - **Location:** You must use Terraform Cloud's web UI to search for providers, modules, and usage examples.
-- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-modules-in-configurations): `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
+- **Module `source` strings:** Private modules use a [four-part format](/docs/cloud/registry/using.html#using-modules-in-configurations): `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<TARGET SYSTEM>`.
 - **Authentication:** Terraform Cloud workspaces using version 0.11 and higher can automatically access your private modules during Terraform runs. But when you run Terraform on the command line, you must [authenticate](/docs/cloud/registry/using.html#authentication) to Terraform Cloud or your Terraform Enterprise instance.
 
 
@@ -61,7 +61,7 @@ terraform {
 > **Hands-on:** Try the [Use Modules from the Registry](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules) tutorial on HashiCorp Learn.
 <br>
 
-The syntax for referencing publicly curated modules in the [module block](/docs/language/modules/syntax.html) `source` argument is `<NAMESPACE>/<MODULE NAME>/<PROVIDER>`.
+The syntax for referencing publicly curated modules in the [module block](/docs/language/modules/syntax.html) `source` argument is `<NAMESPACE>/<MODULE NAME>/<TARGET SYSTEM>`.
 
 ```hcl
 module "subnets" {
@@ -70,7 +70,7 @@ module "subnets" {
 }
 ```
 
-The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` argument is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>`.
+The syntax for referencing private modules in the [module block](/docs/language/modules/syntax.html) `source` argument is `<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<TARGET SYSTEM>`.
 
 - **Hostname:** For the SaaS version of Terraform Cloud, use `app.terraform.io`. In Terraform Enterprise, use the hostname for your instance or the [generic hostname](/docs/cloud/registry/using.html#generic-hostname-terraform-enterprise).
 - **Organization:** If you are using a shared module with Terraform Enterprise, the module's organization name may be different than your organization's name. Check the source string at the top of the module's registry page to find the proper organization name.

--- a/content/source/docs/registry/modules/publish.html.md
+++ b/content/source/docs/registry/modules/publish.html.md
@@ -31,10 +31,11 @@ The list below contains all the requirements for publishing a module:
 This is only a requirement for the [public registry](https://registry.terraform.io).
 If you're using a private registry, you may ignore this requirement.
 
-- **Named `terraform-<PROVIDER>-<NAME>`.** Module repositories must use this
+- **Named `terraform-<SYSTEM>-<NAME>`.** Module repositories must use this
 three-part name format, where `<NAME>` reflects the type of infrastructure the
-module manages and `<PROVIDER>` is the main provider where it creates that
-infrastructure. The `<NAME>` segment can contain additional hyphens. Examples:
+module manages and `<SYSTEM>` is the target system which is usually the main provider
+where it creates that infrastructure. The `<TARGET SYSTEM>` segment must be lowercase
+letters or digits and the `<NAME>` segment can contain additional hyphens. Examples:
 `terraform-google-vault` or `terraform-aws-ec2-instance`.
 
 - **Repository description.** The GitHub repository description is used

--- a/content/source/docs/registry/modules/use.html.md
+++ b/content/source/docs/registry/modules/use.html.md
@@ -28,7 +28,7 @@ modules as well.
 
 The Terraform Registry is integrated directly into Terraform, so a Terraform
 configuration can refer to any module published in the registry. The syntax for
-specifying a registry module is `<NAMESPACE>/<NAME>/<PROVIDER>`. For example:
+specifying a registry module is `<NAMESPACE>/<MODULE NAME>/<TARGET SYSTEM>`. For example:
 `hashicorp/consul/aws`.
 
 ~> **Note:** Module registry integration was added in Terraform v0.10.6, and full versioning support in v0.11.0.
@@ -52,7 +52,7 @@ a configuration.
 
 You can also use modules from a private registry, like the one provided by
 Terraform Cloud. Private registry modules have source strings of the form
-`<HOSTNAME>/<NAMESPACE>/<NAME>/<PROVIDER>`. This is the same format as the
+`<HOSTNAME>/<NAMESPACE>/<MODULE NAME>/<TARGET SYSTEM>`. This is the same format as the
 public registry, but with an added hostname prefix.
 
 ```hcl


### PR DESCRIPTION
Following the discussion in hashicorp/terraform#29532, the documentation for module URLs in public or private registry is ambiguous because it's not the provider in URL but a "target system" and the restriction for characters is not the same as for the name of a provider


<!-- Thanks for the PR! Feel free to delete this message.
QUESTIONS? - Check the README first, then ask in #proj-terraform-docs.
SCREENSHOTS - Please capture the full page width, using a 1024px-wide viewport.
MERGING - Get an approving review before merging your own PRs. (Approved on the private fork? Just say so!)
REVIEWS - For help from the education team, request review from "hashicorp/terraform-education". -->

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
