### PR TITLE
Update Docker Engine requirements

### DIFF
--- a/content/source/docs/enterprise/before-installing/centos-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/centos-requirements.html.md
@@ -5,30 +5,23 @@ page_title: "CentOS Linux Requirements - Installation - Terraform Enterprise"
 
 # CentOS Requirements for Terraform Enterprise
 
-When installing Terraform Enterprise on CentOS Linux, ensure your OS and Docker configuration meet the following requirements:
+When installing Terraform Enterprise on CentOS Linux, ensure you meet the following requirements:
 
 ## Install Requirements
 
 * A [supported version](/docs/enterprise/before-installing/index.html#operating-system-requirements) of CentOS.
-* One of the following installations of Docker:
-  * Docker CE 17.06 or later. Docker CE can either be pre-installed by the operator or installed via our installation script. If Docker CE is pre-installed by the operator, be sure to pass the `no-docker` flag to the installation script to prevent it from trying to install Docker CE again.
-  * Docker EE 17.06 or later.
-  * Docker 1.13.1 installed via the Extras Packages for Enterprise Linux repository. Details on how to subscribe to the Extras Packages for Enterprise Linux repository can be found [here](https://fedoraproject.org/wiki/EPEL).
-* Docker configured with the `overlay2` storage driver. This is the default storage driver for the latest Docker installations.
-
-~> **Note:** The `overlay2` storage driver requires kernel version 3.10.0-693 or greater and the `ftype=1` kernel option when using an XFS filesystem. More details regarding the `overlay2` storage driver can be found [here](https://docs.docker.com/storage/storagedriver/overlayfs-driver/).
-
-~> **Note:** The [Docker documentation] (https://docs.docker.com/storage/storagedriver/select-storage-driver/) states that the `devicemapper` storage driver is deprecated and will be removed in a future release. Users of the `devicemapper` storage driver must migrate to `overlay2`.
+* A [supported Docker Engine](http://localhost:4567/docs/enterprise/before-installing/index.html#docker-engine-requirements) configuration.
 
 ## FAQ
 
 ### Can I use the Docker version in the Extra Packages for Enterprise Linux repository?
 
-Sure! Just be sure to have at least 1.13.1.
+Sure! Just be sure to [modify the default `libeseccomp`
+profile](http://localhost:4567/docs/enterprise/before-installing/index.html#option-3-docker-engine-using-a-modified-libseccomp-profile).
 
 ### Which storage driver should I use?
 
-Please ensure that you are using the `overlay2` storage driver.
+The `overlay2` storage driver.
 
 ### Can an installation where `docker info` says that I’m using devicemapper with a loopback file work?
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -81,7 +81,7 @@ Make sure your data storage services or device meet Terraform Enterprise's requi
 - _External Services_
     - [PostgreSQL Requirements](./postgres-requirements.html)
     - Any S3-compatible object storage service, GCP Cloud Storage or Azure blob storage meets Terraform Enterprise's object storage requirements. You must create a bucket for Terraform Enterprise to use, and specify that bucket during installation. Depending on your infrastructure provider, you might need to ensure the bucket is in the same region as the Terraform Enterprise instance.
-        - In environments without their own storage service, it may be possible to use [Minio](https://min.io/) for object storage. See the [Minio Setup Guide](./minio-setup-guide.html) for details.
+        - In environments without their own storage service, it may be possible to use [Minio](https://min.io/) for object storage. Refer to the [Minio Setup Guide](./minio-setup-guide.html) for details.
     - Optionally: if you already run your own [Vault](https://www.vaultproject.io/) cluster in production, you can configure Terraform Enterprise to use that instead of running its own internal Vault instance. Before installing Terraform Enterprise, follow the instructions in [Externally Managed Vault Configuration](./vault.html).
 
 - *Active/Active*
@@ -161,7 +161,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
     runc --version
     ```
 
-1. If your Docker Engine and `runc` versions meet the requirements from previous steps, you're all set! Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
+1. If your Docker Engine and `runc` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
 
 
 #### Option 2: Docker Engine With a Compatbile `libseccomp` Version
@@ -187,7 +187,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
     runc --version
     ```
 
-1. If your Docker Engine and `libseccomp` versions meet the requirements from previous steps, you're all set! Otherwise, proceed to [option 3](#option-3-docker-engine-using-a-modified-libseccomp-profile).
+1. If your Docker Engine and `libseccomp` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 3](#option-3-docker-engine-using-a-modified-libseccomp-profile).
 
 #### Option 3: Docker Engine Using a Modified `libseccomp` Profile
 
@@ -205,7 +205,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
 1. Edit the `/etc/docker/seccomp.json` file and modify the line `"defaultAction": "SCMP_ACT_ERRNO",` to be `"defaultAction": "SCMP_ACT_TRACE",`. A `sed` command is included below for your convenience.
 
     ```
-    sudo sed -i 's/\(\"defaultAction\"\:\s*\)\"SCMP_ACT_ERRNO\"/\1\"SCMP_ACT_TRACE\"/' /etc/docker/seccomp.json
+    sudo sed -i 's/"defaultAction":\s*"SCMP_ACT_ERRNO"/"defaultAction": "SCMP_ACT_TRACE"/1' /etc/docker/seccomp.json
     ```
 
 1. Create a drop-in systemd unit file for the `docker` systemd service.

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -101,14 +101,12 @@ Terraform Enterprise runs on Linux instances, and you must prepare a running Lin
 
 Terraform Enterprise currently supports running under the following operating systems:
 
-- **Standalone deployment:**
-
-    - Debian 9 - 10
-    - Ubuntu 14.04.5 / 16.04 / 18.04 / 20.04
-    - Red Hat Enterprise Linux 7.4 - 7.9 / 8.4
-    - CentOS 7.4 - 7.9 / 8.4
-    - Amazon Linux 2014.03 / 2014.09 / 2015.03 / 2015.09 / 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
-    - Oracle Linux 7.4 - 7.9 / 8.4
+	- Debian 9 - 10
+	- Ubuntu 14.04.5 / 16.04 / 18.04 / 20.04
+	- Red Hat Enterprise Linux 7.4 - 7.9 / 8.4
+	- CentOS 7.4 - 7.9 / 8.4
+	- Amazon Linux 2014.03 / 2014.09 / 2015.03 / 2015.09 / 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
+	- Oracle Linux 7.4 - 7.9 / 8.4
 
 ### Hardware Requirements
 
@@ -128,29 +126,64 @@ See [Network Requirements](./network-requirements.html) for details.
 
 <a id="software-requirements"></a>
 
-### Software Requirements (Standalone Deployment)
+### Docker Engine Requirements
 
-Every Terraform Enterprise installation requires the following:
-Enterprise:
+Terraform Enterprise requires **at least one** of the following in order of preference:
 
-- A 64-bit architecture Linux-based operating system
-- Linux Kernel 3.10 or greater
-- Docker Engine 17.06.2-ce to 20.10:
-  - Docker Engine 18.01.0-ce or greater requires Replicated 2.32.0
-    or greater
-  - Support for [Alpine 3.14](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2)
-    Docker images:
-    - Docker Engine 17.06.2-ce to 20.09 requires runc v1.0.0-rc93
-    - Docker Engine 20.10 or greater requires libseccomp 2.4.4
-  - In Online mode, the installer will install Docker Engine
-    automatically
-  - In Airgapped mode, you must install Docker Engine before running
-    the installer
+  1. Compatible Docker Engine and `runc` versions:
+    - Docker Engine 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x.
+    - `runc` v1.0.0-rc93 or greater.
+  2. Compatible Docker Engine and `libseccomp` versions:
+    - Docker Engine 20.10.x.
+    - `libseccomp` 2.4.4 or greater.
 
-Some operating systems also have additional requirements:
+#### Installing Compatible Docker Engine and `runc` Versions
 
-- [RedHat Enterprise Linux (RHEL) Requirements](./rhel-requirements.html)
-- [CentOS Requirements](./centos-requirements.html)
+1. [Install](https://docs.docker.com/engine/install/) Docker Engine 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x for your operating system.
+1. Install the latest version of `containerd` for your operating system.
+  - On Debian/Ubuntu:
+
+        ```
+        sudo apt install containerd
+        ```
+  - On RHEL/CentOS:
+
+        ```
+        sudo yum install containerd.io
+        ```
+1. Confirm that the installed `containerd` version is 1.4.9, 1.5.5, or greater.
+
+    ```
+    containerd --version
+    ```
+1. Confirm that the installed `runc` version is v1.0.0-rc93 or greater:
+
+    ```
+    runc --version
+    ```
+
+
+#### Installing Compatible Docker Engine and `libseccomp` Versions
+
+-> **Note:** These instructions should only be used if you cannot meet the [Docker Engine and `runc`](#installing-compatible-docker-engine-and-runc-versions) requirements above.
+
+1. [Install](https://docs.docker.com/engine/install/) Docker Engine 20.10.x for your operating system.
+1. Install the latest version of `libseccomp` for your operating system.
+  - On Debian/Ubuntu:
+
+        ```
+        sudo apt install libseccomp2
+        ```
+  - On RHEL/CentOS:
+
+        ```
+        sudo yum install libseccomp
+        ```
+1. Confirm that the installed `libseccomp` version is 2.4.4 or greater.
+
+    ```
+    runc --version
+    ```
 
 ### IAM Policies
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -148,11 +148,13 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
         ```
         sudo yum install containerd.io
         ```
+
 1. Confirm that the installed `containerd` version is 1.4.9, 1.5.5, or greater.
 
     ```
     containerd --version
     ```
+
 1. Confirm that the installed `runc` version is v1.0.0-rc93 or greater:
 
     ```
@@ -178,6 +180,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
         ```
         sudo yum install libseccomp
         ```
+
 1. Confirm that the installed `libseccomp` version is 2.4.4 or greater.
 
     ```

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -81,7 +81,7 @@ Make sure your data storage services or device meet Terraform Enterprise's requi
 - _External Services_
     - [PostgreSQL Requirements](./postgres-requirements.html)
     - Any S3-compatible object storage service, GCP Cloud Storage or Azure blob storage meets Terraform Enterprise's object storage requirements. You must create a bucket for Terraform Enterprise to use, and specify that bucket during installation. Depending on your infrastructure provider, you might need to ensure the bucket is in the same region as the Terraform Enterprise instance.
-        - In environments without their own storage service, it may be possible to use [Minio](https://minio.io) for object storage. See the [Minio Setup Guide](./minio-setup-guide.html) for details.
+        - In environments without their own storage service, it may be possible to use [Minio](https://min.io/) for object storage. See the [Minio Setup Guide](./minio-setup-guide.html) for details.
     - Optionally: if you already run your own [Vault](https://www.vaultproject.io/) cluster in production, you can configure Terraform Enterprise to use that instead of running its own internal Vault instance. Before installing Terraform Enterprise, follow the instructions in [Externally Managed Vault Configuration](./vault.html).
 
 - *Active/Active*
@@ -161,7 +161,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
     runc --version
     ```
 
-1. If your Docker Engine and `runc` versions meet the requirements from previous steps, you're all set! Otherwise, proceed to [option 2](#).
+1. If your Docker Engine and `runc` versions meet the requirements from previous steps, you're all set! Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
 
 
 #### Option 2: Docker Engine With a Compatbile `libseccomp` Version
@@ -187,7 +187,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
     runc --version
     ```
 
-1. If your Docker Engine and `libseccomp` versions meet the requirements from previous steps, you're all set! Otherwise, proceed to [option 3](#).
+1. If your Docker Engine and `libseccomp` versions meet the requirements from previous steps, you're all set! Otherwise, proceed to [option 3](#option-3-docker-engine-using-a-modified-libseccomp-profile).
 
 #### Option 3: Docker Engine Using a Modified `libseccomp` Profile
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -132,7 +132,11 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
 
   1. Docker Engine 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x with `runc` v1.0.0-rc93 or greater.
   2. Docker Engine 20.10.x with `libseccomp` 2.4.4 or greater.
-  3. Docker Engine 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x using a modified `libseccomp` profile.
+  3. Docker Engine 1.13.1 (RHEL only), 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x using a modified `libseccomp` profile.
+
+Refer to the sections below for instructions on how to verify your Docker Engine configuration.
+
+-> **Note:** Both the online and airgap installers for Terraform Enterprise are not capable of verifying the Docker Engine configuration automatically.
 
 #### Option 1: Docker Engine With a Compatible `runc` Version
 
@@ -164,7 +168,7 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
 1. If your Docker Engine and `runc` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
 
 
-#### Option 2: Docker Engine With a Compatbile `libseccomp` Version
+#### Option 2: Docker Engine With a Compatible `libseccomp` Version
 
 -> **Note:** These instructions should only be used if your operating system does not meet the Docker Engine requirements detailed in [option 1](#option-1-docker-engine-with-a-compatible-runc-version).
 
@@ -193,7 +197,9 @@ Terraform Enterprise requires **at least one** of the following Docker Engine co
 
 -> **Note:** These instructions should only be used if your operating system does not meet the Docker Engine requirements detailed in either [option 1](#option-1-docker-engine-with-a-compatible-runc-version) or [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
 
-1. [Install](https://docs.docker.com/engine/install/) Docker Engine 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x for your operating system.
+1. [Install](https://docs.docker.com/engine/install/) Docker Engine 1.13.1 (RHEL only), 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x for your operating system.
+
+1. Check if the file `/etc/docker/seccomp.json` exists. If it does, proceed to step 4.
 
 1. Download the [default moby `libseccomp` profile](https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json) and save it to the file `/etc/docker/seccomp.json`.
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -101,12 +101,12 @@ Terraform Enterprise runs on Linux instances, and you must prepare a running Lin
 
 Terraform Enterprise currently supports running under the following operating systems:
 
-	- Debian 9 - 10
-	- Ubuntu 14.04.5 / 16.04 / 18.04 / 20.04
-	- Red Hat Enterprise Linux 7.4 - 7.9 / 8.4
-	- CentOS 7.4 - 7.9 / 8.4
-	- Amazon Linux 2014.03 / 2014.09 / 2015.03 / 2015.09 / 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
-	- Oracle Linux 7.4 - 7.9 / 8.4
+  - Debian 9 - 10
+  - Ubuntu 14.04.5 / 16.04 / 18.04 / 20.04
+  - Red Hat Enterprise Linux 7.4 - 7.9 / 8.4
+  - CentOS 7.4 - 7.9 / 8.4
+  - Amazon Linux 2014.03 / 2014.09 / 2015.03 / 2015.09 / 2016.03 / 2016.09 / 2017.03 / 2017.09 / 2018.03 / 2.0
+  - Oracle Linux 7.4 - 7.9 / 8.4
 
 ### Hardware Requirements
 

--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -165,7 +165,7 @@ Refer to the sections below for instructions on how to verify your Docker Engine
     runc --version
     ```
 
-1. If your Docker Engine and `runc` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
+1. If your Docker Engine and `runc` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatible-libseccomp-version).
 
 
 #### Option 2: Docker Engine With a Compatible `libseccomp` Version
@@ -195,7 +195,7 @@ Refer to the sections below for instructions on how to verify your Docker Engine
 
 #### Option 3: Docker Engine Using a Modified `libseccomp` Profile
 
--> **Note:** These instructions should only be used if your operating system does not meet the Docker Engine requirements detailed in either [option 1](#option-1-docker-engine-with-a-compatible-runc-version) or [option 2](#option-2-docker-engine-with-a-compatbile-libseccomp-version).
+-> **Note:** These instructions should only be used if your operating system does not meet the Docker Engine requirements detailed in either [option 1](#option-1-docker-engine-with-a-compatible-runc-version) or [option 2](#option-2-docker-engine-with-a-compatible-libseccomp-version).
 
 1. [Install](https://docs.docker.com/engine/install/) Docker Engine 1.13.1 (RHEL only), 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x for your operating system.
 

--- a/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
@@ -5,22 +5,12 @@ page_title: "RHEL Requirements - Installation - Terraform Enterprise"
 
 # RHEL Requirements for Terraform Enterprise
 
-When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure your OS and Docker configuration meet the following requirements.
+When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure you meet the following requirements.
 
 ## Install Requirements
 
 * A [supported version](/docs/enterprise/before-installing/index.html#operating-system-requirements) of RedHat Enterprise Linux.
-* One of the following installations of Docker:
-  * Docker CE 17.06 or later. Docker CE can either be pre-installed by the operator or installed via our installation script. If Docker CE is pre-installed by the operator, be sure to pass the `no-docker` flag to the installation script to prevent it from trying to install Docker CE again.
-  * Docker EE 17.06 or later.
-  * Docker 1.13.1 installed via the RHEL Extras repository. Details on how to subscribe to the RHEL Extras repository can be found [here](https://access.redhat.com/solutions/912213).
-* Docker configured with the `overlay2` storage driver. This is the default storage driver for the latest Docker installations.
-
-~> **Note:** The `overlay2` storage driver requires kernel version 3.10.0-693 or greater and the `ftype=1` kernel option when using an XFS filesystem. More details regarding the `overlay2` storage driver can be found [here](https://docs.docker.com/storage/storagedriver/overlayfs-driver/).
-
-~> **Note:** The [Docker documentation] (https://docs.docker.com/storage/storagedriver/select-storage-driver/) states that the `devicemapper` storage driver is deprecated and will be removed in a future release. Users of the `devicemapper` storage driver must migrate to `overlay2`.
-
-~> **Note:** Using `docker-1.13.1-84.git07f3374.el7.x86_64` will result in an RPC error as well as 502 errors and inability to use the application.
+* A [supported Docker Engine](/docs/enterprise/before-installing/index.html##docker-engine-requirements) configuration.
 
 ### Pinning the Docker Version
 
@@ -53,7 +43,7 @@ If you opt to use Docker 1.13.1 from RHEL extras, then you must make a change to
 
 ### Can I use the Docker version in the RHEL Extras repository?
 
-Sure! Just be sure to have at least 1.13.1 and authorization plugins disabled.
+Yes! Just be sure to [modify the default `libseccomp` profile](/docs/enterprise/before-installing/index.html#option-3-docker-engine-using-a-modified-libseccomp-profile).
 
 ### When I run the installer, it allows me to download and install Docker CE on RedHat. Can I use that?
 
@@ -61,7 +51,7 @@ Yes, Docker CE is compatible with Terraform Enterprise. However, it is not direc
 
 ### Which storage driver should I use?
 
-Please ensure that you are using the `overlay2` storage driver.
+The `overlay2` storage driver.
 
 ### Can an installation where `docker info` says that I’m using devicemapper with a loopback file work?
 

--- a/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
+++ b/content/source/docs/enterprise/before-installing/rhel-requirements.html.md
@@ -10,7 +10,7 @@ When installing Terraform Enterprise on RedHat Enterprise Linux (RHEL), ensure y
 ## Install Requirements
 
 * A [supported version](/docs/enterprise/before-installing/index.html#operating-system-requirements) of RedHat Enterprise Linux.
-* A [supported Docker Engine](/docs/enterprise/before-installing/index.html##docker-engine-requirements) configuration.
+* A [supported Docker Engine](/docs/enterprise/before-installing/index.html#docker-engine-requirements) configuration.
 
 ### Pinning the Docker Version
 


### PR DESCRIPTION
The Docker Engine requirements needed to be more explicit to deal with
issues that Docker Engine has with Alpine 3.14 containers.

This is basically forwarding the information from the [Alpine 3.14 release notes](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2)
along to Terraform operators.