### PR TITLE
OAuth API: Update Docs to explain key, secret, and rsa_public_key

### DIFF
--- a/content/source/docs/cloud/api/changelog.html.md
+++ b/content/source/docs/cloud/api/changelog.html.md
@@ -13,6 +13,10 @@ page_id: "api-changelog"
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+### 2021-12-03
+
+* OAuth API updated to handle `secret` and `rsa_public_key` fields for POST/PUT.
+
 ### 2021-11-17
 
 * Added pagination support to the following endpoints:

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -206,7 +206,7 @@ Key path                             | Type   | Default | Description
 `data.attributes.oauth-token-string` | string |         | The token string you were given by your VCS provider
 `data.attributes.private-key`        | string |         | **Required for Azure DevOps Server. Not used for any other providers.** The text of the SSH private key associated with your Azure DevOps Server account.
 `data.attributes.secret`             | string |         | The OAuth Client secret. For BitBucket Server, this secret is the the text of the SSH private key associated with your BitBucket Server Application Link.
-`data.attributes.rsa-public-key`     | string |         | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
+`data.attributes.rsa-public-key`     | string |         | **Required for BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
 
 ### Sample Payload
 

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -205,7 +205,7 @@ Key path                             | Type   | Default | Description
 `data.attributes.api-url`            | string |         | The base URL of your VCS provider's API (e.g. `"https://api.github.com"` or `"https://ghe.example.com/api/v3"`)
 `data.attributes.oauth-token-string` | string |         | The token string you were given by your VCS provider
 `data.attributes.private-key`        | string |         | **Required for Azure DevOps Server. Not used for any other providers.** The text of the SSH private key associated with your Azure DevOps Server account.
-`data.attributes.secret`             | string |         | The OAuth Client secret. _For BitBucket Server, this secret is the The text of the SSH private key associated with your BitBucket Server Application Link._
+`data.attributes.secret`             | string |         | The OAuth Client secret. For BitBucket Server, this secret is the the text of the SSH private key associated with your BitBucket Server Application Link.
 `data.attributes.rsa-public-key`     | string |         | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
 
 ### Sample Payload

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -300,7 +300,7 @@ Key path                             | Type   | Default | Description
 `data.type`                          | string |         | Must be `"oauth-clients"`.
 `data.attributes.name`               | string | (previous value)  | An optional display name for the OAuth Client. If set to `null`, the UI will default to the display name of the VCS provider.
 `data.attributes.key`                | string | (previous value) | The OAuth Client key. It can refer to a Consumer Key, Application Key, or another type of client key for the VCS provider.
-`data.attributes.secret`             | string | (previous value) | The OAuth Client secret. _For BitBucket Server, this secret is the The text of the SSH private key associated with your BitBucket Server Application Link._
+`data.attributes.secret`             | string | (previous value) | The OAuth Client secret. For BitBucket Server, this secret is the the text of the SSH private key associated with your BitBucket Server Application Link.
 `data.attributes.rsa-public-key`     | string | (previous value) | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
 
 

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -178,7 +178,7 @@ This endpoint allows you to create a VCS connection between an organization and 
 To learn how to generate one of these token strings for your VCS provider, you can read the following documentation:
 
 * [GitHub and GitHub Enterprise](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-* [GitLab, GitLab Community Edition, and GitLab Enterprise Edition](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creating-a-personal-access-token)
+* [GitLab, GitLab Community Edition, and GitLab Enterprise Edition](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token)
 * [Azure DevOps Server](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops-2019&tabs=preview-page)
 
 ~> **Note:** This endpoint does not currently support creation of a Bitbucket Cloud, Bitbucket Server, or Azure DevOps Services OAuth Client.
@@ -200,10 +200,13 @@ Key path                             | Type   | Default | Description
 `data.type`                          | string |         | Must be `"oauth-clients"`.
 `data.attributes.service-provider`   | string |         | The VCS provider being connected with. Valid options are `"github"`, `"github_enterprise"`, `"gitlab_hosted"`, `"gitlab_community_edition"`, `"gitlab_enterprise_edition"`, or `"ado_server"`.
 `data.attributes.name`               | string | `null`  | An optional display name for the OAuth Client. If left `null`, the UI will default to the display name of the VCS provider.
+`data.attributes.key`                | string |         | The OAuth Client key. It sometimes refers to a Consumer Key or Application Key or some other client key for the VCS provider.
 `data.attributes.http-url`           | string |         | The homepage of your VCS provider (e.g. `"https://github.com"` or `"https://ghe.example.com"`)
 `data.attributes.api-url`            | string |         | The base URL of your VCS provider's API (e.g. `"https://api.github.com"` or `"https://ghe.example.com/api/v3"`)
 `data.attributes.oauth-token-string` | string |         | The token string you were given by your VCS provider
 `data.attributes.private-key`        | string |         | **Required for Azure DevOps Server. Not used for any other providers.** The text of the SSH private key associated with your Azure DevOps Server account.
+`data.attributes.secret`             | string |         | The OAuth Client secret. _For BitBucket Server, this secret is the The text of the SSH private key associated with your BitBucket Server Application Link._
+`data.attributes.rsa-public-key`     | string |         | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
 
 ### Sample Payload
 
@@ -296,8 +299,10 @@ Key path                             | Type   | Default | Description
 -------------------------------------|--------|---------|------------
 `data.type`                          | string |         | Must be `"oauth-clients"`.
 `data.attributes.name`               | string | (previous value)  | An optional display name for the OAuth Client. If set to `null`, the UI will default to the display name of the VCS provider.
-`data.attributes.key`                | string | (previous value) | The OAuth client key.
-`data.attributes.secret`             | string | (previous value) | The OAuth client secret.
+`data.attributes.key`                | string | (previous value) | The OAuth Client key. It sometimes refers to a Consumer Key or Application Key or some other client key for the VCS provider.
+`data.attributes.secret`             | string | (previous value) | The OAuth Client secret. _For BitBucket Server, this secret is the The text of the SSH private key associated with your BitBucket Server Application Link._
+`data.attributes.rsa-public-key`     | string | (previous value) | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
+
 
 ### Sample Payload
 

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -200,7 +200,7 @@ Key path                             | Type   | Default | Description
 `data.type`                          | string |         | Must be `"oauth-clients"`.
 `data.attributes.service-provider`   | string |         | The VCS provider being connected with. Valid options are `"github"`, `"github_enterprise"`, `"gitlab_hosted"`, `"gitlab_community_edition"`, `"gitlab_enterprise_edition"`, or `"ado_server"`.
 `data.attributes.name`               | string | `null`  | An optional display name for the OAuth Client. If left `null`, the UI will default to the display name of the VCS provider.
-`data.attributes.key`                | string |         | The OAuth Client key. It sometimes refers to a Consumer Key or Application Key or some other client key for the VCS provider.
+`data.attributes.key`                | string |         | The OAuth Client key. It can refer to a Consumer Key, Application Key, or another type of client key for the VCS provider.
 `data.attributes.http-url`           | string |         | The homepage of your VCS provider (e.g. `"https://github.com"` or `"https://ghe.example.com"`)
 `data.attributes.api-url`            | string |         | The base URL of your VCS provider's API (e.g. `"https://api.github.com"` or `"https://ghe.example.com/api/v3"`)
 `data.attributes.oauth-token-string` | string |         | The token string you were given by your VCS provider

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -301,7 +301,7 @@ Key path                             | Type   | Default | Description
 `data.attributes.name`               | string | (previous value)  | An optional display name for the OAuth Client. If set to `null`, the UI will default to the display name of the VCS provider.
 `data.attributes.key`                | string | (previous value) | The OAuth Client key. It can refer to a Consumer Key, Application Key, or another type of client key for the VCS provider.
 `data.attributes.secret`             | string | (previous value) | The OAuth Client secret. For BitBucket Server, this secret is the the text of the SSH private key associated with your BitBucket Server Application Link.
-`data.attributes.rsa-public-key`     | string | (previous value) | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
+`data.attributes.rsa-public-key`     | string | (previous value) | **Required for BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
 
 
 ### Sample Payload

--- a/content/source/docs/cloud/api/oauth-clients.html.md
+++ b/content/source/docs/cloud/api/oauth-clients.html.md
@@ -299,7 +299,7 @@ Key path                             | Type   | Default | Description
 -------------------------------------|--------|---------|------------
 `data.type`                          | string |         | Must be `"oauth-clients"`.
 `data.attributes.name`               | string | (previous value)  | An optional display name for the OAuth Client. If set to `null`, the UI will default to the display name of the VCS provider.
-`data.attributes.key`                | string | (previous value) | The OAuth Client key. It sometimes refers to a Consumer Key or Application Key or some other client key for the VCS provider.
+`data.attributes.key`                | string | (previous value) | The OAuth Client key. It can refer to a Consumer Key, Application Key, or another type of client key for the VCS provider.
 `data.attributes.secret`             | string | (previous value) | The OAuth Client secret. _For BitBucket Server, this secret is the The text of the SSH private key associated with your BitBucket Server Application Link._
 `data.attributes.rsa-public-key`     | string | (previous value) | **Required BitBucket Server in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your BitBucket Server Application Link.
 


### PR DESCRIPTION
# Description

This PR updates the OAuth API to:
1. Better explain `key` and `secret` that already exist in the API.
2. Add the `rsa-public-key` to the POST/PUT endpoints.

# Doc Updates

![image](https://user-images.githubusercontent.com/4130121/144613439-583b7097-fe15-4117-b49d-485b114dc7d8.png)

# Changelog

![image](https://user-images.githubusercontent.com/4130121/144613514-9a63f1a6-c531-4096-8500-6e6e59141836.png)
