### PR TITLE
Document 'Require Site Admins to Enable Two-factor Authentication'

### DIFF
--- a/content/source/docs/enterprise/admin/general.html.md
+++ b/content/source/docs/enterprise/admin/general.html.md
@@ -15,13 +15,13 @@ General settings control global behavior in Terraform Enterprise. To access gene
 
 ## Require Site Admins to Enable Two-factor Authentication
 
--> **Note**: This setting can be used in conjunction with SAML in Terraform Enterprise versions v202201-1 or later. Prior to this release, the setting had no effect if SAML was also enabled
+-> **Note**: You can use this setting in conjunction with SAML for Terraform Enterprise v202201-1 or later. For prior versions, this setting has no effect if SAML is also enabled.
 
-Enabling this setting adds the requirement that admins have two-factor authentication enabled to access site admin functionality, which can make the site more secure.
+This setting can make the site more secure by requiring that admins enable two-factor authentication to access site admin functionality.
 
 Admins that do not have two-factor authentication enabled may still log in, but will be unable to perform any admin-only functions until they enable and verify two-factor authentication.
 
-This setting can be used in conjunction with [SAML Single Sign On](https://www.terraform.io/docs/enterprise/saml/index.html).
+You can use this setting in conjunction with [SAML Single Sign On](https://www.terraform.io/docs/enterprise/saml/index.html).
 
 ## Contact Info
 

--- a/content/source/docs/enterprise/admin/general.html.md
+++ b/content/source/docs/enterprise/admin/general.html.md
@@ -13,6 +13,16 @@ General settings control global behavior in Terraform Enterprise. To access gene
 
 -> **API:** See the [Admin Settings API](/docs/cloud/api/admin/settings.html).
 
+## Require Site Admins to Enable Two-factor Authentication
+
+-> **Note**: This setting can be used in conjunction with SAML in Terraform Enterprise versions v202201-1 or later. Prior to this release, the setting had no effect if SAML was also enabled
+
+Enabling this setting adds the requirement that admins have two-factor authentication enabled to access site admin functionality, which can make the site more secure.
+
+Admins that do not have two-factor authentication enabled may still log in, but will be unable to perform any admin-only functions until they enable and verify two-factor authentication.
+
+This setting can be used in conjunction with [SAML Single Sign On](https://www.terraform.io/docs/enterprise/saml/index.html).
+
 ## Contact Info
 
 The support email address is used in system emails and other contact details. It defaults to support@hashicorp.com. If you'd like  users of your instance to reach out to a specific person or team when they have issues, it can be changed to a local email address.


### PR DESCRIPTION
Adds documentation for the already existing 'Require Site Admins to Enable Two-factor Authentication' setting.

Includes a note for this functionality working in conjunction with SAML as of Terraform Enterprise versions v202201-1 or later.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [ ] inaccuracy
- [ ] clarification
- [x] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
