### PR TITLE
Update index.html.md

### DIFF
--- a/content/source/docs/enterprise/before-installing/index.html.md
+++ b/content/source/docs/enterprise/before-installing/index.html.md
@@ -314,3 +314,4 @@ For _Mounted Disk_ installations, you must:
     semanage fcontext -a -t container_file_t "/opt/tfe(/.*)?"
     restorecon -R /opt/tfe
     ```
+-> ** Note: ** The `install.sh` script will attempt to install `container-selinux` in online mode. Regradless of mode container-selinux package as a dependacy on the `policycoreutils-python` package being installed.


### PR DESCRIPTION
#ln1515 (approx) of the replicated install script now attempts to install container-selinux. 
it utilises a direct source method for the package so dependancies are not met. 

the change above calls out the dependancy `policycoreutils-python` the installer will exit if this package is not installed, manual installation of `container-selinux` infers this dependancy being met.

## Labels

<!-- Check any labels that apply to this PR. Or, if you have repo permissions, assign a real label and omit this section. -->

- [] inaccuracy
- [x] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
