### PR TITLE
Fix run task hmac header typo

### DIFF
--- a/content/source/docs/cloud/integrations/run-tasks/index.html.md
+++ b/content/source/docs/cloud/integrations/run-tasks/index.html.md
@@ -68,7 +68,7 @@ Here's what the data flow looks like:
 
 ## Securing your Run Task
 
-When creating your run task, you can supply an HMAC key which Terraform Cloud will use to create a signature of the payload in the `x-tfc-run-task-signature` header when calling your service.
+When creating your run task, you can supply an HMAC key which Terraform Cloud will use to create a signature of the payload in the `x-tfc-task-signature` header when calling your service.
 
 The signature is a sha512 sum of the webhook body using the provided HMAC key. The generation of the signature depends on your implementation, however an example of how to generate a signature in bash is provided below.
 


### PR DESCRIPTION
A very small typo in the run task integration docs, which if used would not work.

## Labels

- [x] inaccuracy
- [ ] clarification
- [ ] new docs
- [ ] cosmetic bug - fixing broken text or markup
- [ ] enhancement - changing the website's behavior/layout
- [ ] api - requires an update to the [changelog](https://www.terraform.io/docs/cloud/api/changelog.html)
