### PR TITLE
Add Makefile and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
+RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
+
+COPY ./package.json /website/package.json
+COPY ./package-lock.json /website/package-lock.json
+WORKDIR /website
+RUN npm install -g npm@latest
+RUN npm install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Default: run this if working on the website locally to run in watch mode.
+website:
+	@echo "==> Downloading latest Docker image..."
+	@docker pull hashicorp/terraform-website
+	@echo "==> Starting website in Docker..."
+	@docker run \
+		--interactive \
+		--rm \
+		--tty \
+		--workdir "/website" \
+		--volume "$(shell pwd):/website" \
+		--volume "/website/node_modules" \
+		--publish "3000:3000" \
+		hashicorp/terraform-website \
+		npm start
+
+# This command will generate a static version of the website to the "out" folder.
+build:
+	@echo "==> Downloading latest Docker image..."
+	@docker pull hashicorp/terraform-website
+	@echo "==> Starting build in Docker..."
+	@docker run \
+		--interactive \
+		--rm \
+		--tty \
+		--workdir "/website" \
+		--volume "$(shell pwd):/website" \
+		--volume "/website/node_modules" \
+		hashicorp/terraform-website \
+		npm run static
+
+# If you are changing node dependencies locally, run this to generate a new
+# local Docker image with the dependency changes included.
+build-image:
+	@echo "==> Building Docker image..."
+	@docker build -t hashicorp-terraform-website-local .
+
+# Use this if you have run `build-image` to use the locally built image
+# rather than our CI-generated image to test dependency changes.
+website-local:
+	@echo "==> Starting website in Docker..."
+	@docker run \
+		--interactive \
+		--rm \
+		--tty \
+		--workdir "/website" \
+		--volume "$(shell pwd):/website" \
+		--volume "/website/node_modules" \
+		--publish "3000:3000" \
+		hashicorp-terraform-website-local \
+		npm start
+
+.DEFAULT_GOAL := website
+.PHONY: build build-image website website-local


### PR DESCRIPTION
This PR adds the `Makefile` and `Dockerfile` that were accidentally overwritten during the Great MDX Migration of December 2021 ™️ .