### PR TITLE
Install the latest version of npm in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
               echo "Not Terraform Website Repo, not indexing Algolia"
               exit 0
             fi
+            npm i -g npm@latest
             npm ci
             node scripts/index_search_content.js
 workflows:


### PR DESCRIPTION
CircleCI uses an older version of npm that incorrectly downloads incompatible binaries for swc when installing Next.js, so this PR ensures that we're always using the latest version of npm (which mirrors the behavior we use when building our Docker image).