### PR TITLE
Pull submodules when building search index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Pull submodules
+          command: git submodule update --init
+      - run:
           name: Push content to Algolia Index
           command: |
             if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/terraform-website.git" ]; then


### PR DESCRIPTION
CircleCI's `checkout` step doesn't initialize submodules, so we're only pushing search index entries from docs in this repo. This change makes sure that we initialize the submodules prior to generating the index.