### PR TITLE
Redirect providers who use index.html in URL

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -127,7 +127,7 @@ module.exports = (async () => {
   const registryTopLevelRedirects = Object.entries(tfProviderNamespaces).map(
     ([namespace, repo]) => {
       return {
-        source: `/docs/providers/${namespace}`,
+        source: `/docs/providers/${namespace}(/index.html)?`,
         destination: `https://registry.terraform.io/providers/${repo}/latest/docs`,
         permanent: true,
       }


### PR DESCRIPTION
This PR updates our providers redirects to account for URLs that include `index.html` (`/docs/providers/github/index.html`).