### PR TITLE
Publish Docker image updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,38 @@ jobs:
             npm i -g npm@latest
             npm ci
             node scripts/index_search_content.js
+  website-docker-image:
+    docker:
+      - image: circleci/buildpack-deps
+    shell: /usr/bin/env bash -euo pipefail -c
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker Image if Necessary
+          command: |
+            IMAGE_TAG="$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)"
+            echo "Using $IMAGE_TAG"
+            if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/terraform-website.git" ]; then
+              echo "Not Terraform Website Repo, not building website docker image"
+            elif curl https://hub.docker.com/v2/repositories/hashicorp/terraform-website/tags/$IMAGE_TAG -fsL > /dev/null; then
+              echo "Dependencies have not changed, not building a new website docker image."
+            else
+              docker build -t hashicorp/terraform-website:$IMAGE_TAG .
+              docker tag hashicorp/terraform-website:$IMAGE_TAG hashicorp/terraform-website:latest
+              docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
+              docker push hashicorp/terraform-website
+            fi
 workflows:
   version: 2
-  algolia_index:
+  website:
     jobs:
       - algolia-index:
+          filters:
+            branches:
+              only:
+                - master
+      - website-docker-image:
           filters:
             branches:
               only:


### PR DESCRIPTION
This PR adds a CircleCI job to publish updates to the `hashicorp/terraform-website` Docker image on pushes to `master`.