### PR TITLE
Build full Docker image on every commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,15 +29,20 @@ jobs:
       - run:
           name: Build Docker Image if Necessary
           command: |
-            IMAGE_TAG="$(git rev-list -n1 HEAD -- Dockerfile package-lock.json)"
-            echo "Using $IMAGE_TAG"
             if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/terraform-website.git" ]; then
               echo "Not Terraform Website Repo, not building website docker image"
-            elif curl https://hub.docker.com/v2/repositories/hashicorp/terraform-website/tags/$IMAGE_TAG -fsL > /dev/null; then
-              echo "Dependencies have not changed, not building a new website docker image."
             else
-              docker build -t hashicorp/terraform-website:$IMAGE_TAG .
-              docker tag hashicorp/terraform-website:$IMAGE_TAG hashicorp/terraform-website:latest
+              echo "Building full image..."
+              docker build -t hashicorp/terraform-website:$CIRCLE_SHA1 -f full.Dockerfile .
+              docker tag hashicorp/terraform-website:$CIRCLE_SHA1 hashicorp/terraform-website:full
+              IMAGE_TAG="$(git rev-list -n1 HEAD -- Dockerfile package-lock.json)"
+              echo "Using $IMAGE_TAG for latest image"
+              if curl https://hub.docker.com/v2/repositories/hashicorp/terraform-website/tags/$IMAGE_TAG -fsL > /dev/null; then
+                echo "Dependencies have not changed, not building a new website docker image."
+              else
+                docker build -t hashicorp/terraform-website:$IMAGE_TAG .
+                docker tag hashicorp/terraform-website:$IMAGE_TAG hashicorp/terraform-website:latest
+              fi
               docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
               docker push hashicorp/terraform-website
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           command: |
             if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/terraform-website.git" ]; then
               echo "Not Terraform Website Repo, not building website docker image"
+              exit 0
             else
               echo "Building full image..."
               docker build -t hashicorp/terraform-website:$CIRCLE_SHA1 -f full.Dockerfile .

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git/
+node_modules/
+.DS_Store
+.next/
+out
+.mdx-data
+
+# As per Next.js conventions (https://nextjs.org/docs/basic-features/environment-variables#default-environment-variables)
+!.env
+.env*.local
+
+Dockerfile
+full.Dockerfile

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
+RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
+
+COPY . /website
+WORKDIR /website
+RUN npm install -g npm@latest
+RUN npm install


### PR DESCRIPTION
This PR builds a `hashicorp/terraform-website:full` Docker image on each commit to `master` to enable consumers in `terraform` and `terraform-cdk` to run `make website` without having a local checkout of the repo.