### PR TITLE
Properly handle more redirects from old URLs

### DIFF
--- a/data/docs-redirects.js
+++ b/data/docs-redirects.js
@@ -845,7 +845,7 @@ export const docsRedirects = {
   '/docs/extend/hashicorp-provider-design-principles.html': '/plugin/hashicorp-provider-design-principles',
   '/docs/extend/how-terraform-works.html': '/plugin/how-terraform-works',
   '/docs/extend/index.html': '/plugin',
-  '/docs/extend/plugin-sdk.html\t\t\t\t': '/plugin/sdkv2/guides/v1-upgrade-guide',
+  '/docs/extend/plugin-sdk.html': '/plugin/sdkv2/guides/v1-upgrade-guide',
   '/docs/extend/plugin-types.html': '/plugin',
   '/docs/extend/resources.html': '/plugin/sdkv2/resources',
   '/docs/extend/resources/customizing-differences.html': '/plugin/sdkv2/resources/customizing-differences',

--- a/pages/docs/[[...page]].jsx
+++ b/pages/docs/[[...page]].jsx
@@ -34,17 +34,32 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  if (params.page) {
+  const DEFINED_DOCS_PAGES = ['glossary', 'partnerships']
+
+  if (params.page && !DEFINED_DOCS_PAGES.includes(params.page[0])) {
     const path = ['/docs', ...params.page].join('/')
-    if (path in docsRedirects) {
-      return {
-        redirect: {
-          destination: docsRedirects[path],
-          permanent: true,
-        },
+    const pathIndexHtml = [path, 'index.html'].join('/')
+    const pathHtml = `${path}.html`
+
+    for (const key of [path, pathIndexHtml, pathHtml]) {
+      if (key in docsRedirects) {
+        return {
+          redirect: {
+            destination: docsRedirects[key],
+            permanent: true,
+          },
+        }
       }
     }
+
+    // We've hit a /docs page that's not in our redirects, and isn't one of the
+    // defined /docs routes, so return a 404 instead of trying to call the
+    // generateStaticProps method which returns a 500 error.
+    return {
+      notFound: true,
+    }
   }
+
   const props = await generateStaticProps({
     navDataFile: NAV_DATA,
     localContentDir: CONTENT_DIR,


### PR DESCRIPTION
Currently, we have redirects defined using the canonical URL from the original sitemap, which includes `.html` and `index.html`. However, S3 would allow you to redirect from pages like `/docs/cdktf` to `/docs/cdktf/index.html` and `/docs/enterprise-beta/workspaces/naming` to `/docs/enterprise-beta/workspaces/naming.html`.

This PR replicates that functionality by appending `/index.html` and `.html` to incoming `/docs` requests and checks if any of them are defined in the `docs-redirects.json` file. If so, it performs the redirect.

Additionally, this PR returns a 404 error when the incoming request is for a page that's not part of our very small number of defined `/docs` pages (currently `/docs/glossary` and `/docs/partnerships`) and also isn't a defined redirect. Previously we returned a 500 error since we attempted to call the `generateStaticProps` method.