### PR TITLE
plugin: Recommend Terraform v1.0 for framework instead of v1.0.3

### DIFF
--- a/content/plugin/framework/index.mdx
+++ b/content/plugin/framework/index.mdx
@@ -9,7 +9,7 @@ description: |-
 
 The plugin framework is a new way to develop Terraform plugins, providing improvements and new features from [Teraform Plugin SDKv2](/plugin/sdkv2/sdkv2-intro).
 
-~> **Important**: HashiCorp is currently developing providers against the framework, but it is still early in its development cycle. Its interfaces are subject to change and it may not yet support all of your desired features. It can also only build providers that require **Terraform v1.0.3 or later**.
+~> **Important**: HashiCorp is currently developing providers against the framework, but it is still early in its development cycle. Its interfaces are subject to change and it may not yet support all of your desired features. It can also only build providers that require **Terraform v1.0 or later**.
 [Which SDK Should I Use?](/plugin/which-sdk) can help you decide whether the framework is right for your provider.
 
 ## Get Started

--- a/content/plugin/framework/index.mdx
+++ b/content/plugin/framework/index.mdx
@@ -9,7 +9,7 @@ description: |-
 
 The plugin framework is a new way to develop Terraform plugins, providing improvements and new features from [Teraform Plugin SDKv2](/plugin/sdkv2/sdkv2-intro).
 
-~> **Important**: HashiCorp is currently developing providers against the framework, but it is still early in its development cycle. Its interfaces are subject to change and it may not yet support all of your desired features. It can also only build providers that require **Terraform v1.0 or later**.
+~> **Important**: HashiCorp is currently developing providers against the framework, but it is still early in its development cycle. Its interfaces are subject to change and it may not yet support all of your desired features. It can also only build providers that require **Terraform CLI v1.0 or later**.
 [Which SDK Should I Use?](/plugin/which-sdk) can help you decide whether the framework is right for your provider.
 
 ## Get Started

--- a/content/plugin/which-sdk.mdx
+++ b/content/plugin/which-sdk.mdx
@@ -25,12 +25,12 @@ to build resources into an SDKv2 provider.
 If you are developing a greenfield provider, you should consider building it
 with the framework.
 
-## Do You Need to Support Users Not On Terraform v1.0 Yet?
+## Do You Need to Support Users Not On Terraform CLI v1.0 Yet?
 
-If you support user bases that have not upgraded to Terraform v1.0 in
+If you support user bases that have not upgraded to Terraform CLI v1.0 in
 significant numbers, we recommend that you continue using SDKv2. The framework
 is built on Terraform protocol version 6, and Terraform could not download
-providers using protocol version 6 until Terraform v1.0.
+providers using protocol version 6 until Terraform CLI v1.0.
 
 If you do not have a user base or your user base has mostly upgraded to v1.0,
 the framework may be appropriate.

--- a/content/plugin/which-sdk.mdx
+++ b/content/plugin/which-sdk.mdx
@@ -25,14 +25,14 @@ to build resources into an SDKv2 provider.
 If you are developing a greenfield provider, you should consider building it
 with the framework.
 
-## Do You Need to Support Users Not On Terraform v1.0.3 Yet?
+## Do You Need to Support Users Not On Terraform v1.0 Yet?
 
-If you support user bases that have not upgraded to Terraform v1.0.3 in
+If you support user bases that have not upgraded to Terraform v1.0 in
 significant numbers, we recommend that you continue using SDKv2. The framework
 is built on Terraform protocol version 6, and Terraform could not download
-providers using protocol version 6 until Terraform v1.0.3.
+providers using protocol version 6 until Terraform v1.0.
 
-If you do not have a user base or your user base has mostly upgraded to v1.0.3,
+If you do not have a user base or your user base has mostly upgraded to v1.0,
 the framework may be appropriate.
 
 ## Do You Have Bandwidth to Track and Resolve Breaking Changes?


### PR DESCRIPTION
Practitioners should generally opt for the latest available patch version of a Terraform CLI minor version. Having this level of specificity in the documentation could potentially be confusing.