### PR TITLE
plugin: Add terraform-provider-scaffolding and terraform-provider-scaffolding-framework CTAs

### DIFF
--- a/content/plugin/framework/index.mdx
+++ b/content/plugin/framework/index.mdx
@@ -14,7 +14,8 @@ The plugin framework is a new way to develop Terraform plugins, providing improv
 
 ## Get Started
 
-Try the [Implement Create and Read with the Terraform Plugin Framework](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers) tutorial on HashiCorp Learn or clone the [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) template repository on GitHub.
+- Try the [Implement Create and Read with the Terraform Plugin Framework](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers) tutorial on HashiCorp Learn.
+- Clone the [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) template repository on GitHub.
 
 ## Key Concepts
 

--- a/content/plugin/framework/index.mdx
+++ b/content/plugin/framework/index.mdx
@@ -14,7 +14,7 @@ The plugin framework is a new way to develop Terraform plugins, providing improv
 
 ## Get Started
 
-Try the [Implement Create and Read with the Terraform Plugin Framework](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers) tutorial on HashiCorp Learn.
+Try the [Implement Create and Read with the Terraform Plugin Framework](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers) tutorial on HashiCorp Learn or clone the [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) template repository on GitHub.
 
 ## Key Concepts
 

--- a/content/plugin/index.mdx
+++ b/content/plugin/index.mdx
@@ -19,6 +19,7 @@ Terraform is logically split into two main parts:
 - Learn the [design principles](/plugin/hashicorp-provider-design-principles) HashiCorp developers follow when creating providers.
 - Decide [which SDK](/plugin/which-sdk) is right for your provider.
 - Try these hands-on tutorials on HashiCorp Learn: [Call APIs with Terraform Providers (SDKv2)](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Implement Create and Read (Framework)](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers)
+- Clone these template repositories on GitHub: [terraform-provider-scaffolding (SDKv2)](https://github.com/hashicorp/terraform-provider-scaffolding) and [terraform-provider-scaffolding-framework (Framework)](https://github.com/hashicorp/terraform-provider-scaffolding-framework)
 
 ## Develop and Share Providers
 

--- a/content/plugin/sdkv2/sdkv2-intro.mdx
+++ b/content/plugin/sdkv2/sdkv2-intro.mdx
@@ -11,7 +11,8 @@ Terraform Plugin SDKv2 is an established way to develop Terraform Plugins. It is
 
 ## Get Started
 
-Try the [Call APIs with Custom Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials on HashiCorp Learn.
+- Try the [Call APIs with Custom Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials on HashiCorp Learn.
+- Clone the [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding) template repository on GitHub.
 
 ## Key Concepts
 


### PR DESCRIPTION
Closes hashicorp/terraform-provider-scaffolding-framework#4

This should help increase visibility of this template repository, which can be very helpful for developers to bootstrap a new provider.