### PR TITLE
Optimize Docker layers by building both images from same Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,15 @@ jobs:
               exit 0
             else
               echo "Building full image..."
-              docker build -t hashicorp/terraform-website:$CIRCLE_SHA1 -f full.Dockerfile .
+              docker build -t hashicorp/terraform-website:$CIRCLE_SHA1 .
               docker tag hashicorp/terraform-website:$CIRCLE_SHA1 hashicorp/terraform-website:full
               IMAGE_TAG="$(git rev-list -n1 HEAD -- Dockerfile package-lock.json)"
               echo "Using $IMAGE_TAG for latest image"
               if curl https://hub.docker.com/v2/repositories/hashicorp/terraform-website/tags/$IMAGE_TAG -fsL > /dev/null; then
                 echo "Dependencies have not changed, not building a new website docker image."
               else
-                docker build -t hashicorp/terraform-website:$IMAGE_TAG .
+                echo "Building base image..."
+                docker build --target base -t hashicorp/terraform-website:$IMAGE_TAG .
                 docker tag hashicorp/terraform-website:$IMAGE_TAG hashicorp/terraform-website:latest
               fi
               docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine AS base
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
-COPY ./package.json /website/package.json
-COPY ./package-lock.json /website/package-lock.json
+COPY ./package.json ./package-lock.json /website/
 WORKDIR /website
-RUN npm install -g npm@latest
-RUN npm install
+RUN npm install -g npm@latest && npm ci
+
+FROM base AS full
+COPY . /website

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -1,7 +1,0 @@
-FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
-RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
-
-COPY . /website
-WORKDIR /website
-RUN npm install -g npm@latest
-RUN npm install


### PR DESCRIPTION
This PR builds both our `:latest` and `:full` images from the same Dockerfile, using multi-stage builds. This gives a slight speed up (since we can reuse the previous base image if deps haven't changed), while ensuring that the `node_modules` folder between the two images is the same.