### PR TITLE
Prevent the rendering of plain text Markdown references

### DIFF
--- a/content/docs/glossary.mdx
+++ b/content/docs/glossary.mdx
@@ -97,10 +97,9 @@ This page collects brief definitions of some of the technical terms used in the 
 ## API
 
 [api]: /docs/glossary#api
-
 [apis]: /docs/glossary#api
 
-"Application Programming Interface". Any interface designed to allow programmatic manipulation of some kind of software system. For most software developers today, the most common kinds of APIs are based on HTTP requests.
+Acronym for "Application Programming Interface". Any interface designed to allow programmatic manipulation of some kind of software system. For most software developers today, the most common kinds of APIs are based on HTTP requests.
 
 Terraform relies on cloud service provider APIs to manage resources; each service's Terraform provider is responsible for mapping Terraform's resource model to the series of actual API calls necessary to create, check, modify, or delete a real infrastructure resource in that cloud service.
 
@@ -395,7 +394,7 @@ Interpolation is a very common feature in programming languages; for example, Ru
 
 [json]: /docs/glossary#json
 
-"JavaScript Object Notation". A popular text-based data interchange format, which can represent strings, numbers, booleans, null, arrays, and objects/maps.
+Acronym for "JavaScript Object Notation". A popular text-based data interchange format, which can represent strings, numbers, booleans, null, arrays, and objects/maps.
 
 Terraform and Terraform Cloud often interact with JSON data in order to consume or provide APIs. Terraform also supports JSON as an alternate format for [configurations][].
 
@@ -503,7 +502,7 @@ Data exported by a Terraform [module][], which can be displayed to a user and/or
 
 [oss]: /docs/glossary#oss
 
-"Open-Source Software". Terraform and the publicly available Terraform providers are open-source. Terraform Cloud and Terraform Enterprise are closed-source commercial software, but they make use of Terraform and the available Terraform providers.
+Acronym for "Open-Source Software". Terraform and the publicly available Terraform providers are open-source. Terraform Cloud and Terraform Enterprise are closed-source commercial software, but they make use of Terraform and the available Terraform providers.
 
 - [Wikipedia: Open-Source Software](https://en.wikipedia.org/wiki/Open-source_software)
 


### PR DESCRIPTION
The MDX parser has a bug where lines beginning with quote characters immediately following a Markdown reference definition will cause the definition to render in plain text. This PR adds the text "Acronym for" before these quoted strings to prevent this from happening.

Before:
![image](https://user-images.githubusercontent.com/88163/146822230-df230e1f-da67-4807-a1d6-170abd985318.png)

After:
![image](https://user-images.githubusercontent.com/88163/146822397-83b61acc-8bf1-4263-b34e-a032da0eefea.png)
