### PR TITLE
[DO NOT MERGE] Replace plain img with next/image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@hashicorp/react-text-split-with-image": "^4.3.0",
         "@hashicorp/react-vertical-text-block-list": "^7.0.0",
         "babel-plugin-import-glob-array": "0.2.0",
+        "image-size": "^1.0.0",
         "next": "11.1.3",
         "next-mdx-remote": "^3.0.5",
         "next-remote-watch": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@hashicorp/react-text-split-with-image": "^4.3.0",
     "@hashicorp/react-vertical-text-block-list": "^7.0.0",
     "babel-plugin-import-glob-array": "0.2.0",
+    "image-size": "^1.0.0",
     "next": "11.1.3",
     "next-mdx-remote": "^3.0.5",
     "next-remote-watch": "1.0.0",

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -6,6 +6,12 @@ import {
   generateStaticPaths,
   generateStaticProps,
 } from '@hashicorp/react-docs-page/server'
+import Image from 'next/image'
+import visit from 'unist-util-visit'
+import imageSizeOf from 'image-size'
+import { promisify } from 'util'
+
+const sizeOf = promisify(imageSizeOf)
 
 //  Configure the docs path
 const BASE_ROUTE = 'intro'
@@ -23,6 +29,7 @@ export default function IntroLayout(props) {
       baseRoute={BASE_ROUTE}
       product={PRODUCT}
       staticProps={modifiedProps}
+      additionalComponents={{ Image }}
     />
   )
 }
@@ -45,6 +52,53 @@ export async function getStaticProps({ params }) {
       const filepath = path.replace('content/', '')
       return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
     },
+    remarkPlugins: [
+      () => {
+        return async function transform(tree) {
+          const promises = []
+
+          visit(tree, 'image', (node, index, parent) => {
+            // Only use next/image for local images
+            if (!node.url.startsWith('http')) {
+              const promise = (async () => {
+                try {
+                  // Assume that images are stored in public/
+                  const relativePath = `./public${node.url}`
+                  // Get image dimensions
+                  const { width, height } = await sizeOf(relativePath)
+                  const props = [
+                    ['src', `"${node.url}"`],
+                    ['alt', `"${node.alt}"`],
+                    ['width', `{${width}}`],
+                    ['height', `{${height}}`],
+                  ]
+                    .map((p) => p.join('='))
+                    .join(' ')
+                  // Build the replacement JSX node
+                  const replacementNode = {
+                    type: 'jsx',
+                    value: `<Image ${props} />`,
+                  }
+
+                  // Replace original img element with the JSX node
+                  parent.children.splice(index, 1, replacementNode)
+                } catch (err) {
+                  // If we encounter any error, log it, but leave the img
+                  // tag in its original state.
+                  console.warn(err)
+                }
+              })()
+
+              // Collect all promises.
+              promises.push(promise)
+            }
+          })
+
+          // Await all promises.
+          await Promise.all(promises)
+        }
+      },
+    ],
   })
   return { props }
 }


### PR DESCRIPTION
This PR demonstrates the usage of a Remark plugin to rewrite image elements with `next/image`. It is only enabled on [this page](https://terraform-website-4jnmrjgb9-hashicorp.vercel.app/intro/core-workflow).

This PR **is not meant to be merged**. It is for demonstration purposes only.