### PR TITLE
Refer to non-deprecated helper

### DIFF
--- a/content/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/plugin/sdkv2/schemas/schema-types.mdx
@@ -181,7 +181,7 @@ resource "example_spot_request" "ex" {
 
 ### Date & Time Data
 
-`TypeString` is also used for date/time data, the preferred format is RFC 3339 (you can use the provided [validation function](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/helper/validation#ValidateRFC3339TimeString)).
+`TypeString` is also used for date/time data, the preferred format is RFC 3339 (you can use the provided [validation function](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation#IsRFC3339Time)).
 
 **Example:** `2006-01-02T15:04:05+07:00`
 
@@ -190,7 +190,7 @@ resource "example_spot_request" "ex" {
 ```go
 "expiration": {
   Type:         schema.TypeString,
-  ValidateFunc: validation.ValidateRFC3339TimeString,
+  ValidateFunc: validation.IsRFC3339Time,
 },
 ```
 


### PR DESCRIPTION
`ValidateRFC3339TimeString` has been deprecated in favor of `IsRFC3339Time` and is completely removed in v2. I've updated the docs to reflect this, and updated the doc link to point to the v2 version of the api docs for this method.

Thanks for Terraform!