### PR TITLE
feat: update downloads page to improve arch display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@hashicorp/react-image": "^4.0.2",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/react-link-wrap": "^3.0.3",
-        "@hashicorp/react-product-downloads-page": "^2.5.3",
+        "@hashicorp/react-product-downloads-page": "^2.6.0",
         "@hashicorp/react-section-header": "^5.0.4",
         "@hashicorp/react-stepped-feature-list": "^4.0.3",
         "@hashicorp/react-subnav": "^9.3.2",
@@ -1631,9 +1631,9 @@
       }
     },
     "node_modules/@hashicorp/react-product-downloads-page": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.5.3.tgz",
-      "integrity": "sha512-SY3sEM/xYZDbd7XSDaqkT4L+DVRdGJYPpF/0WRDHfR0PObf2zE+iqRjm2APaIACg32sAM1NIZPuc+oQv6vKq5A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.6.0.tgz",
+      "integrity": "sha512-AFQtkbOHok4w0gYYwSJ17S1/ZG5nqcNnoa/9U8RwvRC/avGkObSsIC3LFAysg00FEGlC7Lw/zLvvGkGdPd8QZg==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.0",
@@ -26986,9 +26986,9 @@
       "requires": {}
     },
     "@hashicorp/react-product-downloads-page": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.5.3.tgz",
-      "integrity": "sha512-SY3sEM/xYZDbd7XSDaqkT4L+DVRdGJYPpF/0WRDHfR0PObf2zE+iqRjm2APaIACg32sAM1NIZPuc+oQv6vKq5A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.6.0.tgz",
+      "integrity": "sha512-AFQtkbOHok4w0gYYwSJ17S1/ZG5nqcNnoa/9U8RwvRC/avGkObSsIC3LFAysg00FEGlC7Lw/zLvvGkGdPd8QZg==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@hashicorp/react-image": "^4.0.2",
     "@hashicorp/react-inline-svg": "^6.0.3",
     "@hashicorp/react-link-wrap": "^3.0.3",
-    "@hashicorp/react-product-downloads-page": "^2.5.3",
+    "@hashicorp/react-product-downloads-page": "^2.6.0",
     "@hashicorp/react-section-header": "^5.0.4",
     "@hashicorp/react-stepped-feature-list": "^4.0.3",
     "@hashicorp/react-subnav": "^9.3.2",


### PR DESCRIPTION
Updating the arch display per internal discussions, this will just display the raw arch slug/identifier for more clarity.