### PR TITLE
Add redirect for provisioners overview page

### DIFF
--- a/data/docs-redirects.js
+++ b/data/docs-redirects.js
@@ -1520,4 +1520,6 @@ export const docsRedirects = {
   '/docs/state/remote.html': '/language/state/remote',
   '/docs/state/sensitive-data.html': '/language/state/sensitive-data',
   '/docs/state/workspaces.html': '/language/state/workspaces',
+  '/language/resources/provisioners': '/language/resources/provisioners/syntax',
+  '/language/resources/provisioners/#provisioners-are-a-last-resort': '/language/resources/provisioners/syntax#provisioners-are-a-last-resort'
 }


### PR DESCRIPTION
Do not merge until https://github.com/hashicorp/terraform/pull/30296 is merged. 

Refer to https://github.com/hashicorp/terraform/issues/30207 for details about why the provisioners "Overview" page has been removed. 