### PR TITLE
Fix Attribute Validator example

### DIFF
--- a/content/plugin/framework/validation.mdx
+++ b/content/plugin/framework/validation.mdx
@@ -72,7 +72,7 @@ func (v stringLengthBetweenValidator) Validate(ctx context.Context, req tfsdk.Va
         return
     }
 
-    strLen := len(str)
+    strLen := len(str.Value)
 
     if strLen < v.Min || strLen > v.Max {
         resp.Diagnostics.AddAttributeError(


### PR DESCRIPTION
This updates the Attribute Validator example so it takes the length form the `.Value` field, and not the whole struct, which would cause an error.