### PR TITLE
Making run-specific variables JSON friendly for the payload

### DIFF
--- a/content/cloud-docs/api-docs/run.mdx
+++ b/content/cloud-docs/api-docs/run.mdx
@@ -90,8 +90,8 @@ When creating a run, you may optionally provide a list of variable objects conta
 ```
 "attributes": {
   "variables": [
-    { key: "replicas", value: "2" },
-    { key: "access_key", value: "\"ABCDE12345\"" }
+    { "key": "replicas", "value": "2" },
+    { "key": "access_key", "value": "\"ABCDE12345\"" }
   ]
 }
 ```


### PR DESCRIPTION
HCL payload is not JSON-friendly for run-specific variables.