### PR TITLE
Add visual regression testing to more pages

### DIFF
--- a/cypress/integration/examples/agents.spec.js
+++ b/cypress/integration/examples/agents.spec.js
@@ -1,0 +1,6 @@
+describe('Terraform Cloud Agents page tests', () => {
+  it('Loads the Terraform Cloud Agents page and snapshots', () => {
+    cy.visit('/cloud-docs/agents')
+    cy.percySnapshot()
+  })
+})

--- a/cypress/integration/examples/cdktf.spec.js
+++ b/cypress/integration/examples/cdktf.spec.js
@@ -1,0 +1,6 @@
+describe('CDKTF page tests', () => {
+  it('Loads the CDKTF page and snapshots', () => {
+    cy.visit('/cdktf')
+    cy.percySnapshot()
+  })
+})

--- a/cypress/integration/examples/docs.spec.js
+++ b/cypress/integration/examples/docs.spec.js
@@ -1,0 +1,6 @@
+describe('Docs page tests', () => {
+  it('Loads the docs page and snapshots', () => {
+    cy.visit('/docs')
+    cy.percySnapshot()
+  })
+})

--- a/cypress/integration/examples/language.spec.js
+++ b/cypress/integration/examples/language.spec.js
@@ -1,0 +1,6 @@
+describe('Configuration Language page tests', () => {
+  it('Loads the Configuration Language page and snapshots', () => {
+    cy.visit('/language')
+    cy.percySnapshot()
+  })
+})

--- a/cypress/integration/examples/partnerships.spec.js
+++ b/cypress/integration/examples/partnerships.spec.js
@@ -1,0 +1,6 @@
+describe('Terraform Integration Program page tests', () => {
+  it('Loads the Terraform Integration Program page and snapshots', () => {
+    cy.visit('/docs/partnerships')
+    cy.percySnapshot()
+  })
+})


### PR DESCRIPTION
This PR adds more Percy tests to CI, encompassing some of the more complicated docs pages to ensure that we don't inadvertently break pages.