### PR TITLE
update api docs so sample response examples include speculative attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Right now, there are two submodules included in this project: `hashicorp/terrafo
 
 In your local checkout of this repo, Git submodules can be active or inactive. The first time you clone the repo, unless you have modified your git command defaults, the submodules will all default to being inactive, and their folders will be empty. To activate all submodules, run `git init submodule`. To activate only certain submodules, a path can be passed to the command as such: `git submodule init <PATH>`. To switch a submodule back to bring inactive `git submodule deinit <PATH>` can be used, though this is not typically necessary.
 
-Once you `init` a submodule, you usually need to run `git submodule update`, which will either do the initial checkout or update the working copy to the commit that `terraform-website` currently expects. Every time that changes are made to the upstream repo that the submodule represents, it will need to be updated as well.
+Once you `init` a submodule, you usually need to run `git submodule update`, which will either do the initial checkout or update the working copy to the commit that `terraform-website` currently expects. Every time changes are made to the upstream repo that the submodule represents, it will need to be updated as well.
 
 If a submodule shows up as "changed" in `git status` but you haven't done anything with it, it probably means that the upstream repo of a submodule was updated and you need to "pull" that update to point to the most recent commit. Run `git submodule update` to resolve this and you should see a clean `git status` return. Inactive submodules don't show up in `git status`.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Right now, there are two submodules included in this project: `hashicorp/terrafo
 
 In your local checkout of this repo, Git submodules can be active or inactive. The first time you clone the repo, unless you have modified your git command defaults, the submodules will all default to being inactive, and their folders will be empty. To activate all submodules, run `git init submodule`. To activate only certain submodules, a path can be passed to the command as such: `git submodule init <PATH>`. To switch a submodule back to bring inactive `git submodule deinit <PATH>` can be used, though this is not typically necessary.
 
-Once you `init` a submodule, you usually need to run `git submodule update`, which will either do the initial checkout or update the working copy to the commit that `terraform-website` currently expects. Every time changes are made to the upstream repo that the submodule represents, it will need to be updated as well.
+Once you `init` a submodule, you usually need to run `git submodule update`, which will either do the initial checkout or update the working copy to the commit that `terraform-website` currently expects. You also need to update the submodule every time changes are made to the upstream repo that the submodule represents.
 
 If a submodule shows up as "changed" in `git status` but you haven't done anything with it, it probably means that the upstream repo of a submodule was updated and you need to "pull" that update to point to the most recent commit. Run `git submodule update` to resolve this and you should see a clean `git status` return. Inactive submodules don't show up in `git status`.
 

--- a/content/cloud-docs/api-docs/configuration-versions.mdx
+++ b/content/cloud-docs/api-docs/configuration-versions.mdx
@@ -83,6 +83,7 @@ curl \
         "error": null,
         "error-message": null,
         "source": "gitlab",
+        "speculative":false,
         "status": "uploaded",
         "status-timestamps": {}
       },
@@ -135,6 +136,7 @@ curl \
       "error": null,
       "error-message": null,
       "source": "gitlab",
+      "speculative":false,
       "status": "uploaded",
       "status-timestamps": {}
     },
@@ -290,6 +292,7 @@ curl \
       "error": null,
       "error-message": null,
       "source": "tfe-api",
+      "speculative":false,
       "status": "pending",
       "status-timestamps": {},
       "upload-url":


### PR DESCRIPTION
CHANGELOG: `Added` speculative attribute to Configuration Version API documentation.

## Description

This PR is being created to update the Configuration Version API docs, in response to a [PR that is now closed](https://github.com/hashicorp/atlas/pull/11550). The API documentation has been updated so the sample response examples now include the `speculative attribute` in the response body. Please note: [the ticket requesting this update](https://app.asana.com/0/1118351459439625/1200739247697069/f) named the [List Configuration Versions](https://www.terraform.io/cloud-docs/api-docs/configuration-versions#list-configuration-versions) and [Show a Configuration Version](https://www.terraform.io/cloud-docs/api-docs/configuration-versions#show-a-configuration-version) as needing updates. I also tested the [Create a Configuration Version](https://www.terraform.io/cloud-docs/api-docs/configuration-versions#create-a-configuration-version) request and the response body, now, also includes the `speculative attribute`. So I made that change in the docs, as well.

Found minor grammar fix in the README.md.

## Is this PR safe to rollback if necessary?

yes

## External links

- [Asana](https://app.asana.com/0/1199201948575144/1200103448624137/f)
- [Configuration Version API docs](https://www.terraform.io/cloud-docs/api-docs/configuration-versions)
