### PR TITLE
Add a note to explicitly call out that TFE VCS Integration with a SaaS VCS provider requires inbound connectivity

### DIFF
--- a/content/cloud-docs/vcs/index.mdx
+++ b/content/cloud-docs/vcs/index.mdx
@@ -56,7 +56,7 @@ Terraform Cloud uses webhooks to monitor new commits and pull requests.
 - When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace.
 - When someone submits a pull request/merge request to a branch, any Terraform Cloud workspaces based on that branch will perform a [speculative plan](/cloud-docs/run/#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
 
-~> **Important:** In Terraform Enterprise, integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the inbound web hooks reach Terraform Enterprise. You should also configure appropriate security controls, such as a WAF.
+~> **Important:** In Terraform Enterprise, integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the inbound web hooks reach Terraform Enterprise. You should also configure appropriate security controls, such as a Web Application Firewall (WAF).
 
 ### SSH Keys
 

--- a/content/cloud-docs/vcs/index.mdx
+++ b/content/cloud-docs/vcs/index.mdx
@@ -56,6 +56,8 @@ Terraform Cloud uses webhooks to monitor new commits and pull requests.
 - When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace.
 - When someone submits a pull request/merge request to a branch, any Terraform Cloud workspaces based on that branch will perform a [speculative plan](/cloud-docs/run/#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
 
+~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to configure a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
+
 ### SSH Keys
 
 For most supported VCS providers, Terraform Cloud does not need an SSH key — it can do everything it needs with the provider's API and an OAuth token. The exceptions are Azure DevOps Server and Bitbucket Server, which require an SSH key for downloading repository contents. The setup instructions for  [Azure DevOps Server](/cloud-docs/vcs/azure-devops-server) and [Bitbucket Server](/cloud-docs/vcs/bitbucket-server) include this step.

--- a/content/cloud-docs/vcs/index.mdx
+++ b/content/cloud-docs/vcs/index.mdx
@@ -56,7 +56,7 @@ Terraform Cloud uses webhooks to monitor new commits and pull requests.
 - When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace.
 - When someone submits a pull request/merge request to a branch, any Terraform Cloud workspaces based on that branch will perform a [speculative plan](/cloud-docs/run/#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
 
-~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to configure a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
+~> **Note:** Terraform Enterprise Only: If using VCS Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), Terraform Enterprise requires Ingress from the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. Ensure to use appropriate security controls, such as a WAF in this scenario.
 
 ### SSH Keys
 

--- a/content/cloud-docs/vcs/index.mdx
+++ b/content/cloud-docs/vcs/index.mdx
@@ -56,7 +56,7 @@ Terraform Cloud uses webhooks to monitor new commits and pull requests.
 - When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace.
 - When someone submits a pull request/merge request to a branch, any Terraform Cloud workspaces based on that branch will perform a [speculative plan](/cloud-docs/run/#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
 
-~> **Note:** Terraform Enterprise Only: If using VCS Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), Terraform Enterprise requires Ingress from the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. Ensure to use appropriate security controls, such as a WAF in this scenario.
+~> **Important:** In Terraform Enterprise, integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the inbound web hooks reach Terraform Enterprise. You should also configure appropriate security controls, such as a WAF.
 
 ### SSH Keys
 

--- a/content/enterprise/before-installing/network-requirements.mdx
+++ b/content/enterprise/before-installing/network-requirements.mdx
@@ -13,12 +13,12 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **80:** Terraform Enterprise application access (HTTP; redirects to HTTPS)
 * **443:** Terraform Enterprise application access (HTTPS)
 
+~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to configure a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
+
 ### Source — Administrators
 
 * **22:** SSH access (administration and debugging)
 * **8800:** Replicated (TFE setup dashboard, HTTPS)
-
-~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to configure a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
 
 ### Source — TFE Server(s)
 

--- a/content/enterprise/before-installing/network-requirements.mdx
+++ b/content/enterprise/before-installing/network-requirements.mdx
@@ -13,7 +13,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **80:** Terraform Enterprise application access (HTTP; redirects to HTTPS)
 * **443:** Terraform Enterprise application access (HTTPS)
 
-~> **Note:** If using VCS Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), Terraform Enterprise requires Ingress from the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. Ensure to use appropriate security controls, such as a WAF in this scenario.
+~> **Important:** Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the [inbound web hooks](/cloud-docs/vcs#webhooks) reach Terraform Enterprise. You should also configure appropriate security controls, such as a WAF.
 
 ### Source — Administrators
 

--- a/content/enterprise/before-installing/network-requirements.mdx
+++ b/content/enterprise/before-installing/network-requirements.mdx
@@ -18,7 +18,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **22:** SSH access (administration and debugging)
 * **8800:** Replicated (TFE setup dashboard, HTTPS)
 
-~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to put a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
+~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to configure a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
 
 ### Source — TFE Server(s)
 

--- a/content/enterprise/before-installing/network-requirements.mdx
+++ b/content/enterprise/before-installing/network-requirements.mdx
@@ -13,7 +13,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **80:** Terraform Enterprise application access (HTTP; redirects to HTTPS)
 * **443:** Terraform Enterprise application access (HTTPS)
 
-~> **Important:** Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the [inbound web hooks](/cloud-docs/vcs#webhooks) reach Terraform Enterprise. You should also configure appropriate security controls, such as a WAF.
+~> **Important:** Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the [inbound web hooks](/cloud-docs/vcs#webhooks) reach Terraform Enterprise. You should also configure appropriate security controls, such as a Web Application Firewall (WAF).
 
 ### Source — Administrators
 

--- a/content/enterprise/before-installing/network-requirements.mdx
+++ b/content/enterprise/before-installing/network-requirements.mdx
@@ -18,6 +18,8 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **22:** SSH access (administration and debugging)
 * **8800:** Replicated (TFE setup dashboard, HTTPS)
 
+~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to put a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
+
 ### Source — TFE Server(s)
 
 * **8201:** Vault HA request forwarding (only necessary when operating in Active/Active mode)

--- a/content/enterprise/before-installing/network-requirements.mdx
+++ b/content/enterprise/before-installing/network-requirements.mdx
@@ -13,7 +13,7 @@ The Linux instance that runs Terraform Enterprise needs to allow several kinds o
 * **80:** Terraform Enterprise application access (HTTP; redirects to HTTPS)
 * **443:** Terraform Enterprise application access (HTTPS)
 
-~> **Note:** If using VCS integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), you will need to expose TFE to the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. It is recommended to configure a WAF in front of your load balancer in this scenario and restrict to the outbound IP range of your SaaS VCS as a minimum.
+~> **Note:** If using VCS Integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud or Azure DevOps Services), Terraform Enterprise requires Ingress from the public internet in order for the Inbound Web Hooks to reach Terraform Enterprise. Ensure to use appropriate security controls, such as a WAF in this scenario.
 
 ### Source — Administrators
 


### PR DESCRIPTION
If a customer is using TFE (not TFC) and is leveraging a SaaS VCS provider, there is an extra step required that is not currently called out in our docs if they wish to use the native VCS integration capabilities.

The web hook architecture for notifying TFE of VCS updates requires inbound connectivity to TFE. Without this connectivity, it is not possible to use native VCS Integration for Workspaces, Private Modules or Policy Sets.

This pull request adds notes to two sections of the docs to explicitly call out this requirement.

This is based on customer feedback that this information is missing from the docs.

I'm happy to re-word, move or re-format the notes. This is my first PR for the docs, so not aware of the standards.