### PR TITLE
Add deprecated, deprecated-reason field to admin terraform versions

### DIFF
--- a/content/cloud-docs/api-docs/admin/terraform-versions.mdx
+++ b/content/cloud-docs/api-docs/admin/terraform-versions.mdx
@@ -49,7 +49,7 @@ The Terraform Versions Admin API lets site administrators manage which versions 
 This endpoint lists all known versions of Terraform.
 
 | Status  | Response                                             | Reason                                 |
-| ------- | ---------------------------------------------------- | -------------------------------------- |
+|---------|------------------------------------------------------|----------------------------------------|
 | [200][] | [JSON API document][] (`type: "terraform-versions"`) | Successfully listed Terraform versions |
 | [404][] | [JSON API error object][]                            | Client is not an administrator.        |
 
@@ -58,7 +58,7 @@ This endpoint lists all known versions of Terraform.
 This endpoint supports pagination [with standard URL query parameters](/cloud-docs/api-docs/#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
 
 | Parameter      | Description                                                                        |
-| -------------- | ---------------------------------------------------------------------------------- |
+|----------------|------------------------------------------------------------------------------------|
 | `page[number]` | **Optional.** If omitted, the endpoint will return the first page.                 |
 | `page[size]`   | **Optional.** If omitted, the endpoint will return 20 Terraform versions per page. |
 
@@ -129,7 +129,7 @@ curl \
 `POST /admin/terraform-versions`
 
 | Status  | Response                                             | Reason                                         |
-| ------- | ---------------------------------------------------- | ---------------------------------------------- |
+|---------|------------------------------------------------------|------------------------------------------------|
 | [201][] | [JSON API document][] (`type: "terraform-versions"`) | The Terraform version was successfully created |
 | [404][] | [JSON API error object][]                            | Client is not an administrator                 |
 | [422][] | [JSON API error object][]                            | Validation errors                              |
@@ -140,15 +140,15 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path                   | Type   | Default | Description                                                                                         |
-| -------------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------- |
-| `data.type`                | string |         | Must be `"terraform-versions"`                                                                      |
-| `data.attributes.version`  | string |         | A semantic version string in N.N.N or N.N.N-bundleName format (e.g. `"0.11.0"`, `"0.12.20-beta1"`.) |
-| `data.attributes.url`      | string |         | The URL where a ZIP-compressed 64-bit Linux binary of this version can be downloaded                |
-| `data.attributes.sha`      | string |         | The SHA-256 checksum of the compressed Terraform binary                                             |
-| `data.attributes.official` | bool   | `false` | Whether or not this is an official release of Terraform                                             |
-| `data.attributes.enabled`  | bool   | `true`  | Whether or not this version of Terraform is enabled for use in Terraform Cloud                      |
-| `data.attributes.beta`     | bool   | `false` | Whether or not this version of Terraform is a beta pre-release                                      |
+| Key path                            | Type   | Default | Description                                                                                                 |
+|-------------------------------------|--------|---------|-------------------------------------------------------------------------------------------------------------|
+| `data.type`                         | string |         | Must be `"terraform-versions"`                                                                              |
+| `data.attributes.version`           | string |         | A semantic version string in N.N.N or N.N.N-bundleName format (e.g. `"0.11.0"`, `"0.12.20-beta1"`.)         |
+| `data.attributes.url`               | string |         | The URL where a ZIP-compressed 64-bit Linux binary of this version can be downloaded                        |
+| `data.attributes.sha`               | string |         | The SHA-256 checksum of the compressed Terraform binary                                                     |
+| `data.attributes.official`          | bool   | `false` | Whether or not this is an official release of Terraform                                                     |
+| `data.attributes.enabled`           | bool   | `true`  | Whether or not this version of Terraform is enabled for use in Terraform Cloud                              |
+| `data.attributes.beta`              | bool   | `false` | Whether or not this version of Terraform is a beta pre-release                                              |
 
 ### Sample Payload
 
@@ -205,11 +205,11 @@ curl \
 `GET /api/v2/admin/terraform-versions/:id`
 
 | Parameter | Description                             |
-| --------- | --------------------------------------- |
+|-----------|-----------------------------------------|
 | `:id`     | The ID of the Terraform version to show |
 
 | Status  | Response                                             | Reason                                                         |
-| ------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+|---------|------------------------------------------------------|----------------------------------------------------------------|
 | [200][] | [JSON API document][] (`type: "terraform-versions"`) | The request was successful                                     |
 | [404][] | [JSON API error object][]                            | Terraform version not found, or client is not an administrator |
 
@@ -248,11 +248,11 @@ curl \
 `PATCH /admin/terraform-versions/:id`
 
 | Parameter | Description                               |
-| --------- | ----------------------------------------- |
+|-----------|-------------------------------------------|
 | `:id`     | The ID of the Terraform version to update |
 
 | Status  | Response                                             | Reason                                                         |
-| ------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+|---------|------------------------------------------------------|----------------------------------------------------------------|
 | [200][] | [JSON API document][] (`type: "terraform-versions"`) | The Terraform version was successfully updated                 |
 | [404][] | [JSON API error object][]                            | Terraform version not found, or client is not an administrator |
 | [422][] | [JSON API error object][]                            | Validation errors                                              |
@@ -264,7 +264,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 Properties without a default value are required.
 
 | Key path                   | Type   | Default          | Description                                                                                         |
-| -------------------------- | ------ | ---------------- | --------------------------------------------------------------------------------------------------- |
+|----------------------------|--------|------------------|-----------------------------------------------------------------------------------------------------|
 | `data.type`                | string |                  | Must be `"terraform-versions"`                                                                      |
 | `data.attributes.version`  | string | (previous value) | A semantic version string in N.N.N or N.N.N-bundleName format (e.g. `"0.11.0"`, `"0.12.20-beta1"`.) |
 | `data.attributes.url`      | string | (previous value) | The URL where a ZIP-compressed 64-bit Linux binary of this version can be downloaded                |
@@ -326,11 +326,11 @@ curl \
 This endpoint removes a Terraform version from Terraform Cloud. Versions cannot be removed if they are labeled as official versions of Terraform or if there are workspaces using them.
 
 | Parameter | Description                               |
-| --------- | ----------------------------------------- |
+|-----------|-------------------------------------------|
 | `:id`     | The ID of the Terraform version to delete |
 
 | Status  | Response                  | Reason                                                                |
-| ------- | ------------------------- | --------------------------------------------------------------------- |
+|---------|---------------------------|-----------------------------------------------------------------------|
 | [204][] | Empty response            | The Terraform version was successfully deleted                        |
 | [404][] | [JSON API error object][] | Terraform version not found, or client is not an administrator        |
 | [422][] | [JSON API error object][] | The Terraform version cannot be removed (it is official or is in use) |

--- a/content/cloud-docs/api-docs/admin/terraform-versions.mdx
+++ b/content/cloud-docs/api-docs/admin/terraform-versions.mdx
@@ -83,6 +83,8 @@ curl \
         "version": "0.11.8",
         "url": "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip",
         "sha": "84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7",
+        "deprecated": false,
+        "deprecated-reason": null,
         "official": true,
         "enabled": true,
         "beta": false,
@@ -97,6 +99,8 @@ curl \
         "version": "0.11.7",
         "url": "https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip",
         "sha": "6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418",
+        "deprecated": false,
+        "deprecated-reason": null,
         "official": true,
         "enabled": true,
         "beta": false,
@@ -146,6 +150,8 @@ Properties without a default value are required.
 | `data.attributes.version`           | string |         | A semantic version string in N.N.N or N.N.N-bundleName format (e.g. `"0.11.0"`, `"0.12.20-beta1"`.)         |
 | `data.attributes.url`               | string |         | The URL where a ZIP-compressed 64-bit Linux binary of this version can be downloaded                        |
 | `data.attributes.sha`               | string |         | The SHA-256 checksum of the compressed Terraform binary                                                     |
+| `data.attributes.deprecated`        | bool   | `false` | Whether or not this version of Terraform is deprecated                                                      |
+| `data.attributes.deprecated-reason` | string | `null`  | Additional context about why a version of Terraform is deprecated. Field is null unless deprecated is true. |
 | `data.attributes.official`          | bool   | `false` | Whether or not this is an official release of Terraform                                                     |
 | `data.attributes.enabled`           | bool   | `true`  | Whether or not this version of Terraform is enabled for use in Terraform Cloud                              |
 | `data.attributes.beta`              | bool   | `false` | Whether or not this version of Terraform is a beta pre-release                                              |
@@ -191,6 +197,8 @@ curl \
       "url": "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip",
       "sha": "84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7",
       "official": true,
+      "deprecated": false,
+      "deprecated-reason": null,
       "enabled": true,
       "beta": false,
       "usage": 0,
@@ -234,6 +242,8 @@ curl \
       "url": "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip",
       "sha": "84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7",
       "official": true,
+      "deprecated": false,
+      "deprecated-reason": null,
       "enabled": true,
       "beta": false,
       "usage": 0,
@@ -263,15 +273,17 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 Properties without a default value are required.
 
-| Key path                   | Type   | Default          | Description                                                                                         |
-|----------------------------|--------|------------------|-----------------------------------------------------------------------------------------------------|
-| `data.type`                | string |                  | Must be `"terraform-versions"`                                                                      |
-| `data.attributes.version`  | string | (previous value) | A semantic version string in N.N.N or N.N.N-bundleName format (e.g. `"0.11.0"`, `"0.12.20-beta1"`.) |
-| `data.attributes.url`      | string | (previous value) | The URL where a ZIP-compressed 64-bit Linux binary of this version can be downloaded                |
-| `data.attributes.sha`      | string | (previous value) | The SHA-256 checksum of the compressed Terraform binary                                             |
-| `data.attributes.official` | bool   | (previous value) | Whether or not this is an official release of Terraform                                             |
-| `data.attributes.enabled`  | bool   | (previous value) | Whether or not this version of Terraform is enabled for use in Terraform Cloud                      |
-| `data.attributes.beta`     | bool   | (previous value) | Whether or not this version of Terraform is a beta pre-release                                      |
+| Key path                            | Type   | Default          | Description                                                                                         |
+|-------------------------------------|--------|------------------|-----------------------------------------------------------------------------------------------------|
+| `data.type`                         | string |                  | Must be `"terraform-versions"`                                                                      |
+| `data.attributes.version`           | string | (previous value) | A semantic version string in N.N.N or N.N.N-bundleName format (e.g. `"0.11.0"`, `"0.12.20-beta1"`.) |
+| `data.attributes.url`               | string | (previous value) | The URL where a ZIP-compressed 64-bit Linux binary of this version can be downloaded                |
+| `data.attributes.sha`               | string | (previous value) | The SHA-256 checksum of the compressed Terraform binary                                             |
+| `data.attributes.official`          | bool   | (previous value) | Whether or not this is an official release of Terraform                                             |
+| `data.attributes.deprecated`        | bool   | (previous value) | Whether or not this version of Terraform is deprecated                                              |
+| `data.attributes.deprecated-reason` | string | (previous value) | Additional context about why a version of Terraform is deprecated.                                  |
+| `data.attributes.enabled`           | bool   | (previous value) | Whether or not this version of Terraform is enabled for use in Terraform Cloud                      |
+| `data.attributes.beta`              | bool   | (previous value) | Whether or not this version of Terraform is a beta pre-release                                      |
 
 ### Sample Payload
 
@@ -280,8 +292,8 @@ Properties without a default value are required.
   "data": {
     "type": "terraform-versions",
     "attributes": {
-      "official": true,
-      "beta": false
+      "deprecated": true,
+      "deprecated-reason": "A bug was discovered in this version of Terraform. Please upgrade as soon as possible"
     }
   }
 }
@@ -310,6 +322,8 @@ curl \
       "url": "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip",
       "sha": "84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7",
       "official": true,
+      "deprecated": true,
+      "deprecated-reason": "A bug was discovered in this version of Terraform. Please upgrade as soon as possible",
       "enabled": true,
       "beta": false,
       "usage": 0,


### PR DESCRIPTION
Updates the cloud API documents to reflect this new addition to the API