### PR TITLE
Corrects function receiver name

### DIFF
--- a/content/plugin/framework/resources/plan-modification.mdx
+++ b/content/plugin/framework/resources/plan-modification.mdx
@@ -69,12 +69,12 @@ type stringDefaultModifier struct {
 
 // Description returns a plain text description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (m stringDefaultModifier) Description(ctx context.Context) string {
-    return fmt.Sprintf("If value is not configured, defaults to %s", v.Default)
+    return fmt.Sprintf("If value is not configured, defaults to %s", m.Default)
 }
 
 // MarkdownDescription returns a markdown formatted description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (m stringDefaultModifier) MarkdownDescription(ctx context.Context) string {
-    return fmt.Sprintf("If value is not configured, defaults to `%s`", v.Default)
+    return fmt.Sprintf("If value is not configured, defaults to `%s`", m.Default)
 }
 
 // Modify runs the logic of the plan modifier.


### PR DESCRIPTION
In the `stringDefaultModifier` `Description` and `MarkdownDescription` functions, the receiver name was not consistent with the usage in the function. The sample code does not compile as-is.