### PR TITLE
Update index.mdx

### DIFF
--- a/content/enterprise/before-installing/index.mdx
+++ b/content/enterprise/before-installing/index.mdx
@@ -217,7 +217,7 @@ Refer to the sections below for instructions on how to verify your Docker Engine
      https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json
    ```
 
-1. Edit the `/etc/docker/seccomp.json` file and modify the line `"defaultAction": "SCMP_ACT_ERRNO",` to be `"defaultAction": "SCMP_ACT_TRACE",`. A `sed` command is included below for your convenience.
+1. Edit the `/etc/docker/seccomp.json` file and modify the line `"defaultAction": "SCMP_ACT_ERRNO",` to be `"defaultAction": "SCMP_ACT_TRACE",`. A `sed` command is included below for your convenience. For Docker Engine 1.13.1 (RHEL only), as the `/etc/docker/seccomp.json` file already exists you can proceed with restarting the docker engine after modifying the aforementioned line by running `sudo systemctl restart docker`.
 
    ```
    sudo sed -i 's/"defaultAction":\s*"SCMP_ACT_ERRNO"/"defaultAction": "SCMP_ACT_TRACE"/1' /etc/docker/seccomp.json

--- a/content/enterprise/before-installing/index.mdx
+++ b/content/enterprise/before-installing/index.mdx
@@ -141,34 +141,32 @@ Refer to the sections below for instructions on how to verify your Docker Engine
 #### Option 1: Docker Engine With a Compatible `runc` Version
 
 1. [Install](https://docs.docker.com/engine/install/) Docker Engine 17.06.2-ce, 18.09.x, 19.03.x, or 20.10.x for your operating system.
+
 1. Install the latest version of `containerd` for your operating system.
 
-- On Debian/Ubuntu:
+  On Debian/Ubuntu:
 
-  ````
-  ```
+  ```sh
   sudo apt install containerd
   ```
-  ````
-- On RHEL/CentOS:
 
-  ````
-  ```
+  On RHEL/CentOS:
+
+  ```sh
   sudo yum install containerd.io
   ```
-  ````
 
 1. Confirm that the installed `containerd` version is 1.4.9, 1.5.5, or greater.
 
-   ```
-   containerd --version
-   ```
+  ```sh
+  containerd --version
+  ```
 
 1. Confirm that the installed `runc` version is v1.0.0-rc93 or greater:
 
-   ```
-   runc --version
-   ```
+  ```sh
+  runc --version
+  ```
 
 1. If your Docker Engine and `runc` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 2](#option-2-docker-engine-with-a-compatible-libseccomp-version).
 
@@ -177,28 +175,26 @@ Refer to the sections below for instructions on how to verify your Docker Engine
 -> **Note:** These instructions should only be used if your operating system does not meet the Docker Engine requirements detailed in [option 1](#option-1-docker-engine-with-a-compatible-runc-version).
 
 1. [Install](https://docs.docker.com/engine/install/) Docker Engine 20.10.x for your operating system.
+
 1. Install the latest version of `libseccomp` for your operating system.
 
-- On Debian/Ubuntu:
+  On Debian/Ubuntu:
 
-  ````
-  ```
+  ```sh
   sudo apt install libseccomp2
   ```
-  ````
-- On RHEL/CentOS:
 
-  ````
-  ```
+  On RHEL/CentOS:
+
+  ```sh
   sudo yum install libseccomp
   ```
-  ````
 
 1. Confirm that the installed `libseccomp` version is 2.4.4 or greater.
 
-   ```
-   runc --version
-   ```
+  ```sh
+  runc --version
+  ```
 
 1. If your Docker Engine and `libseccomp` versions meet the requirements from previous steps, your system is properly configured. Otherwise, proceed to [option 3](#option-3-docker-engine-using-a-modified-libseccomp-profile).
 
@@ -212,51 +208,50 @@ Refer to the sections below for instructions on how to verify your Docker Engine
 
 1. Download the [default moby `libseccomp` profile](https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json) and save it to the file `/etc/docker/seccomp.json`.
 
-   ```
-   sudo curl -L -o /etc/docker/seccomp.json \
-     https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json
-   ```
+  ```sh
+  sudo curl -L -o /etc/docker/seccomp.json \
+    https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json
+  ```
 
-1. Edit the `/etc/docker/seccomp.json` file and modify the line `"defaultAction": "SCMP_ACT_ERRNO",` to be `"defaultAction": "SCMP_ACT_TRACE",`. A `sed` command is included below for your convenience. For Docker Engine 1.13.1 (RHEL only), as the `/etc/docker/seccomp.json` file already exists you can proceed with restarting the docker engine after modifying the aforementioned line by running `sudo systemctl restart docker`.
+1. In the `/etc/docker/seccomp.json` file, change `"defaultAction": "SCMP_ACT_ERRNO",` to `"defaultAction": "SCMP_ACT_TRACE",`.
 
-   ```
-   sudo sed -i 's/"defaultAction":\s*"SCMP_ACT_ERRNO"/"defaultAction": "SCMP_ACT_TRACE"/1' /etc/docker/seccomp.json
-   ```
+  ```sh
+  sudo sed -i 's/"defaultAction":\s*"SCMP_ACT_ERRNO"/"defaultAction": "SCMP_ACT_TRACE"/1' /etc/docker/seccomp.json
+  ```
+
+  **Docker Engine 1.13.1 (RHEL only):**  After modifying the `/etc/docker/seccomp.json` file, proceed to step 8.
 
 1. Create a drop-in systemd unit file for the `docker` systemd service.
 
-   ```
-   sudo cp /lib/systemd/system/docker.service /etc/systemd/system/docker.service
-   ```
+  ```sh
+  sudo cp /lib/systemd/system/docker.service /etc/systemd/system/docker.service
+  ```
 
 1. Edit the drop-in `/etc/systemd/system/docker.service` systemd unit file and modify the line starting with `ExecStart=` to include the option `--seccomp-profile=/etc/docker/seccomp.json`.
 
-- For example, the following line:
+  For example, the following line:
 
-  ````
-  ```
+  ```ini
   ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock $OPTIONS $DOCKER_STORAGE_OPTIONS $DOCKER_ADD_RUNTIMES
   ```
-  ````
-- Would become:
 
-  ````
-  ```
+  Would become:
+
+  ```ini
   ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock --seccomp-profile=/etc/docker/seccomp.json $OPTIONS $DOCKER_STORAGE_OPTIONS $DOCKER_ADD_RUNTIMES
   ```
-  ````
 
 1. Reload the systemd daemon.
 
-   ```
-   sudo systemctl daemon-reload
-   ```
+  ```sh
+  sudo systemctl daemon-reload
+  ```
 
 1. Restart Docker Engine.
 
-   ```
-   sudo systemctl restart docker 
-   ```
+  ```sh
+  sudo systemctl restart docker
+  ```
 
 ### IAM Policies
 


### PR DESCRIPTION
Updating Option 3: Docker Engine Using a Modified libseccomp Profile, step 4 to note that RHEL 7.x with docker 1.13.1 already has the `/etc/docker/seccomp.json` and only requires to modify the `defaultAction` line and restarting docker.