### PR TITLE
plugin/sdkv2/debugging: Add VS Code and clarify Delve CLI usage

### DIFF
--- a/content/plugin/sdkv2/debugging.mdx
+++ b/content/plugin/sdkv2/debugging.mdx
@@ -89,24 +89,53 @@ To do so, build the provider binary with the necessary
 
 ### Starting A Provider In Debug Mode
 
-Once a provider has a debug mode added to its `main` function, it can be
-activated. Run your debugger, and pass it the provider binary as the command to
-run, specifying whatever flags, environment variables, or other input is
-necessary to start your provider in debug mode:
+Once a provider has a debug mode added to its `main` function, it can be activated. Run your debugger, which is typically built into an editor or the Delve CLI, by passing it the provider binary as the command to execute. Specify any flags, environment variables, or other input that is necessary to start your provider.
 
-```sh
-$ dlv exec --headless ./terraform-provider-my-provider -- --debug
+#### Visual Studio Code
+
+Visual Studio Code (VS Code) features native [debugging](https://code.visualstudio.com/docs/editor/debugging) support with the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go). The necessary launch configuration can be created within the repository as a `.vscode/launch.json` file, [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration), or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
+
+An example `.vscode/launch.json` configuration file:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}
 ```
 
-Connect your debugger (whether it's your IDE or the debugger client) to the
-debugger server. Have it continue execution (it pauses the process by default)
-and it will print output like the following to `stdout`:
+Running the editor debugger will output the reattach configuration to the debug console.
+
+#### Delve CLI
+
+Start a [`delve`](https://github.com/go-delve/delve) debugging session:
+
+```sh
+$ dlv exec --accept-multiclient --continue --headless ./terraform-provider-example -- -debug
+```
+
+It will print output like the following to `stdout`:
 
 ```
 Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:
 
         TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}'
 ```
+
+Connect your debugger, such as your editor or another delve CLI process, to the debugger server.
 
 ### Running Terraform With A Provider In Debug Mode
 

--- a/content/plugin/sdkv2/debugging.mdx
+++ b/content/plugin/sdkv2/debugging.mdx
@@ -89,11 +89,11 @@ To do so, build the provider binary with the necessary
 
 ### Starting A Provider In Debug Mode
 
-Once a provider has a debug mode added to its `main` function, it can be activated. Run your debugger, which is typically built into an editor or the Delve CLI, by passing it the provider binary as the command to execute. Specify any flags, environment variables, or other input that is necessary to start your provider.
+After you add a debug mode to your provider's `main` function, you can activate the debugger, which is typically built into an editor or the Delve CLI. To run your debugger, pass it the provider binary as the command to execute. Specify flags, environment variables, and any other input your provider needs to run.
 
 #### Visual Studio Code
 
-Visual Studio Code (VS Code) features native [debugging](https://code.visualstudio.com/docs/editor/debugging) support with the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go). The necessary launch configuration can be created within the repository as a `.vscode/launch.json` file, [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration), or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
+Visual Studio Code (VS Code) features native [debugging](https://code.visualstudio.com/docs/editor/debugging) support with the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go). You can create the necessary launch configuration within the repository as a `.vscode/launch.json` file, [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration), or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
 
 An example `.vscode/launch.json` configuration file:
 
@@ -136,6 +136,12 @@ Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:
 ```
 
 Connect your debugger, such as your editor or another delve CLI process, to the debugger server.
+
+For example with Delve CLI, using the server address and port output by `dlv exec` such as `API server listening at: 127.0.0.1:55413`:
+
+```shell
+dlv connect 127.0.0.1:55413
+```
 
 ### Running Terraform With A Provider In Debug Mode
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-scaffolding/blob/6908b6b7ada594861f7db42f3d47ad37a221e416/.vscode/launch.json

Adds Visual Studio Code debugging information to match the launch configuration already present in terraform-provider-scaffolding. Documenting only this particular editor right now is not meant to dissuade using other editors, but rather it is a well known and verified debugging setup from the SDK maintainers. Other popular editors can be added later with additional investigation and verification.