### PR TITLE
website: Add consent manager

### DIFF
--- a/lib/consent-manager-services/index.ts
+++ b/lib/consent-manager-services/index.ts
@@ -1,0 +1,15 @@
+import { ConsentManagerService } from '@hashicorp/react-consent-manager/types'
+
+const localConsentManagerServices: ConsentManagerService[] = [
+  {
+    name: 'Demandbase Tag',
+    description:
+      'The Demandbase tag is a tracking service to identify website visitors and measure interest on our website.',
+    category: 'Analytics',
+    url: 'https://tag.demandbase.com/960ab0a0f20fb102.min.js',
+    async: true,
+  },
+]
+
+export default localConsentManagerServices
+

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,7 +2,8 @@ import './style.css'
 import '@hashicorp/platform-util/nprogress/style.css'
 
 import NProgress from '@hashicorp/platform-util/nprogress'
-// import createConsentManager from '@hashicorp/react-consent-manager/loader'
+// import createConsentManager from '@hashicorp/react-consent-manager'
+// import localConsentManagerServices from 'lib/consent-manager-services'
 import usePageviewAnalytics from '@hashicorp/platform-analytics'
 import useAnchorLinkAnalytics from '@hashicorp/platform-util/anchor-link-analytics'
 import Router from 'next/router'
@@ -19,6 +20,7 @@ import alertBannerData, { ALERT_BANNER_ACTIVE } from 'data/alert-banner'
 NProgress({ Router })
 // const { ConsentManager, openConsentManager } = createConsentManager({
 //   preset: 'oss',
+//   otherServices: [...localConsentManagerServices]
 // })
 
 function App({ Component, pageProps }) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,8 +2,8 @@ import './style.css'
 import '@hashicorp/platform-util/nprogress/style.css'
 
 import NProgress from '@hashicorp/platform-util/nprogress'
-// import createConsentManager from '@hashicorp/react-consent-manager'
-// import localConsentManagerServices from 'lib/consent-manager-services'
+import createConsentManager from '@hashicorp/react-consent-manager/loader'
+import localConsentManagerServices from 'lib/consent-manager-services'
 import usePageviewAnalytics from '@hashicorp/platform-analytics'
 import useAnchorLinkAnalytics from '@hashicorp/platform-util/anchor-link-analytics'
 import Router from 'next/router'
@@ -18,10 +18,10 @@ import { productName } from '../data/metadata'
 import alertBannerData, { ALERT_BANNER_ACTIVE } from 'data/alert-banner'
 
 NProgress({ Router })
-// const { ConsentManager, openConsentManager } = createConsentManager({
-//   preset: 'oss',
-//   otherServices: [...localConsentManagerServices]
-// })
+const { ConsentManager, openConsentManager } = createConsentManager({
+  preset: 'oss',
+  otherServices: [...localConsentManagerServices]
+})
 
 function App({ Component, pageProps }) {
   usePageviewAnalytics()
@@ -49,8 +49,8 @@ function App({ Component, pageProps }) {
       <div className="page-content">
         <Component {...pageProps} />
       </div>
-      {/* <Footer openConsentManager={openConsentManager} />
-      <ConsentManager /> */}
+      <Footer openConsentManager={openConsentManager} />
+      <ConsentManager />
       <Footer />
     </ErrorBoundary>
   )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -51,7 +51,6 @@ function App({ Component, pageProps }) {
       </div>
       <Footer openConsentManager={openConsentManager} />
       <ConsentManager />
-      <Footer />
     </ErrorBoundary>
   )
 }


### PR DESCRIPTION
[:mag: Preview link](https://terraform-website-git-nqweb-add-demandbase-consent-hashicorp.vercel.app/)

---

This PR re-enables the consent manager for the Terraform website. This also adds a Demandbase tag to the consent manager.