### PR TITLE
fix: you can't actually update the key text for an existing SSH key

### DIFF
--- a/content/cloud-docs/api-docs/ssh-keys.mdx
+++ b/content/cloud-docs/api-docs/ssh-keys.mdx
@@ -222,7 +222,7 @@ curl \
 | ------------- | ------------------------- |
 | `:ssh_key_id` | The SSH key ID to update. |
 
-This endpoint replaces the name and/or key text of an existing SSH key. Existing workspaces that use the key will be updated with the new values.
+This endpoint replaces the name of an existing SSH key.
 
 Editing SSH keys requires permission to manage VCS settings. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
 
@@ -245,7 +245,6 @@ Properties without a default value are required.
 | ----------------------- | ------ | --------- | ----------------------------------------------------------------------------- |
 | `data.type`             | string |           | Must be `"ssh-keys"`.                                                         |
 | `data.attributes.name`  | string | (nothing) | A name to identify the SSH key. If omitted, the existing name is preserved.   |
-| `data.attributes.value` | string | (nothing) | The text of the SSH private key. If omitted, the existing value is preserved. |
 
 ### Sample Payload
 


### PR DESCRIPTION
From the very beginning it's not been possible to update the value of an SSH key text. The reason for this is the non-repudiation of security auditing. For example, if an attacker uses the ssh key to access a resource, the security audit of the ssh authentication can be trusted to mean key X was always key X and never updated.
