### PR TITLE
Remove pre apply stage

### DIFF
--- a/content/cloud-docs/api-docs/run-tasks.mdx
+++ b/content/cloud-docs/api-docs/run-tasks.mdx
@@ -458,7 +458,8 @@ curl \
     "id": "wstask-tBXYu8GVAFBpcmPm",
       "type": "workspace-tasks",
       "attributes": {
-        "enforcement-level": "advisory"
+        "enforcement-level": "advisory",
+        "stage": "post_plan"
       },
       "relationships": {
         "task": {
@@ -520,7 +521,8 @@ curl \
     "id": "wstask-tBXYu8GVAFBpcmPm",
       "type": "workspace-tasks",
       "attributes": {
-        "enforcement-level": "advisory"
+        "enforcement-level": "advisory",
+        "stage": "post_plan"
       },
       "relationships": {
         "task": {
@@ -591,7 +593,8 @@ curl --request GET \
     "id": "wstask-tBXYu8GVAFBpcmPm",
       "type": "workspace-tasks",
       "attributes": {
-        "enforcement-level": "advisory"
+        "enforcement-level": "advisory",
+        "stage": "post_plan"
       },
       "relationships": {
         "task": {
@@ -671,7 +674,8 @@ curl \
     "id": "wstask-tBXYu8GVAFBpcmPm",
       "type": "workspace-tasks",
       "attributes": {
-        "enforcement-level": "mandatory"
+        "enforcement-level": "mandatory",
+        "stage": "post_plan"
       },
       "relationships": {
         "task": {

--- a/content/cloud-docs/integrations/run-tasks/index.mdx
+++ b/content/cloud-docs/integrations/run-tasks/index.mdx
@@ -25,6 +25,8 @@ When a run reaches the appropriate phase and a run task is triggered, the suppli
 {
   "payload_version": 1,
   "access_token": "4QEuyyxug1f2rw.atlasv1.iDyxqhXGVZ0ykes53YdQyHyYtFOrdAWNBxcVUgWvzb64NFHjcquu8gJMEdUwoSLRu4Q",
+  "stage": "post_plan",
+  "is_speculative": false,
   "task_result_id": "taskrs-2nH5dncYoXaMVQmJ",
   "task_result_enforcement_level": "mandatory",
   "task_result_callback_url": "https://app.terraform.io/api/v2/task-results/5ea8d46c-2ceb-42cd-83f2-82e54697bddd/callback",

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -82,7 +82,7 @@ _Leaving this stage:_
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## 6. The Apply Stage
+## 5. The Apply Stage
 
 _States in this stage:_
 
@@ -96,7 +96,7 @@ After applying, the run proceeds automatically to completion.
 - If the apply failed, the run ends in the **Apply Errored** state.
 - If a user canceled the apply by pressing the "Cancel Run" button, the run ends in the **Canceled** state.
 
-## 7. Completion
+## 6. Completion
 
 A run is considered completed if it finishes applying, if any part of the run fails, if there's nothing to do, or if a user chooses not to continue. Once a run is completed, the next run in the queue can enter the plan stage.
 

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -82,26 +82,6 @@ _Leaving this stage:_
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## 5. The Pre-Apply Stage
-
--> **Note:** As of September 2021, Run Tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
-
-This phase only occurs if there are [run tasks](/cloud-docs/workspaces/settings/run-tasks) enabled for the workspace, and it executes any configured run tasks after the Plan, optional Cost Estimation, and optional Policy Check phases have completed. During this phase, Terraform Cloud sends information about your run to the configured external system and waits for a pass or fail response to determine whether the plan can be applied.
-
--> **Note:** The information sent to the configured external system includes the [JSON output](/internals/json-format) of your plan.
-
-_States in this stage:_
-
-- **Running tasks:** Terraform Cloud is currently waiting for a response from the configured external system(s).
-  - External systems must respond initially with a `200 OK` acknowledging the request is in progress. After that, they have 10 minutes to return a status of `passed` or `failed`, or the timeout will expire and the task will be assumed to be in the `failed` status.
-
-_Leaving this stage:_
-
-- If any mandatory tasks failed, the run skips to completion (**Plan Errored** state).
-- If any advisory tasks failed, the run proceeds to the **Applying** state, with a visible warning regarding the failed task.
-- If a combination of mandatory and advisory tasks are configured for a single run, Terraform will take the most restrictive action. This means that if there are two advisory tasks that succeed and one mandatory task that failed, the run will fail. If one mandatory task succeeds and two advisory tasks fail, the run will succeed with a warning.
-- If a user canceled the apply by pressing the "Cancel Run" button, the run ends in the **Canceled** state.
-
 ## 6. The Apply Stage
 
 _States in this stage:_


### PR DESCRIPTION
Some recent changes were made to run tasks, including a migration away from Pre-Apply to Post-Plan. With this recent change, and the potential for future changes to stages up until Run Tasks GA release, we want to remove references of the Pre-Apply stage from the documentation.