### PR TITLE
Add log rotation information

### DIFF
--- a/content/enterprise/admin/infrastructure/logging.mdx
+++ b/content/enterprise/admin/infrastructure/logging.mdx
@@ -9,7 +9,7 @@ destinations, a process called log forwarding. Log forwarding provides increased
 observability, assistance complying with log retention requirements, and
 information during troubleshooting.
 
--> **Note:** If you are using a version of Terraform Enterprise prior to v202109-1, please refer to the [previous version of this page](/enterprise/admin/logging-old) with logspout information.
+-> **Note:** For Terraform Enterprise versions prior to v202109-1, please refer to the [previous version of this page](/enterprise/admin/logging-old) with logspout information.
 
 ## Requirements
 
@@ -30,22 +30,17 @@ Log forwarding is disabled by default. To enable log forwarding, set the
 `log_forwarding_enabled` Terraform Enterprise application setting to the value
 `1`.
 
-<Tabs>
-  <Tab heading="Standalone" group="standalone">
+For a Standalone installation of Terraform Enterprise:
 
 ```sh
 replicatedctl app-config set log_forwarding_enabled --value 1
 ```
 
-  </Tab>
-  <Tab heading="Active/Active" group="active-active">
+For an Active/Active installation of Terraform Enterprise:
 
 ```sh
 tfe-admin app-config -k log_forwarding_enabled -v 1
 ```
-
-  </Tab>
-</Tabs>
 
 When log forwarding is enabled, the Terraform Enterprise application settings
 show the following for `log_forwarding_enabled`:
@@ -73,22 +68,17 @@ Fluent Bit `[OUTPUT]` configuration and then using that file to configure the
 configuration is stored in the application settings exactly how it appears in
 the `fluent-bit.conf` file.
 
-<Tabs>
-  <Tab heading="Standalone" group="standalone">
+For a Standalone installation of Terraform Enterprise:
 
 ```sh
 replicatedctl app-config set log_forwarding_config --value "$(cat fluent-bit.conf)"
 ```
 
-  </Tab>
-  <Tab heading="Active/Active" group="active-active">
+For an Active/Active installation of Terraform Enterprise:
 
 ```sh
 tfe-admin app-config -k log_forwarding_config -v "$(cat fluent-bit.conf)"
 ```
-
-  </Tab>
-</Tabs>
 
 Once configured, the Terraform Enterprise application settings show the
 `log_forwarding_config` setting in escaped JSON string format:

--- a/content/enterprise/admin/infrastructure/logging.mdx
+++ b/content/enterprise/admin/infrastructure/logging.mdx
@@ -89,7 +89,7 @@ Once configured, the Terraform Enterprise application settings show the
     },
 ```
 
-Here's what that escaped JSON string will render to:
+That escaped JSON string renders to the following:
 
 ```ini
 # Match all logs and do not forward them anywhere.
@@ -340,19 +340,18 @@ Log forwarding uses the `journald` Docker logging driver to send Terraform
 Enterprise logs to `systemd-journald`. This can cause increased disk utilization
 for the `/var/log/journal` path.
 
-To limit this disk utilization, configure the `SystemMaxFileSize` and
-`SystemMaxFiles` settings within `/etc/systemd/journald.conf` to use reasonable
-values:
+To limit disk utilization, configure the `SystemMaxFileSize` and
+`SystemMaxFiles` settings within `/etc/systemd/journald.conf`.
+
+The following configuration tells `systemd-journald` to use up to 7GB of disk
+space by limiting the size a log file to 1024MB and keeping up to 7 files at any
+given time:
 
 ```ini
 [Journal]
 SystemMaxFileSize=1024M
 SystemMaxFiles=7
 ```
-
-This configuration tells `systemd-journald` that it can use up to 7GB of disk
-space by limiting the size a log file to 1024MB and keeping up to 7 files at any
-given time.
 
 To apply these changes, restart `systemd-journald`:
 

--- a/content/enterprise/admin/infrastructure/logging.mdx
+++ b/content/enterprise/admin/infrastructure/logging.mdx
@@ -9,6 +9,8 @@ destinations, a process called log forwarding. Log forwarding provides increased
 observability, assistance complying with log retention requirements, and
 information during troubleshooting.
 
+-> **Note:** If you are using a version of Terraform Enterprise prior to v202109-1, please refer to the [previous version of this page](/enterprise/admin/logging-old) with logspout information.
+
 ## Requirements
 
 Log forwarding requires:
@@ -28,30 +30,33 @@ Log forwarding is disabled by default. To enable log forwarding, set the
 `log_forwarding_enabled` Terraform Enterprise application setting to the value
 `1`.
 
-For a Standalone installation of Terraform Enterprise:
+<Tabs>
+  <Tab heading="Standalone" group="standalone">
 
-```
+```sh
 replicatedctl app-config set log_forwarding_enabled --value 1
 ```
 
-For an Active/Active installation of Terraform Enterprise:
+  </Tab>
+  <Tab heading="Active/Active" group="active-active">
 
-```
+```sh
 tfe-admin app-config -k log_forwarding_enabled -v 1
 ```
+
+  </Tab>
+</Tabs>
 
 When log forwarding is enabled, the Terraform Enterprise application settings
 show the following for `log_forwarding_enabled`:
 
-```
-    ...
+```json
     "log_forwarding_enabled": {
         "value": "1"
     },
-    ...
 ```
 
-### Configure External Destinations
+## Configure External Destinations
 
 The `log_forwarding_config` Terraform Enterprise application setting must
 contain valid
@@ -68,30 +73,35 @@ Fluent Bit `[OUTPUT]` configuration and then using that file to configure the
 configuration is stored in the application settings exactly how it appears in
 the `fluent-bit.conf` file.
 
-For a Standalone installation of Terraform Enterprise:
+<Tabs>
+  <Tab heading="Standalone" group="standalone">
 
-```
+```sh
 replicatedctl app-config set log_forwarding_config --value "$(cat fluent-bit.conf)"
 ```
 
-For an Active/Active installation of Terraform Enterprise:
+  </Tab>
+  <Tab heading="Active/Active" group="active-active">
 
-```
+```sh
 tfe-admin app-config -k log_forwarding_config -v "$(cat fluent-bit.conf)"
 ```
+
+  </Tab>
+</Tabs>
 
 Once configured, the Terraform Enterprise application settings show the
 `log_forwarding_config` setting in escaped JSON string format:
 
-```
-    ...
+```json
     "log_forwarding_config": {
         "value": "# Match all logs and do not forward them anywhere.\n[OUTPUT]\n    Name null\n    Match *\n"
     },
-    ...
 ```
 
-```
+Here's what that escaped JSON string will render to:
+
+```ini
 # Match all logs and do not forward them anywhere.
 [OUTPUT]
     Name null
@@ -101,7 +111,7 @@ Once configured, the Terraform Enterprise application settings show the
 To forward logs to multiple external destinations, use multiple `[OUTPUT]`
 directives.
 
-```
+```ini
 # Forward all logs to Datadog.
 [OUTPUT]
     Name datadog
@@ -119,7 +129,7 @@ directives.
 [`stdout` Fluent Bit output plugin](https://docs.fluentbit.io/manual/pipeline/outputs/standard-output).
 Doing this creates a loop that continuously emits logs!
 
-## Restart Terraform Enterprise
+### Restart Terraform Enterprise
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
@@ -140,7 +150,7 @@ This example configuration forwards all logs to Amazon CloudWatch. Refer to the
 [`cloudwatch_logs` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name               cloudwatch_logs
     Match              *
@@ -163,7 +173,7 @@ This example configuration forwards all logs to Amazon S3. Refer to the
 [`s3` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/s3)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name                          s3
     Match                         *
@@ -184,7 +194,7 @@ This example configuration forwards all logs to Azure Blob Storage. Refer to the
 [`azure_blob` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob)
 for more information.
 
-```
+```ini
 [OUTPUT]
     name                   azure_blob
     match                  *
@@ -202,7 +212,7 @@ This example configuration forwards all logs to Azure Log Analytics. Refer to
 the [`azure` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/azure)
 for more information.
 
-```
+```ini
 [OUTPUT]
     name         azure
     match        *
@@ -216,7 +226,7 @@ This example configuration forwards all logs to Datadog. Refer to the
 [`datadog` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/datadog)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name        datadog
     Match       *
@@ -236,7 +246,7 @@ Fluentd instance. Refer to the
 [`forward` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/forward)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name   forward
     Match  *
@@ -254,7 +264,7 @@ Logging (formerly known as Stackdriver). Refer to the
 [`stackdriver` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name       stackdriver
     Match      *
@@ -276,7 +286,7 @@ Event Collector (HEC) interface. Refer to the
 [`splunk` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/splunk)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name          splunk
     Match         *
@@ -292,7 +302,7 @@ Refer to the
 [`syslog` Fluent Bit output plugin documentation](https://docs.fluentbit.io/manual/pipeline/outputs/syslog)
 for more information.
 
-```
+```ini
 [OUTPUT]
     Name                 syslog
     Match                *
@@ -315,7 +325,7 @@ contain the string `[Audit Log]`.
 
 Here's an example audit log entry formatted for readability:
 
-```
+```json
 2021-08-31 04:58:30 [INFO] [7a233ad1-c50c-4737-a925-3be901e55fcb] [Audit Log]
 {
   "resource":"run",
@@ -334,4 +344,28 @@ recommend forwarding all Terraform Enterprise logs to a log aggregation system,
 filtering the audit logs based on the `[Audit Log]` string, and forwarding just
 the audit logs to the desired destination.
 
--> **Note:** If you are using a version of Terraform Enterprise prior to v202109-1, please refer to the [previous version of this page](/enterprise/admin/logging-old) with logspout information.
+## Log Rotation
+
+Log forwarding uses the `journald` Docker logging driver to send Terraform
+Enterprise logs to `systemd-journald`. This can cause increased disk utilization
+for the `/var/log/journal` path.
+
+To limit this disk utilization, configure the `SystemMaxFileSize` and
+`SystemMaxFiles` settings within `/etc/systemd/journald.conf` to use reasonable
+values:
+
+```ini
+[Journal]
+SystemMaxFileSize=1024M
+SystemMaxFiles=7
+```
+
+This configuration tells `systemd-journald` that it can use up to 7GB of disk
+space by limiting the size a log file to 1024MB and keeping up to 7 files at any
+given time.
+
+To apply these changes, restart `systemd-journald`:
+
+```sh
+sudo systemctl restart systemd-journald
+```

--- a/content/enterprise/before-installing/index.mdx
+++ b/content/enterprise/before-installing/index.mdx
@@ -263,8 +263,12 @@ Terraform Enterprise uses the `json-file` Docker logging driver to send its logs
 to JSON files on disk. This can cause increased disk utilization for the Docker
 data directory (which defaults to `/var/lib/docker`).
 
-To limit this disk utilization, configure the `log-driver` and `log-opts`
-settings within `/etc/docker/daemon.json` to use reasonable values:
+To limit disk utilization, configure the `log-driver` and `log-opts` settings
+within `/etc/docker/daemon.json`.
+
+This following configuration tells the `json-file` Docker logging driver to use
+up to 384MB of disk space per container by limiting the size of a JSON log file
+to 128MB and keeping up to 3 JSON log files at any given time:
 
 ```json
 {
@@ -275,10 +279,6 @@ settings within `/etc/docker/daemon.json` to use reasonable values:
 	}
 }
 ```
-
-This configuration tells Docker that each container can use up to 384MB of disk
-space for JSON file logs by limiting the size of a JSON file to 128MB and
-keeping up to 3 files at any given time.
 
 To apply these changes, restart Docker:
 

--- a/content/enterprise/before-installing/index.mdx
+++ b/content/enterprise/before-installing/index.mdx
@@ -255,6 +255,10 @@ Refer to the sections below for instructions on how to verify your Docker Engine
 
 ### Log Rotation
 
+-> **Note:** If using log forwarding, refer to
+[this log rotation documentation](/enterprise/admin/infrastructure/logging#log-rotation)
+instead.
+
 Terraform Enterprise uses the `json-file` Docker logging driver to send its logs
 to JSON files on disk. This can cause increased disk utilization for the Docker
 data directory (which defaults to `/var/lib/docker`).

--- a/content/enterprise/before-installing/index.mdx
+++ b/content/enterprise/before-installing/index.mdx
@@ -253,6 +253,35 @@ Refer to the sections below for instructions on how to verify your Docker Engine
   sudo systemctl restart docker
   ```
 
+### Log Rotation
+
+Terraform Enterprise uses the `json-file` Docker logging driver to send its logs
+to JSON files on disk. This can cause increased disk utilization for the Docker
+data directory (which defaults to `/var/lib/docker`).
+
+To limit this disk utilization, configure the `log-driver` and `log-opts`
+settings within `/etc/docker/daemon.json` to use reasonable values:
+
+```json
+{
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "128m",
+		"max-file": "3" 
+	}
+}
+```
+
+This configuration tells Docker that each container can use up to 384MB of disk
+space by limiting the size of a JSON file to 128MB and keeping up to 3 files at
+any given time.
+
+To apply these changes, restart Docker:
+
+```sh
+sudo systemctl restart docker
+```
+
 ### IAM Policies
 
 If you have chosen the [external services operational mode](/enterprise/before-installing#operational-mode-decision), Terraform Enterprise will need access to an S3-compliant endpoint for object storage. You can grant access to the object storage endpoint by either assigning an AWS instance profile or an equivalent IAM system in non-AWS environments.

--- a/content/enterprise/before-installing/index.mdx
+++ b/content/enterprise/before-installing/index.mdx
@@ -273,8 +273,8 @@ settings within `/etc/docker/daemon.json` to use reasonable values:
 ```
 
 This configuration tells Docker that each container can use up to 384MB of disk
-space by limiting the size of a JSON file to 128MB and keeping up to 3 files at
-any given time.
+space for JSON file logs by limiting the size of a JSON file to 128MB and
+keeping up to 3 files at any given time.
 
 To apply these changes, restart Docker:
 

--- a/content/enterprise/release/v202109-1.mdx
+++ b/content/enterprise/release/v202109-1.mdx
@@ -11,6 +11,8 @@ The following operating systems are no longer supported:
 - Ubuntu 14
 - Debian 7
 
+Docker logs using the `json-file` logging driver (the default driver) will no longer be automatically rotated. Please refer to the [log rotation documentation](/enterprise/before-installing#log-rotation) for details on how to configure log rotation.
+
 ## Application Level Features
 
 1. Added Terraform CLI versions up through 1.1.0-alpha20210811 to Terraform Enterprise.

--- a/content/enterprise/release/v202109-2.mdx
+++ b/content/enterprise/release/v202109-2.mdx
@@ -15,6 +15,8 @@ The following operating systems are no longer supported:
 - Ubuntu 14
 - Debian 7
 
+Docker logs using the `json-file` logging driver (the default driver) will no longer be automatically rotated. Please refer to the [log rotation documentation](/enterprise/before-installing#log-rotation) for details on how to configure log rotation.
+
 ## Application Level Features
 
 1. Added Terraform CLI versions up through 1.1.0-alpha20210811 to Terraform Enterprise.


### PR DESCRIPTION
Operators have been experiencing increased disk utilization since Terraform Enterprise v202109-1. This is because the default `log-opts` for the `json-file` Docker logging driver were removed as a part of the log forwarding work. These changes detail how an operator can configure log rotation to limit disk utilization regardless whether or not they are using the log forwarding feature.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201747281670986