### PR TITLE
Fixed metric naming

### DIFF
--- a/content/enterprise/admin/infrastructure/monitoring.mdx
+++ b/content/enterprise/admin/infrastructure/monitoring.mdx
@@ -81,8 +81,8 @@ In addition to the per-container metrics, the following global metrics are expos
 
 |              Exposed Metric              | Metrics Type |                                             Description                                            |
 |:---------------------------------------- |:------------:|:-------------------------------------------------------------------------------------------------- |
-| `tfe.operation.count`                    | `gauge `     | Number of running containers being used for Terraform operators (runs and plans)                   |
-| `tfe.operation.limit`                    | `gauge`      | Maximum number of jobs as defined by the `capacity_concurrency` Replicated config                  |
+| `tfe.run.count`                    | `gauge `     | Number of running containers being used for Terraform operators (runs and plans)                   |
+| `tfe.run.limit`                    | `gauge`      | Maximum number of jobs as defined by the `capacity_concurrency` Replicated config                  |
 
 The name and ID for build worker containers are unique for each build, and build container names take the form of a UUID. Be aware of this when planning for Prometheus storage capacity requirements that relate to metric cardinality. Environments that do not need to track resource consumption of individual build containers or runs can use [Prometheus metric relabelling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to remove the unique ID, name, and run type labels from container metrics. This reduces cardinality within the dataset while still retaining the ability to associate resource usage with a given workspace and organization.
 


### PR DESCRIPTION
changed `tfe.operation.count` to `tfe.run.count`