### PR TITLE
Adding the --tty flag to the example and adding a note to explain it

### DIFF
--- a/content/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/enterprise/install/automated/automating-initial-user.mdx
@@ -20,14 +20,13 @@ After installation, run the following from a shell connected to your Terraform E
 replicated admin --tty=0 retrieve-iact
 ```
 
-If you want to create the initial user in an automated deployment script, run a command like the following instead so that you can capture the IACT:
+If you want to create the initial user in an automated deployment script, run a command that lets you capture the IACT. The following example command outputs the complete IACT with the carriage return character removed. The `--tty=0` flag enables the command to run successfully in automation, such as cloud-init. Without this flag set, the command will return an empty string:
 
 ```shell
 initial_token=$(replicated admin --tty=0 retrieve-iact | tr -d '\r')
 ```
-The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.
 
-~> NOTE: The `--tty=0` flag enables the command to run successfully in automation, such as cloud-init. Without this flag set it will return an empty string.
+The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.
 
 ### Via API
 

--- a/content/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/enterprise/install/automated/automating-initial-user.mdx
@@ -23,8 +23,10 @@ replicated admin --tty=0 retrieve-iact
 If you want to create the initial user in an automated deployment script, run a command like the following instead so that you can capture the IACT:
 
 ```shell
-initial_token=$(replicated admin retrieve-iact | tr -d '\r')
+initial_token=$(replicated admin --tty=0 retrieve-iact | tr -d '\r')
 ```
+
+~> NOTE: The `--tty=0` flag enables the command to run successfully in automation, such as cloud-init. Without this flag set it will return an empty string.
 
 The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.
 

--- a/content/enterprise/install/automated/automating-initial-user.mdx
+++ b/content/enterprise/install/automated/automating-initial-user.mdx
@@ -25,10 +25,9 @@ If you want to create the initial user in an automated deployment script, run a 
 ```shell
 initial_token=$(replicated admin --tty=0 retrieve-iact | tr -d '\r')
 ```
+The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.
 
 ~> NOTE: The `--tty=0` flag enables the command to run successfully in automation, such as cloud-init. Without this flag set it will return an empty string.
-
-The command outputs the complete IACT with the carriage return character removed, which facilitates use in automation.
 
 ### Via API
 


### PR DESCRIPTION
The `--tty=0` flag was missing from the example code. This flag is needed for it to run successfully outside of an interactive user session. Also added a note to explain why the flag is there.