### PR TITLE
extend alert banner for addtl week

### DIFF
--- a/data/alert-banner.js
+++ b/data/alert-banner.js
@@ -8,5 +8,5 @@ export default {
   linkText: 'Take our survey',
   // Set the expirationDate prop with a datetime string (e.g. '2020-01-31T12:00:00-07:00')
   // if you'd like the component to stop showing at or after a certain date
-  expirationDate: '2022-02-04T23:00:00-07:00',
+  expirationDate: '2022-02-10T23:00:00-07:00',
 }


### PR DESCRIPTION
per request from matt terich + melina mclarty, they'd like to see the alert banner to continue for an additional week while they capture participants