### PR TITLE
Remove unclear line around caching of public providers/modules in TFC

### DIFF
--- a/content/cloud-docs/registry/add.mdx
+++ b/content/cloud-docs/registry/add.mdx
@@ -11,7 +11,7 @@ description: >-
 
 # Adding Public Providers and Modules to the Private Registry
 
-You can add providers and modules from the public [Terraform Registry](/registry) to your Terraform Cloud private registry. This lets you clearly designate which public providers and modules are recommended for the organization and makes their supporting documentation and examples centrally accessible.
+You can add providers and modules from the public [Terraform Registry](/registry) to your Terraform Cloud private registry. The private registry stores a pointer to these public providers and modules so that you can view their data from within Terraform Cloud. This lets you clearly designate which public providers and modules are recommended for the organization and makes their supporting documentation and examples centrally accessible.
 
 -> **Note:** Public providers and modules are available in Terraform Enterprise v202012-1 and later. Your instance must allow access to `registry.terraform.io` and `https://yy0ffni7mf-dsn.algolia.net/`.
 

--- a/content/cloud-docs/registry/add.mdx
+++ b/content/cloud-docs/registry/add.mdx
@@ -17,8 +17,6 @@ You can add providers and modules from the public [Terraform Registry](/registry
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-The private registry automatically synchronizes public providers and modules with their source on the Terraform Registry. The private registry handles downloads and controls access with Terraform Cloud API tokens, so consumers do not need access to the provider and module source repositories, even when they run Terraform from the command line.
-
 You can add providers and modules through the UI as detailed below or through the [Registry Providers API](/cloud-docs/api-docs/providers) and the [Registry Modules API](/cloud-docs/api-docs/modules#create-a-module-with-no-vcs-connection-).
 
 ## Permissions


### PR DESCRIPTION
We received feedback that this line makes it appear that public providers and modules are actually cached in Terraform Cloud Private Registry. Actually, the Private Registry will store a pointer to the module or provider in the public registry and behind the scenes the modules and providers are pulled from the public registry. I have removed the line from the documentation, but I'm open to suggestions on if there should be something to indicate that we are only storing a pointer to the public registry.