### PR TITLE
Update teams.mdx

### DIFF
--- a/content/cloud-docs/api-docs/teams.mdx
+++ b/content/cloud-docs/api-docs/teams.mdx
@@ -143,7 +143,7 @@ Properties without a default value are required.
 | --------------------------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `data.type`                             | string |            | Must be `"teams"`.                                                                                                                                                                                                                   |
 | `data.attributes.name`                  | string |            | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.                                                                              |
-| `data.attributes.organization-access`   | object | (nothing)  | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-workspaces`, and `manage-vcs-settings` properties with boolean values. All properties default to `false`. |
+| `data.attributes.organization-access`   | object | (nothing)  | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-workspaces`, `manage-vcs-settings`, `manage-providers`, and `manage-modules` properties with boolean values. All properties default to `false`. |
 | `data.attributes.visibility` **(beta)** | string | `"secret"` | The team's visibility. Must be `"secret"` or `"organization"` (visible).                                                                                                                                                             |
 
 ### Sample Payload
@@ -184,7 +184,9 @@ $ curl \
         "manage-policies": false,
         "manage-policy-overrides": false,
         "manage-vcs-settings": false,
-        "manage-workspaces": true
+        "manage-workspaces": true,
+        "manage-providers": false,
+        "manage-modules": false
       },
       "permissions": {
         "can-update-membership": true,
@@ -253,7 +255,9 @@ $ curl \
         "manage-policies": true,
         "manage-policy-overrides": false,
         "manage-workspaces": false,
-        "manage-vcs-settings": false
+        "manage-vcs-settings": false,
+        "manage-providers": false,
+        "manage-modules": false
       }
     },
     "relationships": {
@@ -297,7 +301,7 @@ Properties without a default value are required.
 | --------------------------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `data.type`                             | string |                  | Must be `"teams"`.                                                                                                                                                                                                                   |
 | `data.attributes.name`                  | string | (previous value) | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.                                                                              |
-| `data.attributes.organization-access`   | object | (previous value) | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-workspaces`, and `manage-vcs-settings` properties with boolean values. All properties default to `false`. |
+| `data.attributes.organization-access`   | object | (previous value) | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-workspaces`, `manage-vcs-settings`, `manage-providers`, and `manage-modules` properties with boolean values. All properties default to `false`. |
 | `data.attributes.visibility` **(beta)** | string | (previous value) | The team's visibility. Must be `"secret"` or `"organization"` (visible).                                                                                                                                                             |
 
 ### Sample Payload
@@ -338,7 +342,9 @@ $ curl \
         "manage-policies": false,
         "manage-policy-overrides": false,
         "manage-vcs-settings": true,
-        "manage-workspaces": true
+        "manage-workspaces": true,
+        "manage-providers": false,
+        "manage-modules": false
       },
       "visibility": "organization",
       "permissions": {


### PR DESCRIPTION
Adds `manage-providers` and `manage-modules` as valid team organization permissions. Support was added to the API about 2 months ago and to go-tfe today.