### PR TITLE
Add clarity to release page around the Terraform CLI Version

### DIFF
--- a/content/enterprise/releases/2018/index.mdx
+++ b/content/enterprise/releases/2018/index.mdx
@@ -8,7 +8,7 @@ description: >-
 
 Terraform Enterprise releases from 2018 are listed in the table below.
 
-| Version     | Release Sequence | Recommended<br /> Replicated CLI                                   | Latest <br />Terraform CLI                                              | Sentinel                                                                       |
+| Version     | Release Sequence | Recommended<br /> Replicated CLI                                   | Bundled <br />Terraform CLI**                                              | Sentinel                                                                       |
 | ----------- | ---------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | v201812-2\* | 314              | [2.9.2](https://release-notes.replicated.com/release-notes/2.9.2/) | [0.11.10](https://github.com/hashicorp/terraform/releases/tag/v0.11.10) | [0.6.0](https://docs.hashicorp.com/sentinel/changelog#0-6-0-november-30-2018)  |
 | v201812-1   | 311              | [2.9.2](https://release-notes.replicated.com/release-notes/2.9.2/) | [0.11.10](https://github.com/hashicorp/terraform/releases/tag/v0.11.10) | [0.6.0](https://docs.hashicorp.com/sentinel/changelog#0-6-0-november-30-2018)  |
@@ -28,3 +28,5 @@ Terraform Enterprise releases from 2018 are listed in the table below.
 | v201804-1\* | 251              | [2.9.2](https://release-notes.replicated.com/release-notes/2.9.2/) | [0.11.1](https://github.com/hashicorp/terraform/releases/tag/v0.11.1)   | [0.1.0](https://docs.hashicorp.com/sentinel/changelog#0-1-0-september-19-2017) |
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
+
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions).

--- a/content/enterprise/releases/2019/index.mdx
+++ b/content/enterprise/releases/2019/index.mdx
@@ -8,7 +8,7 @@ description: >-
 
 Terraform Enterprise releases from 2019 are listed in the table below.
 
-| Version     | Release Sequence | Recommended<br /> Replicated CLI                                     | Latest <br />Terraform CLI                                              | Sentinel                                                                        |
+| Version     | Release Sequence | Recommended<br /> Replicated CLI                                     | Bundled <br />Terraform CLI**                                              | Sentinel                                                                        |
 | ----------- | ---------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | v201912-4   | 408              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.12.17](https://github.com/hashicorp/terraform/releases/tag/v0.12.17) | [0.13.0](https://docs.hashicorp.com/sentinel/changelog#0-13-0-november-15-2019) |
 | v201912-3   | 407              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.12.17](https://github.com/hashicorp/terraform/releases/tag/v0.12.17) | [0.13.0](https://docs.hashicorp.com/sentinel/changelog#0-13-0-november-15-2019) |
@@ -42,3 +42,5 @@ Terraform Enterprise releases from 2019 are listed in the table below.
 | v201901-1   | 319              | [2.9.2](https://release-notes.replicated.com/release-notes/2.9.2/) | [0.11.11](https://github.com/hashicorp/terraform/releases/tag/v0.11.11) | [0.8.1](https://docs.hashicorp.com/sentinel/changelog#0-8-1-january-17-2019)    |
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
+
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions).

--- a/content/enterprise/releases/2020/index.mdx
+++ b/content/enterprise/releases/2020/index.mdx
@@ -8,7 +8,7 @@ description: >-
 
 Terraform Enterprise releases from 2020 are listed in the table below.
 
-| Version     | Release Sequence | Recommended<br /> Replicated CLI                                     | Latest <br />Terraform CLI                                              | Sentinel                                                                       |
+| Version     | Release Sequence | Recommended<br /> Replicated CLI                                     | Bundled <br />Terraform CLI**                                              | Sentinel                                                                       |
 | ----------- | ---------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | v202012-2   | 502              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.13.5](https://github.com/hashicorp/terraform/releases/tag/v0.13.5)   | [0.16.1](https://docs.hashicorp.com/sentinel/changelog#0-16-1-october-21-2020) |
 | v202012-1   | 501              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.13.5](https://github.com/hashicorp/terraform/releases/tag/v0.13.5)   | [0.16.1](https://docs.hashicorp.com/sentinel/changelog#0-16-1-october-21-2020) |
@@ -40,3 +40,5 @@ Terraform Enterprise releases from 2020 are listed in the table below.
 | v202001-1   | 409              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.12.19](https://github.com/hashicorp/terraform/releases/tag/v0.12.19) | [0.14.2](https://docs.hashicorp.com/sentinel/changelog#0-14-2-january-15-2020) |
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
+
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions).

--- a/content/enterprise/releases/2021/index.mdx
+++ b/content/enterprise/releases/2021/index.mdx
@@ -8,7 +8,7 @@ description: >-
 
 Terraform Enterprise releases from 2021 are listed in the table below.
 
-| Version                                           | Release Sequence | Recommended<br /> Replicated CLI                                     | Latest <br />Terraform CLI                                            | Sentinel                                                                       |
+| Version                                           | Release Sequence | Recommended<br /> Replicated CLI                                     | Bundled <br />Terraform CLI**                                            | Sentinel                                                                       |
 | ------------------------------------------------- | ---------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | [v202112-2](/enterprise/releases/2021/v202112-2)   | 590              | [2.53.2](https://release-notes.replicated.com/release-notes/2.53.2/) | [1.0.11](https://github.com/hashicorp/terraform/releases/tag/v1.0.11) | [0.18.4](https://docs.hashicorp.com/sentinel/changelog#0-18-4-july-20-2021)    |
 | [v202112-1](/enterprise/releases/2021/v202112-1)   | 588              | [2.53.2](https://release-notes.replicated.com/release-notes/2.53.2/) | [1.0.11](https://github.com/hashicorp/terraform/releases/tag/v1.0.11) | [0.18.4](https://docs.hashicorp.com/sentinel/changelog#0-18-4-july-20-2021)    |
@@ -29,3 +29,5 @@ Terraform Enterprise releases from 2021 are listed in the table below.
 | [v202101-1](/enterprise/releases/2021/v202101-1)   | 504              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.13.5](https://github.com/hashicorp/terraform/releases/tag/v0.13.5) | [0.16.1](https://docs.hashicorp.com/sentinel/changelog#0-16-1-october-21-2020) |
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
+
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions).

--- a/content/enterprise/releases/2022/index.mdx
+++ b/content/enterprise/releases/2022/index.mdx
@@ -8,9 +8,11 @@ description: >-
 
 Terraform Enterprise releases from 2022 are listed in the table below.
 
-| Version                                         | Release Sequence | Recommended<br /> Replicated CLI                                     | Latest <br />Terraform CLI                                          | Sentinel                                                                    |
+| Version                                         | Release Sequence | Recommended<br /> Replicated CLI                                     | Bundled <br />Terraform CLI**                                          | Sentinel                                                                    |
 | ----------------------------------------------- | ---------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | [v202201-2](/enterprise/releases/2022/v202201-2) | 595              | [2.53.2](https://release-notes.replicated.com/release-notes/2.53.2/) | [1.1.3](https://github.com/hashicorp/terraform/releases/tag/v1.1.3) | [0.18.4](https://docs.hashicorp.com/sentinel/changelog#0-18-4-july-20-2021) |
 | [v202201-1](/enterprise/releases/2022/v202201-1) | 594              | [2.53.2](https://release-notes.replicated.com/release-notes/2.53.2/) | [1.1.3](https://github.com/hashicorp/terraform/releases/tag/v1.1.3) | [0.18.4](https://docs.hashicorp.com/sentinel/changelog#0-18-4-july-20-2021) |
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
+
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions).

--- a/content/enterprise/releases/index.mdx
+++ b/content/enterprise/releases/index.mdx
@@ -11,10 +11,12 @@ description: >-
 
 We release a new Terraform Enterprise version each month. The table below lists releases from the current calendar year as well as the last required release. You can find previous releases in the sidebar.
 
-| Version                                           | Release Sequence | Recommended<br /> Replicated CLI                                     | Latest <br />Terraform CLI                                            | Sentinel                                                                       |
+| Version                                           | Release Sequence | Recommended<br /> Replicated CLI                                     | Bundled <br />Terraform CLI**                                            | Sentinel                                                                       |
 | ------------------------------------------------- | ---------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | [v202201-2](/enterprise/releases/2022/v202201-2)   | 595              | [2.53.2](https://release-notes.replicated.com/release-notes/2.53.2/) | [1.1.3](https://github.com/hashicorp/terraform/releases/tag/v1.1.3)   | [0.18.4](https://docs.hashicorp.com/sentinel/changelog#0-18-4-july-20-2021)    |
 | [v202201-1](/enterprise/releases/2022/v202201-1)   | 594              | [2.53.2](https://release-notes.replicated.com/release-notes/2.53.2/) | [1.1.3](https://github.com/hashicorp/terraform/releases/tag/v1.1.3)   | [0.18.4](https://docs.hashicorp.com/sentinel/changelog#0-18-4-july-20-2021)    |
 | [v202103-1](/enterprise/releases/2021/v202103-1)\* | 519              | [2.29.0](https://release-notes.replicated.com/release-notes/2.29.0/) | [0.14.7](https://github.com/hashicorp/terraform/releases/tag/v0.14.7) | [0.17.4](https://docs.hashicorp.com/sentinel/changelog#0-17-4-february-2-2021) |
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
+
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions) .

--- a/content/enterprise/releases/index.mdx
+++ b/content/enterprise/releases/index.mdx
@@ -19,4 +19,4 @@ We release a new Terraform Enterprise version each month. The table below lists 
 
 \* Denotes a <strong>required release</strong>. All online upgrades will automatically install this version, but airgap customers must upgrade to this version before proceeding to later releases.
 
-\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions) .
+\** The release package contains this version of the CLI, but you can install older and newer versions of the Terraform CLI as needed via the [Admin UI](https://www.terraform.io/enterprise/admin/application/resources#managing-terraform-versions) or [API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions).


### PR DESCRIPTION
The existing release page does not make it clear whether the 'Lastest Terraform CLI' refers to the bundled version of the CLI or whether this is the maximum version that version of TFE supports. Customer feedback prompted adding clarity to the release page so it is clear what it means.