### PR TITLE
correcting which keys are shown

### DIFF
--- a/content/cloud-docs/vcs/bitbucket-server.mdx
+++ b/content/cloud-docs/vcs/bitbucket-server.mdx
@@ -76,7 +76,7 @@ Leave the page open in a browser tab, and remain logged in as an admin user.
 
    ![Terraform Cloud screenshot: text fields for adding a Bitbucket Server VCS provider](/img/docs/bitbucket-server-tfe-add-url-fields.png)
 
-1. Click "Continue" to view the generated **Consumer Key**, **Public Key**, and **Private Key** you can use to create a new Application Link in BitBucket Server. Leave this page open so you can copy and paste these values in Step 2.
+1. Click "Continue" to view the generated **Consumer Key** and **Public Key** you can use to create a new Application Link in BitBucket Server. Leave this page open so you can copy and paste these values in Step 2.
 
     To use keys from an existing Application Link, toggle "Use Custom Keys" and enter them into the page.
 


### PR DESCRIPTION
Documentation advised that a private key would be shown. This is not true and is reflected in the screenshots. Removed mention of private key in this step to avoid confusion from customers.