### PR TITLE
Add CODEOWNERS for /content/plugin/ files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Plugin Development
+/content/plugin/ @hashicorp/terraform-provider-devex

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Plugin Development
-/content/plugin/ @hashicorp/terraform-provider-devex
+/content/plugin/ @hashicorp/terraform-devex


### PR DESCRIPTION
Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Until this documentation is potentially migrated into the terraform-plugin-* repositories, flag the Terraform Provider Development Experience team for code reviews of `/content/plugin/` changes.