### PR TITLE
Clarify where to find VCS Providers

### DIFF
--- a/content/cloud-docs/vcs/github.mdx
+++ b/content/cloud-docs/vcs/github.mdx
@@ -33,8 +33,8 @@ The rest of this page explains the GitHub versions of these steps.
 
    1. Make sure the upper-left organization menu currently shows your organization.
    1. Click the "Settings" link at the top of the page (or within the ☰ menu)
-   1. On the next page, click "VCS Providers" in the left sidebar.
-   1. Click the "Add VCS Provider" button.
+   1. On the next page, click "Providers" in the "Version control" section of the left sidebar.
+   1. Click the "Add a VCS Provider" button.
 
 1. The "Add VCS Provider" page is divided into multiple steps to guide you through adding a new VCS provider.
 


### PR DESCRIPTION
The docs did not match up with what I was seeing in terraform cloud.
I was looking for "VCS Providers" that didn't exist.