### PR TITLE
Added notation of sentinel version update

### DIFF
--- a/content/enterprise/releases/2022/v202202-1.mdx
+++ b/content/enterprise/releases/2022/v202202-1.mdx
@@ -26,6 +26,7 @@ The Terraform Enterprise April 2022 release will:
 1. Fixed slow initial UI load for users who belong to hundreds of organizations.
 1. Fixed bug to disallow workspace from being renamed when a run has not completed.
 1. Fixed a UI issue where newly created organization API tokens weren't shown when the previous one was recently deleted.
+1. Updated Sentinel to 0.18.6
 
 
 ## APPLICATION LEVEL SECURITY FIXES:


### PR DESCRIPTION
The last time the sentinel version was updated, [it was notated in the release notes](https://www.terraform.io/enterprise/releases/2021/v202109-1#application-level-bug-fixes) If this time around it was not notated on purpose then please inform. Otherwise, please approve this PR if applicable.

i _did_ notice that it is mentioned within our private version of the release notes under _[Possible Non Customer Facing Changes](https://github.com/hashicorp/ptfe-releases/blob/master/releases/v202202-1.md#possible-non-customer-facing-changes)_

145. modules: upgrade sentinel to 0.18.6 -- @hc-github-team-tf-commercial-sentinel [hashicorp/tfe-sentinel-worker#160](https://github.com/hashicorp/tfe-sentinel-worker/pull/160)