### PR TITLE
Add missing include relations in docs

### DIFF
--- a/content/cloud-docs/api-docs/admin/runs.mdx
+++ b/content/cloud-docs/api-docs/admin/runs.mdx
@@ -66,14 +66,6 @@ This endpoint lists all runs in the Terraform Enterprise installation.
 
 A VCS repository identifier is a reference to a VCS repository in the format `:org/:repo`, where `:org` and `:repo` refer to the organization (or project) and repository in your VCS provider.
 
-### Available Related Resources
-
-This GET endpoint can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
-
-| Resource Name            | Description                                   |
-| ------------------------ | --------------------------------------------- |
-| `workspace`              | The workspace this run belongs in.            |
-| `workspace.organization` | The organization of the associated workspace. |
 
 ### Sample Request
 
@@ -219,3 +211,13 @@ curl \
   }
 }
 ```
+
+### Available Related Resources
+
+This GET endpoint can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
+
+| Resource Name                   | Description                                                       |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `workspace`                     | The workspace this run belongs in.                                |
+| `workspace.organization`        | The organization of the associated workspace.                     |
+| `workspace.organization.owners` | The owners of the organization of the associated workspace.       |

--- a/content/cloud-docs/api-docs/agents.mdx
+++ b/content/cloud-docs/api-docs/agents.mdx
@@ -545,3 +545,11 @@ $ curl \
   --request DELETE \
   https://app.terraform.io/api/v2/agent-pools/apool-MCf6kkxu5FyHbqhd
 ```
+
+### Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
+
+| Resource Name  | Description                                 |
+| -------------- | ------------------------------------------- |
+| `workspaces`   | The workspaces attached to this agent pool. |

--- a/content/cloud-docs/api-docs/configuration-versions.mdx
+++ b/content/cloud-docs/api-docs/configuration-versions.mdx
@@ -350,4 +350,7 @@ curl \
 
 The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
 
-* `ingress_attributes` - The commit information used in the configuration
+| Resource Name        | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `ingress_attributes` | The commit information used in the configuration. |
+| `run`                | The run created by the configuration.             |

--- a/content/cloud-docs/api-docs/oauth-clients.mdx
+++ b/content/cloud-docs/api-docs/oauth-clients.mdx
@@ -409,3 +409,11 @@ curl \
   --request DELETE \
   https://app.terraform.io/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K
 ```
+
+### Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
+
+| Resource Name  | Description                              |
+| -------------- | ---------------------------------------- |
+| `oauth_tokens` | The OAuth tokens managed by this client  |

--- a/content/cloud-docs/api-docs/organizations.mdx
+++ b/content/cloud-docs/api-docs/organizations.mdx
@@ -800,12 +800,22 @@ curl \
 }
 ```
 
+## Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
+
+| Resource Name         | Description                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `entitlement_set`     | The entitlement set that determines which Terraform Cloud features the organization can use. |
+
 ## Relationships
 
-The following relationships may be present in various responses:
+The following relationships may be present in various responses.
 
-* `module-producers`: Other organizations that are configured to share modules with the organization. Terraform Enterprise v202103-1 or later only.
-* `oauth-tokens`: OAuth tokens associated with VCS configurations for the organization.
-* `authentication-token`: The API token for an organization.
-* `entitlement-set`: The entitlement set that determines which Terraform Cloud features the organization can use.
-* `subscription`: The current subscription for an organization.
+| Resource Name         | Description                                                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `module-producers`    | Other organizations that are configured to share modules with the organization. Terraform Enterprise v202103-1 or later only. |
+| `oauth-tokens`        | OAuth tokens associated with VCS configurations for the organization.                                                         |
+| `authentication-token`| The API token for an organization.                                                                                            |
+| `entitlement-set`     | The entitlement set that determines which Terraform Cloud features the organization can use.                                  |
+| `subscription`        | The current subscription for an organization.                                                                                 |

--- a/content/cloud-docs/api-docs/policies.mdx
+++ b/content/cloud-docs/api-docs/policies.mdx
@@ -438,4 +438,6 @@ curl \
 
 The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
 
-* `policy-sets` - Policy sets that any returned policies are members of.
+| Resource Name | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| `policy_sets` | Policy sets that any returned policies are members of. |

--- a/content/cloud-docs/api-docs/policy-checks.mdx
+++ b/content/cloud-docs/api-docs/policy-checks.mdx
@@ -241,3 +241,12 @@ curl \
   }
 }
 ```
+
+### Available Related Resources
+
+The GET endpoints above can optionally return related resources, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
+
+| Resource Name      | Description                            |
+| ------------------ | -------------------------------------- |
+| `run`              | The run this policy check belongs to.  |
+| `run.workspace`    | The associated workspace of the run.   |

--- a/content/cloud-docs/api-docs/policy-sets.mdx
+++ b/content/cloud-docs/api-docs/policy-sets.mdx
@@ -934,16 +934,37 @@ curl \
 
 The `upload` link URL in the above response is valid for one hour after the `created_at` timestamp of the policy set version. Make a `PUT` request to this URL directly, sending the policy set contents in `tar.gz` format as the request body. Once uploaded successfully, you can request the [Show Policy Set Version](#show-a-policy-set-version) endpoint again to verify that the status has changed from `pending` to `ready`.
 
-## Relationships
+## Available Related Resources
+
+The GET endpoints above can optionally return related resources for policy sets, if requested with [the `include` query parameter](/cloud-docs/api-docs/#inclusion-of-related-resources). The following resource types are available:
+
+| Resource Name     | Description              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `current_version` | The most recent **successful** policy set version.                                                                                                                                             |
+| `newest_version`  | The most recently created policy set version, regardless of status. Note that this relationship may include an errored and unusable version, and is intended to allow checking for VCS errors. |
+| `policies`        | Individually managed policies which are associated with the policy set.                                                                                                                        |
+| `workspaces`      | The workspaces to which the policy set applies.                                                                                                                                                |
+
+The following resource types may be included for policy set versions:
+
+| Resource Name | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `policy_set`  | The policy set associated with the specified policy set version. |
+
+## Relationships 
 
 The following relationships may be present in various responses for policy sets:
 
-* `current-version`: The most recent **successful** policy set version.
-* `newest-version`: The most recently created policy set version, regardless of status. Note that this relationship may include an errored and unusable version, and is intended to allow checking for VCS errors.
-* `organization`: The organization associated with the specified policy set.
-* `policies`: Individually managed policies which are associated with the policy set.
-* `workspaces`: The workspaces to which the policy set applies.
+| Resource Name     | Description              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `current-version` | The most recent **successful** policy set version.                                                                                                                                             |
+| `newest-version`  | The most recently created policy set version, regardless of status. Note that this relationship may include an errored and unusable version, and is intended to allow checking for VCS errors. |
+| `organization`    | The organization associated with the specified policy set.                                                                                                                                     |
+| `policies`        | Individually managed policies which are associated with the policy set.                                                                                                                        |
+| `workspaces`      | The workspaces to which the policy set applies.                                                                                                                                                |
 
 The following relationships may be present in various responses for policy set versions:
 
-* `policy-set`: The policy set associated with the specified policy set version.
+| Resource Name | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `policy-set`  | The policy set associated with the specified policy set version. |


### PR DESCRIPTION
## Description
This PR does two things:
* Add missing `include` relations for several resources. These relations are defined in a `Available Related Resources` section at the bottom of the page.
* Some relations were listed in bullet point format (see [Organizations](https://www.terraform.io/cloud-docs/api-docs/organizations#relationships)) and have now been moved to table format. 

## Notes for Reviewer
There is some slight discrepancy between `Available Related Resources` sections, where for some the description mentions the relations are available for all GET endpoints and others are more ambiguous, mentioning they may be available in several responses. Which convention should we follow? 