### PR TITLE
Add detail to the 'Queue Plans permission' for adding comments

### DIFF
--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -69,7 +69,7 @@ The following workspace permissions can be granted to teams on a per-workspace b
 
 - **Runs:**
   - **Read runs:** — Allows users to view information about remote Terraform runs, including the run history, the status of runs, the log output of each stage of a run (plan, apply, cost estimation, policy check), and configuration versions associated with a run.
-  - **Queue plans:** — _Implies permission to read runs._ Allows users to queue Terraform plans in a workspace, including both speculative plans and normal plans. Normal plans must be approved by a user with permission to apply runs.
+  - **Queue plans:** — _Implies permission to read runs._ Allows users to queue Terraform plans in a workspace, including both speculative plans and normal plans. Normal plans must be approved by a user with permission to apply runs. This also allows users to comment on runs.
   - **Apply runs:** — _Implies permission to queue plans._ Allows users to approve and apply Terraform plans, causing changes to real infrastructure.
 - **Lock and unlock workspace:** — Allows users to manually lock the workspace to temporarily prevent runs. When a workspace's execution mode is set to "local", this permission is required for performing local CLI runs using this workspace's state.
 - **Download Sentinel mocks:** — Allows users to download data from runs in the workspace in a format that can be used for developing Sentinel policies. This run data is very detailed, and often contains unredacted sensitive information.


### PR DESCRIPTION
A minor change to the **General Workspace Permissions** documentation describing what level access a user must be before they can add comments to a Run.