### PR TITLE
fix: POST requires singular form

### DIFF
--- a/content/cloud-docs/api-docs/notification-configurations.mdx
+++ b/content/cloud-docs/api-docs/notification-configurations.mdx
@@ -185,7 +185,7 @@ If `enabled` is set to `true`, a verification request will be sent before saving
 ```json
 {
   "data": {
-    "type": "notification-configurations",
+    "type": "notification-configuration",
     "attributes": {
       "destination-type": "generic",
       "enabled": true,


### PR DESCRIPTION
Hi 👋 We noticed that the `type` seems to be `notification-configuration` instead of `notification-configurations`. The docs also mention the singular form right above this sample.
Else we'd get an HTTP 400 error when trying to post a new notification configuration.

It seems a bit inconsistent across other calls (we've encountered both `notification-configuration` and `notification-configurations` in the `type` field). But I haven't checked whether that matches the docs.