### PR TITLE
Added the Comments API docs

### DIFF
--- a/content/cloud-docs/api-docs/comments.mdx
+++ b/content/cloud-docs/api-docs/comments.mdx
@@ -38,8 +38,7 @@ page_title: Comments - API Docs - Terraform Cloud and Terraform Enterprise
 
 # Comments API
 
-A Comment represents a Terraform Enterprise comment. 
-
+Comments allow users to leave feedback or record decisions about a run. 
 
 ## List Comments for a Run
 

--- a/content/cloud-docs/api-docs/comments.mdx
+++ b/content/cloud-docs/api-docs/comments.mdx
@@ -1,0 +1,224 @@
+---
+page_title: Comments - API Docs - Terraform Cloud and Terraform Enterprise
+---
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+
+[307]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
+
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+
+[JSON API document]: /cloud-docs/api-docs#json-api-documents
+
+[JSON API error object]: https://jsonapi.org/format/#error-objects
+
+# Comments API
+
+A Comment represents a Terraform Enterprise comment. 
+
+
+## List Comments for a Run
+
+`GET /runs/:id/comments`
+
+| Parameter | Description        |
+| --------- | ------------------ |
+| `id`      | The ID of the run. |
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/runs/run-KTuq99JSzgmDSvYj/comments
+```
+
+### Sample Reponse
+
+```json
+{
+  "data": [
+    {
+      "id": "wsc-JdFX3u8o114F4CWf",
+      "type": "comments",
+      "attributes": {
+        "body": "A comment body"
+      },
+      "relationships": {
+        "run-event": {
+          "data": {
+            "id": "re-fo1YXZ8W5bp5GBKM",
+            "type": "run-events"
+          },
+          "links": {
+            "related": "/api/v2/run-events/re-fo1YXZ8W5bp5GBKM"
+          }
+        }
+      },
+      "links": {
+        "self": "/api/v2/comments/wsc-JdFX3u8o114F4CWf"
+      }
+    },
+    {
+      "id": "wsc-QdhSPFTNoCTpfafp",
+      "type": "comments",
+      "attributes": {
+        "body": "Another comment body"
+      },
+      "relationships": {
+        "run-event": {
+          "data": {
+            "id": "re-fo1YXZ8W5bp5GBKM",
+            "type": "run-events"
+          },
+          "links": {
+            "related": "/api/v2/run-events/re-fo1YXZ8W5bp5GBKM"
+          }
+        }
+      },
+      "links": {
+        "self": "/api/v2/comments/wsc-QdhSPFTNoCTpfafp"
+      }
+    }
+  ]
+}
+```
+
+## Show a Comment
+
+`GET /comments/:id`
+
+| Parameter | Description            |
+| --------- | ---------------------- |
+| `id`      | The ID of the comment. |
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/comments/wsc-gTFq83JSzjmAvYj
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "wsc-gTFq83JSzjmAvYj",
+    "type": "comments",
+    "attributes": {
+      "body": "Another comment"
+    },
+    "relationships": {
+      "run-event": {
+        "data": {
+            "id": "re-8RB5ZaFrDanG2hGY",
+            "type": "run-events"
+        },
+        "links": {
+            "related": "/api/v2/run-events/re-8RB5ZaFrDanG2hGY"
+        }
+      }
+    },
+    "links": {
+      "self": "/api/v2/comments/wsc-gTFq83JSzjmAvYj"
+    }
+  }
+}
+```
+
+## Create Comment
+
+`POST /runs/:id/comments`
+
+| Parameter | Description        |
+| --------- | ------------------ |
+| `id`      | The ID of the run. |
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as the request payload.
+
+| Key Path                 | Type   | Default | Description
+| ------------------------ | ------ | ------- | ----------------
+| `data.type`              | string |         | Must be `"comments"`.
+| `data.attributes.body`   | string |         | The body of the comment.
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "attributes": {
+      "body": "A comment about the run",
+    },
+    "type": "comments"
+  }
+}
+```
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/runs/run-KTuq99JSzgmDSvYj/comments
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "wsc-oRiShushpgLU4JD2",
+    "type": "comments",
+    "attributes": {
+      "body": "A comment about the run"
+    },
+    "relationships": {
+      "run-event": {
+          "data": {
+            "id": "re-E3xsBX11F1fbm2zV",
+            "type": "run-events"
+          },
+          "links": {
+            "related": "/api/v2/run-events/re-E3xsBX11F1fbm2zV"
+          }
+      }
+    },
+    "links": {
+      "self": "/api/v2/comments/wsc-oRiShushpgLU4JD2"
+    }
+  }
+}
+```

--- a/data/cloud-docs-nav-data.json
+++ b/data/cloud-docs-nav-data.json
@@ -318,7 +318,10 @@
       { "title": "Agent Tokens", "path": "api-docs/agent-tokens" },
       { "title": "Applies", "path": "api-docs/applies" },
       { "title": "Audit Trails", "path": "api-docs/audit-trails" },
-
+      {
+        "title": "Comments",
+        "path": "api-docs/comments"
+      },
       {
         "title": "Configuration Versions",
         "path": "api-docs/configuration-versions"


### PR DESCRIPTION
Adding documentations for the comments API. Support for the comments API will be added to [go-tfe](https://github.com/hashicorp/go-tfe/pull/355) and thus go-tfe's docs need to be able to reference a API documentation page that exists. 