### PR TITLE
Add API documentation for the Run Task Integration API

### DIFF
--- a/content/cloud-docs/api-docs/run-tasks-integration.mdx
+++ b/content/cloud-docs/api-docs/run-tasks-integration.mdx
@@ -10,23 +10,23 @@ page_title: Run Tasks Integration - API Docs - Terraform Cloud and Terraform Ent
 
 # Run Tasks Integration API
 
--> Note: Run Tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
+-> Note: Run tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
 
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle.
 This page lists the API endpoints used to trigger a run task and the expected response from the integration.
 
-Refer to [Run Tasks](/cloud-docs/api-docs/run-tasks) for the API endpoints to create and manage Run Tasks within Terraform Cloud.
+Refer to [run tasks](/cloud-docs/api-docs/run-tasks) for the API endpoints to create and manage run tasks within Terraform Cloud.
 
 ## Run Task Request
 
-When a run reaches the appropriate phase and a run task is triggered, Terraform Cloud will send a request to the Run Task's URL.
+When a run reaches the appropriate phase and a run task is triggered, Terraform Cloud will send a request to the run task's URL.
 The service receiving the run task request should respond with `200 OK`, or Terraform Cloud will retry to trigger the run task.
 
 `POST :url`
 
 | Parameter | Description                                             |
 |-----------|---------------------------------------------------------|
-| `:url`    | The URL configured in the Run Task to send requests to. |
+| `:url`    | The URL configured in the run task to send requests to. |
 
 | Status  | Response | Reason                            |
 |---------|----------|-----------------------------------|
@@ -106,7 +106,7 @@ Once a run task request has been fulfilled by the external integration, the inte
 
 |    Parameter    |                           Description                            |
 | --------------- | ---------------------------------------------------------------- |
-| `:callback_url` | The `task_result_callback_url` specified in the Run Task request. Typically `/task-results/:guid/callback`. |
+| `:callback_url` | The `task_result_callback_url` specified in the run task request. Typically `/task-results/:guid/callback`. |
 
 | Status  |         Response          |                  Reason                  |
 | ------- | ------------------------- | ---------------------------------------- |

--- a/content/cloud-docs/api-docs/run-tasks-integration.mdx
+++ b/content/cloud-docs/api-docs/run-tasks-integration.mdx
@@ -1,0 +1,147 @@
+---
+page_title: Run Tasks Integration - API Docs - Terraform Cloud and Terraform Enterprise
+---
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+
+[JSON API error object]: https://jsonapi.org/format/#error-objects
+
+# Run Tasks Integration API
+
+-> Note: As of September 2021, Run Tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
+
+[Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle.
+Run tasks are reusable configurations that you can attach to any workspace in an organization.
+This page lists the API endpoints which are used when triggering a Run Task and the expected response from the integration.
+
+You can find more information about managing Run Tasks within Terraform Cloud in [Run Tasks Management](/cloud-docs/api-docs/run-tasks) documentation.
+
+## Run Task Request
+
+When a run reaches the appropriate phase and a run task is triggered, Terraform Cloud will send a request to the Run Task's URL.
+The service receiving the run task request should respond with `200 OK`, or Terraform Cloud will retry to trigger the run task.
+
+`POST :url`
+
+| Parameter | Description                                             |
+|-----------|---------------------------------------------------------|
+| `:url`    | The URL configured in the Run Task to send requests to. |
+
+| Status  | Response | Reason                            |
+|---------|----------|-----------------------------------|
+| [200][] | Nothing  | Successfully submitted a run task |
+
+### Request Body
+
+The POST request submits a JSON object with the following properties as a request payload.
+
+|            Key path             |  Type   |          Values          |                                                 Description                                                 |
+| ------------------------------- | ------- | ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `payload_version`               | integer | `1`                      | Schema version of the payload. Only `1` is supported.                                                       |
+| `access_token`                  | string  |                          | Bearer token to use when calling back to Terraform Cloud.                                                   |
+| `stage`                         | string  | `post-plan`, `pre-apply` | The [stage](/cloud-docs/run/states) the task was triggered at.                                              |
+| `is_speculative`                | bool    |                          | Whether the task is part of a [speculative run](/cloud-docs/run#speculative-plans).                         |
+| `task_result_id`                | string  |                          | Id of task result within Terraform Cloud.                                                                   |
+| `task_result_enforcement_level` | string  | `mandatory`, `advisory`  | Enforcement level for this task.                                                                            |
+| `task_result_callback_url`      | string  |                          | URL that should called back with the result of this task.                                                   |
+| `run_id`                        | string  |                          | Id of the run this task is part of.                                                                         |
+| `run_app_url`                   | string  |                          | URL within Terraform Cloud to the run.                                                                      |
+| `run_message`                   | string  |                          | Message that was associated with the run.                                                                   |
+| `run_created_at`                | string  |                          | When the run was started.                                                                                   |
+| `run_created_by`                | string  |                          | Who created the run.                                                                                        |
+| `workspace_id`                  | string  |                          | Id of the workspace the task is associated with.                                                            |
+| `workspace_name`                | string  |                          | Name of the workspace.                                                                                      |
+| `workspace_app_url`             | string  |                          | URL within Terraform Cloud to the workspace.                                                                |
+| `organization_name`             | string  |                          | Name of the organization the task is configured within.                                                     |
+| `plan_json_api_url`             | string  |                          | URL to retrieve the JSON Terraform Plan for this run.                                                       |
+| `vcs_repo_url`                  | string  |                          | URL to the workspace's VCS repository. `null` if the workspace does not have a VCS repository.              |
+| `vcs_branch`                    | string  |                          | Repository branch that the workspace executes from. `null` if the workspace does not have a VCS repository. |
+| `vcs_pull_request_url`          | string  |                          | URL to the Pull Request/Merge Request that triggered this run. `null` if the run was not triggered.         |
+| `vcs_commit_url`                | string  |                          | URL to the commit that triggered this run. `null` if the workspace does not a VCS repository.               |
+
+### Sample Payload
+
+```json
+{
+  "payload_version": 1,
+  "access_token": "4QEuyyxug1f2rw.atlasv1.iDyxqhXGVZ0ykes53YdQyHyYtFOrdAWNBxcVUgWvzb64NFHjcquu8gJMEdUwoSLRu4Q",
+  "stage": "post_plan",
+  "is_speculative": false,
+  "task_result_id": "taskrs-2nH5dncYoXaMVQmJ",
+  "task_result_enforcement_level": "mandatory",
+  "task_result_callback_url": "https://app.terraform.io/api/v2/task-results/5ea8d46c-2ceb-42cd-83f2-82e54697bddd/callback",
+  "run_app_url": "https://app.terraform.io/app/hashicorp/my-workspace/runs/run-i3Df5to9ELvibKpQ",
+  "run_id": "run-i3Df5to9ELvibKpQ",
+  "run_message": "Triggered via UI",
+  "run_created_at": "2021-09-02T14:47:13.036Z",
+  "run_created_by": "username",
+  "workspace_id": "ws-ck4G5bb1Yei5szRh",
+  "workspace_name": "tfr_github_0",
+  "workspace_app_url": "https://app.terraform.io/app/hashicorp/my-workspace",
+  "organization_name": "hashicorp",
+  "plan_json_api_url": "https://app.terraform.io/api/v2/plans/plan-6AFmRJW1PFJ7qbAh/json-output",
+  "vcs_repo_url": "https://github.com/hashicorp/terraform-random",
+  "vcs_branch": "main",
+  "vcs_pull_request_url": null,
+  "vcs_commit_url": "https://github.com/hashicorp/terraform-random/commit/7d8fb2a2d601edebdb7a59ad2088a96673637d22"
+}
+```
+
+### Request Headers
+
+The POST request submits the following properties as the request headers.
+
+|          Name          |                   Value                    |                                                                                                                    Description                                                                                                                    |
+| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Content-Type`         | `application/json`                         | Specifies the type of data in the request body                                                                                                                                                                                                    |
+| `User-Agent`           | `TFC/1.0 (+https://app.terraform.io; TFC)` | Identifies the request is coming from Terraform Cloud                                                                                                                                                                                             |
+| `X-TFC-Task-Signature` | string                                     | If the Run Task is configured with a [HMAC Key](cloud-docs/integrations/run-tasks#securing-your-run-task), this header will contain the signed SHA512 sum of the request payload using the configured HMAC key. Otherwise this is an empty string |
+
+## Run Task Callback
+
+Once a Run Task request has been fulfilled by the external integration it must call back into Terraform Cloud with the result. Terraform expects this callback within 10 minutes, or the request will be considered to have errored.
+
+`PATCH :callback_url`
+
+|    Parameter    |                           Description                            |
+| --------------- | ---------------------------------------------------------------- |
+| `:callback_url` | The `task_result_callback_url` specified in the Run Task request. Typically `/task-results/:guid/callback`. |
+
+| Status  |         Response          |                  Reason                  |
+| ------- | ------------------------- | ---------------------------------------- |
+| [200][] | Nothing                   | Successfully submitted a run task result |
+| [401][] | [JSON API error object][] | Not authorized to perform action         |
+
+### Request Body
+
+The PATCH request submits a JSON object with the following properties as a request payload.
+
+|         Key path          |  Type  |                                           Description                                           |
+| ------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| `data.type`               | string | Must be `"task-results"`.                                                                       |
+| `data.attributes.status`  | string | The current status of the task. Only `passed` or `failed` indicate that the task has completed. |
+| `data.attributes.message` | string | (Optional) A short message describing the status of the task.                                   |
+| `data.attributes.url`     | string | (Optional) A URL where more information can be obtained about the task.                         |
+
+Status values other than `passed` or `failed` are considered a partial update and will not complete the task within Terraform Cloud.
+This could be used by an External Service to send a `started` status with a URL so that a user could monitor the task at the External Service's website.
+The External Service can send another callback when the task completes.
+
+```json
+{
+  "data": {
+    "type": "task-results",
+    "attributes": {
+      "status": "passed",
+      "message": "4 passed, 0 skipped, 0 failed",
+      "url": "https://external.service.dev/terraform-plan-checker/run-i3Df5to9ELvibKpQ"
+    }
+  }
+}
+```
+
+### Request Headers
+
+The PATCH request must use the token supplied in the originating request (`access_token`) for [authentication](/cloud-docs/api-docs#authentication).

--- a/content/cloud-docs/api-docs/run-tasks-integration.mdx
+++ b/content/cloud-docs/api-docs/run-tasks-integration.mdx
@@ -10,13 +10,12 @@ page_title: Run Tasks Integration - API Docs - Terraform Cloud and Terraform Ent
 
 # Run Tasks Integration API
 
--> Note: As of September 2021, Run Tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
+-> Note: Run Tasks are available only as a beta feature, are subject to change, and not all customers will see this functionality in their Terraform Cloud organization.
 
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle.
-Run tasks are reusable configurations that you can attach to any workspace in an organization.
-This page lists the API endpoints which are used when triggering a Run Task and the expected response from the integration.
+This page lists the API endpoints used to trigger a run task and the expected response from the integration.
 
-You can find more information about managing Run Tasks within Terraform Cloud in [Run Tasks Management](/cloud-docs/api-docs/run-tasks) documentation.
+Refer to [Run Tasks](/cloud-docs/api-docs/run-tasks) for the API endpoints to create and manage Run Tasks within Terraform Cloud.
 
 ## Run Task Request
 
@@ -43,7 +42,7 @@ The POST request submits a JSON object with the following properties as a reques
 | `access_token`                  | string  |                          | Bearer token to use when calling back to Terraform Cloud.                                                   |
 | `stage`                         | string  | `post-plan`, `pre-apply` | The [stage](/cloud-docs/run/states) the task was triggered at.                                              |
 | `is_speculative`                | bool    |                          | Whether the task is part of a [speculative run](/cloud-docs/run#speculative-plans).                         |
-| `task_result_id`                | string  |                          | Id of task result within Terraform Cloud.                                                                   |
+| `task_result_id`                | string  |                          | ID of task result within Terraform Cloud.                                                                   |
 | `task_result_enforcement_level` | string  | `mandatory`, `advisory`  | Enforcement level for this task.                                                                            |
 | `task_result_callback_url`      | string  |                          | URL that should called back with the result of this task.                                                   |
 | `run_id`                        | string  |                          | Id of the run this task is part of.                                                                         |
@@ -55,11 +54,11 @@ The POST request submits a JSON object with the following properties as a reques
 | `workspace_name`                | string  |                          | Name of the workspace.                                                                                      |
 | `workspace_app_url`             | string  |                          | URL within Terraform Cloud to the workspace.                                                                |
 | `organization_name`             | string  |                          | Name of the organization the task is configured within.                                                     |
-| `plan_json_api_url`             | string  |                          | URL to retrieve the JSON Terraform Plan for this run.                                                       |
-| `vcs_repo_url`                  | string  |                          | URL to the workspace's VCS repository. `null` if the workspace does not have a VCS repository.              |
-| `vcs_branch`                    | string  |                          | Repository branch that the workspace executes from. `null` if the workspace does not have a VCS repository. |
-| `vcs_pull_request_url`          | string  |                          | URL to the Pull Request/Merge Request that triggered this run. `null` if the run was not triggered.         |
-| `vcs_commit_url`                | string  |                          | URL to the commit that triggered this run. `null` if the workspace does not a VCS repository.               |
+| `plan_json_api_url`             | string  |                          | URL to retrieve the JSON Terraform plan for this run.                                                       |
+| `vcs_repo_url`                  | string  |                          | URL to the workspace's VCS repository. This is `null` if the workspace does not have a VCS repository.              |
+| `vcs_branch`                    | string  |                          | Repository branch that the workspace executes from. This is `null` if the workspace does not have a VCS repository. |
+| `vcs_pull_request_url`          | string  |                          | URL to the Pull Request/Merge Request that triggered this run. This is `null` if the run was not triggered.         |
+| `vcs_commit_url`                | string  |                          | URL to the commit that triggered this run. This is `null` if the workspace does not a VCS repository.               |
 
 ### Sample Payload
 
@@ -97,11 +96,11 @@ The POST request submits the following properties as the request headers.
 | ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Content-Type`         | `application/json`                         | Specifies the type of data in the request body                                                                                                                                                                                                    |
 | `User-Agent`           | `TFC/1.0 (+https://app.terraform.io; TFC)` | Identifies the request is coming from Terraform Cloud                                                                                                                                                                                             |
-| `X-TFC-Task-Signature` | string                                     | If the Run Task is configured with a [HMAC Key](cloud-docs/integrations/run-tasks#securing-your-run-task), this header will contain the signed SHA512 sum of the request payload using the configured HMAC key. Otherwise this is an empty string |
+| `X-TFC-Task-Signature` | string                                     | If the run task is configured with an [HMAC Key](cloud-docs/integrations/run-tasks#securing-your-run-task), this header contains the signed SHA512 sum of the request payload using the configured HMAC key. Otherwise, this is an empty string. |
 
 ## Run Task Callback
 
-Once a Run Task request has been fulfilled by the external integration it must call back into Terraform Cloud with the result. Terraform expects this callback within 10 minutes, or the request will be considered to have errored.
+Once a run task request has been fulfilled by the external integration, the integration must call back into Terraform Cloud with the result. Terraform expects this callback within 10 minutes, or the request will be considered to have errored.
 
 `PATCH :callback_url`
 
@@ -123,11 +122,9 @@ The PATCH request submits a JSON object with the following properties as a reque
 | `data.type`               | string | Must be `"task-results"`.                                                                       |
 | `data.attributes.status`  | string | The current status of the task. Only `passed` or `failed` indicate that the task has completed. |
 | `data.attributes.message` | string | (Optional) A short message describing the status of the task.                                   |
-| `data.attributes.url`     | string | (Optional) A URL where more information can be obtained about the task.                         |
+| `data.attributes.url`     | string | (Optional) A URL where users can obtain more information about the task.                         |
 
-Status values other than `passed` or `failed` are considered a partial update and will not complete the task within Terraform Cloud.
-This could be used by an External Service to send a `started` status with a URL so that a user could monitor the task at the External Service's website.
-The External Service can send another callback when the task completes.
+Status values other than `passed` or `failed` are considered a partial update and will not complete the task within Terraform Cloud. An External Service could use this to send a `started` status with a URL so that a user could monitor the task at the External Service's website. The External Service can send another callback when the task completes.
 
 ```json
 {

--- a/content/cloud-docs/api-docs/run-tasks.mdx
+++ b/content/cloud-docs/api-docs/run-tasks.mdx
@@ -40,7 +40,7 @@ page_title: Run Tasks - API Docs - Terraform Cloud and Terraform Enterprise
 
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization. This page lists the API endpoints for run tasks in an organization and explains how to attach run tasks to workspaces.
 
-Refer to [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) for the API endpoints related triggering run tasks and the expected integration response.
+Refer to [run tasks Integration](/cloud-docs/api-docs/run-tasks-integration) for the API endpoints related triggering run tasks and the expected integration response.
 
 ## Required Permissions
 

--- a/content/cloud-docs/api-docs/run-tasks.mdx
+++ b/content/cloud-docs/api-docs/run-tasks.mdx
@@ -40,6 +40,8 @@ page_title: Run Tasks - API Docs - Terraform Cloud and Terraform Enterprise
 
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization. This page lists the API endpoints for run tasks in an organization and explains how to attach run tasks to workspaces.
 
+You can find more information about the integration API in the [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) documentation.
+
 ## Required Permissions
 
 You need organization owner [permissions](/cloud-docs/users-teams-organizations/permissions) to interact with run tasks and workspace administrator permissions to connect run tasks to workspaces.

--- a/content/cloud-docs/api-docs/run-tasks.mdx
+++ b/content/cloud-docs/api-docs/run-tasks.mdx
@@ -708,7 +708,7 @@ curl \
 }
 ```
 
-## Delete Workspace Task
+## Delete Workspace Run Task
 
 `DELETE /workspaces/:workspace_id/tasks/:id`
 

--- a/content/cloud-docs/api-docs/run-tasks.mdx
+++ b/content/cloud-docs/api-docs/run-tasks.mdx
@@ -40,7 +40,7 @@ page_title: Run Tasks - API Docs - Terraform Cloud and Terraform Enterprise
 
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization. This page lists the API endpoints for run tasks in an organization and explains how to attach run tasks to workspaces.
 
-You can find more information about the integration API in the [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) documentation.
+Refer to [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) for the API endpoints related triggering run tasks and the expected integration response.
 
 ## Required Permissions
 

--- a/content/cloud-docs/integrations/run-tasks/index.mdx
+++ b/content/cloud-docs/integrations/run-tasks/index.mdx
@@ -21,7 +21,7 @@ This feature relies heavily on the proper parsing of [plan JSON output](/interna
 
 When a run reaches the appropriate phase and a run task is triggered, the supplied URL will receive details about the run in a payload similar to the one below. The server receiving the run task should respond `200 OK`, or Terraform will retry to trigger the run task.
 
-See the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) for the exact payload specification.
+Refer to the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) for the exact payload specification.
 
 ```json
 {
@@ -51,7 +51,7 @@ See the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) f
 
 Once your server receives this payload, Terraform Cloud expects you to callback to the supplied `task_result_callback_url` using the `access_token` as an [Authentication Header](/cloud-docs/api-docs/#authentication) with a [jsonapi](/cloud-docs/api-docs/#json-api-formatting) payload of the form:
 
-See the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) for the exact callback specification.
+Refer to the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) for the exact callback specification.
 
 ```json
 {

--- a/content/cloud-docs/integrations/run-tasks/index.mdx
+++ b/content/cloud-docs/integrations/run-tasks/index.mdx
@@ -21,6 +21,8 @@ This feature relies heavily on the proper parsing of [plan JSON output](/interna
 
 When a run reaches the appropriate phase and a run task is triggered, the supplied URL will receive details about the run in a payload similar to the one below. The server receiving the run task should respond `200 OK`, or Terraform will retry to trigger the run task.
 
+See the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) for the exact payload specification.
+
 ```json
 {
   "payload_version": 1,
@@ -48,6 +50,8 @@ When a run reaches the appropriate phase and a run task is triggered, the suppli
 ```
 
 Once your server receives this payload, Terraform Cloud expects you to callback to the supplied `task_result_callback_url` using the `access_token` as an [Authentication Header](/cloud-docs/api-docs/#authentication) with a [jsonapi](/cloud-docs/api-docs/#json-api-formatting) payload of the form:
+
+See the [Run Task Integration API](/cloud-docs/api-docs/run-tasks-integration) for the exact callback specification.
 
 ```json
 {

--- a/data/cloud-docs-nav-data.json
+++ b/data/cloud-docs-nav-data.json
@@ -378,6 +378,7 @@
       },
       { "title": "Runs", "path": "api-docs/run" },
       { "title": "Run Tasks", "path": "api-docs/run-tasks" },
+      { "title": "Run Tasks Integration", "path": "api-docs/run-tasks-integration" },
       { "title": "Run Triggers", "path": "api-docs/run-triggers" },
       { "title": "SSH Keys", "path": "api-docs/ssh-keys" },
       {


### PR DESCRIPTION
The documentation was lacking the formal specification for the Run Tasks Integration API flow