### PR TITLE
Adds registry module downloads summary API docs

### DIFF
--- a/content/registry/api-docs.mdx
+++ b/content/registry/api-docs.mdx
@@ -697,7 +697,7 @@ Content-Type: text/html; charset=utf-8
 
 ## Get a Module Downloads Metrics Summary
 
--> **Note:** The download metrics summary APIs are `v2`and use its API `<base_url>` of
+-> **Note:** The download metrics summary APIs are `v2`and use the API `<base_url>` of
 `https://registry.terraform.io/v2/modules/`
 
 This endpoint returns a module's download metrics summary.

--- a/content/registry/api-docs.mdx
+++ b/content/registry/api-docs.mdx
@@ -695,6 +695,50 @@ Content-Type: text/html; charset=utf-8
 <a href="/v1/modules/hashicorp/consul/aws/0.0.1/download">Found</a>.
 ```
 
+## Get a Module Downloads Metrics Summary
+
+-> **Note:** The download metrics summary APIs are `v2`and use its API `<base_url>` of
+`https://registry.terraform.io/v2/modules/`
+
+This endpoint returns a module's download metrics summary.
+
+| Method | Path                                                      | Produces           |
+| ------ | --------------------------------------------------------- | ------------------ |
+| `GET`  | `<base_url>/:namespace/:name/:provider/downloads/summary` | `application/json` |
+
+### Parameters
+
+- `namespace` `(string: <required>)` - The user the module is owned by.
+  This is required and is specified as part of the URL path.
+
+- `name` `(string: <required>)` - The name of the module.
+  This is required and is specified as part of the URL path.
+
+- `provider` `(string: <required>)` - The name of the provider.
+  This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```shell
+$ curl \
+    https://registry.terraform.io/v2/modules/hashicorp/consul/aws/downloads/summary
+```
+
+### Sample Response
+
+```json
+"data": {
+    "type": "module-downloads-summary",
+    "id": "5792",
+    "attributes": {
+      "week": 645,
+      "month": 2474,
+      "year": 8621,
+      "total": 90237
+    }
+  }
+```
+
 ## HTTP Status Codes
 
 The API follows regular HTTP status semantics. To make implementing a complete


### PR DESCRIPTION
This PR adds documentation for the registry's new downloads summary endpoint. It is currently only added for the `modules` API. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201985254052954
  - https://app.asana.com/0/0/1201985254052950