### PR TITLE
Push v202203-1 release date back by two days

### DIFF
--- a/content/enterprise/releases/index.mdx
+++ b/content/enterprise/releases/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Terraform Enterprise Releases
 
-~> The next release `v202203-1` is scheduled for March 22, 2022.
+~> The next release `v202203-1` is scheduled for March 24, 2022.
 
 We release a new Terraform Enterprise version each month. The table below lists releases from the current calendar year as well as the last required release. You can find previous releases in the sidebar.
 


### PR DESCRIPTION
The v202203-1 release date has been slightly delayed in order to include a fix for [CVE-2022-0778](https://nvd.nist.gov/vuln/detail/CVE-2022-0778).