### PR TITLE
update private registry provider publishing docs

### DIFF
--- a/content/cloud-docs/registry/publish-providers.mdx
+++ b/content/cloud-docs/registry/publish-providers.mdx
@@ -41,7 +41,7 @@ To publish a new provider through the Terraform Cloud API:
     ```json
     "key-id": "32966F3FB5AC1129"
     ```
-1. If the provider does not yet exist in the private registry use the [Create a Provider endpoint](/https://www.terraform.io/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create it. If you are publishing a new version for an already existing provider skip this step.
+1. Use the [Create a Provider endpoint](/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in Terraform Cloud. 
 
 1. Use the [Create a Provider Version endpoint](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version with the `key-id` from the previous step. The response includes URL links that you will use to upload the `SHA256SUMS` and `SHA256.sig` files.
 

--- a/content/cloud-docs/registry/publish-providers.mdx
+++ b/content/cloud-docs/registry/publish-providers.mdx
@@ -41,6 +41,8 @@ To publish a new provider through the Terraform Cloud API:
     ```json
     "key-id": "32966F3FB5AC1129"
     ```
+1. If the provider does not yet exist in the private registry use the [Create a Provider endpoint](/https://www.terraform.io/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create it. If you are publishing a new version for an already existing provider skip this step.
+
 1. Use the [Create a Provider Version endpoint](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version with the `key-id` from the previous step. The response includes URL links that you will use to upload the `SHA256SUMS` and `SHA256.sig` files.
 
     ```json


### PR DESCRIPTION
When a user is trying to publish a new provider to the TFC private registry they need to create the provider before creating a version for it (step 2).

This step is missing from the [Publishing Private Providers docs](https://www.terraform.io/cloud-docs/registry/publish-providers#publishing-a-provider-and-creating-a-version).