### PR TITLE
Single Sign-on: Microsoft Azure AD

### DIFF
--- a/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -63,10 +63,11 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
 1. In the **Add Assignment** dialog, click the **Assign** button.
 
 ## Configuration (Terraform Cloud)
-1. Edit settings of your Azure SSO configuration
-   1. Go to **Public Certificate** 
-   1. Paste the contents of the SAML Signing Certificate downloaded from Microsoft Azure AD
-   1. Save Settings  
+To edit your Azure SSO configuration settings:
+
+   1. Go to **Public Certificate**. 
+   1. Paste the contents of the SAML Signing Certificate you downloaded from Microsoft Azure AD.
+   1. Save Settings.  
 1. [Verify](/cloud-docs/users-teams-organizations/single-sign-on/testing) your settings and click "Enable".
 
 1. Your Azure SSO configuration is complete and ready to [use](/cloud-docs/users-teams-organizations/single-sign-on#signing-in-with-sso).

--- a/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -55,7 +55,7 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
    1. In the **Reply URL** text box, paste the **Reply URL**.
    1. In the **Sign-on URL** text box, type the URL: `https://app.terraform.io/session`
    1. Select **Save**.
-1. On the **Single sign-on** page, download the `Certificate (Base64)` file from under SAML Signing Certificate
+1. On the **Single sign-on** page, download the `Certificate (Base64)` file from under **SAML Signing Certificate**.
 1. In the app's overview page, find the **Manage** section and select **Users and groups**.
 1. Select **Add user**, then select **Users and groups** in the **Add Assignment** dialog.
 1. In the **Users and groups** dialog, select your user from the Users list, then click the **Select** button at the bottom of the screen.

--- a/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -44,7 +44,7 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
 
 1. Save, and you should see a completed Terraform Cloud SAML configuration.
 
-1. Copy Entity ID and Assertion Consumer Service URL.
+1. Copy Entity ID and Reply URL.
 
 ## Configuration (Microsoft Azure AD)
 
@@ -52,7 +52,7 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
 1. On the **Select a single sign-on method** page, select **SAML**.
 1. On the **Set up single sign-on with SAML** page, click the edit/pen icon for **Basic SAML Configuration** to edit the settings.
    1. In the **Identifier** text box, paste the **Entity ID**.
-   1. In the **Reply URL** text box, paste the **Assertion Consumer Service URL**.
+   1. In the **Reply URL** text box, paste the **Reply URL**.
    1. In the **Sign-on URL** text box, type the URL: `https://app.terraform.io/session`
    1. Select **Save**.
 1. In the app's overview page, find the **Manage** section and select **Users and groups**.

--- a/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -55,6 +55,7 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
    1. In the **Reply URL** text box, paste the **Reply URL**.
    1. In the **Sign-on URL** text box, type the URL: `https://app.terraform.io/session`
    1. Select **Save**.
+1. On the **Single sign-on** page, download the `Certificate (Base64)` file from under SAML Signing Certificate
 1. In the app's overview page, find the **Manage** section and select **Users and groups**.
 1. Select **Add user**, then select **Users and groups** in the **Add Assignment** dialog.
 1. In the **Users and groups** dialog, select your user from the Users list, then click the **Select** button at the bottom of the screen.
@@ -62,7 +63,10 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
 1. In the **Add Assignment** dialog, click the **Assign** button.
 
 ## Configuration (Terraform Cloud)
-
+1. Edit settings of your Azure SSO configuration
+   1. Go to **Public Certificate** 
+   1. Paste the contents of the SAML Signing Certificate downloaded from Microsoft Azure AD
+   1. Save Settings  
 1. [Verify](/cloud-docs/users-teams-organizations/single-sign-on/testing) your settings and click "Enable".
 
 1. Your Azure SSO configuration is complete and ready to [use](/cloud-docs/users-teams-organizations/single-sign-on#signing-in-with-sso).

--- a/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/content/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -24,9 +24,6 @@ For more information on the listed features, visit the [Microsoft Azure AD SAML 
 1. Select **Terraform Cloud** from results panel and then add the app. Wait a few seconds while the app is added to your tenant.
 1. On the **Terraform Cloud** application integration page, find the **Manage** section and select **single sign-on**.
 1. On the **Select a single sign-on method** page, select **SAML**.
-1. In the **SAML Signing Certificate** section select **Add a certificate**.
-   1. Select **New Certificate**.
-   1. Select **Save**.
 1. In the SAML Signing Certificate section (you may need to refresh the page) copy the **App Federation Metadata Url**.
 
 ## Configuration (Terraform Cloud)


### PR DESCRIPTION
Procedure currently described doesn't work and has some naming mistakes

- The certificate in Azure AD Single sign-on won't be generated until after providing the Terraform Cloud information entered
- You manually need to download the certificate from Azure
- You then need to edit the SSO information in Terraform cloud to include this certificate

- Sometimes in the documentation Assertion Consumer Service URL is mentioned but this refers to the Reply URL

Someone need to check if the steps are correct and functioning more smoothly when you go over them