### PR TITLE
update 'protocols' attribute in the examples for creating private provider version

### DIFF
--- a/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
@@ -79,7 +79,7 @@ Properties without a default value are required.
 | `data.attributes.key-id`    | string |         | A valid gpg-key string.                                           |
 | `data.attributes.protocols` | array  |         | An array of Terraform provider API versions that this version supports. Must be one or all of the following values `["4.0","5.0","6.0"]`. |
 
-**Note:** Only Terraform 0.13 and later support third-party provider registries and that Terraform version requires provider API version 5.0 or later, so in practice it isn't useful to list major versions 4 or earlier in the `protocols` attribute.
+-> **Note:** Only Terraform 0.13 and later support third-party provider registries, and that Terraform version requires provider API version 5.0 or later. So you do not need to list major versions 4.0 or earlier in the `protocols` attribute.
 
 ### Sample Payload
 

--- a/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
@@ -88,7 +88,7 @@ Properties without a default value are required.
     "attributes": {
       "version": "3.1.1",
       "key-id": "32966F3FB5AC1129",
-      "protocols": ["4.0"]
+      "protocols": ["5.0"]
     }
   }
 }
@@ -117,7 +117,7 @@ curl \
       "created-at": "2022-02-11T19:16:59.876Z",
       "updated-at": "2022-02-11T19:16:59.876Z",
       "key-id": "32966F3FB5AC1129",
-      "protocols": ["4.0"],
+      "protocols": ["5.0"],
       "permissions": {
         "can-delete": true,
         "can-upload-asset": true
@@ -190,7 +190,7 @@ curl \
         "created-at": "2022-02-11T19:16:59.876Z",
         "updated-at": "2022-02-11T19:16:59.876Z",
         "key-id": "32966F3FB5AC1129",
-        "protocols": ["4.0"],
+        "protocols": ["5.0"],
         "permissions": {
           "can-delete": true,
           "can-upload-asset": true
@@ -303,7 +303,7 @@ curl \
       "created-at": "2022-02-11T19:16:59.876Z",
       "updated-at": "2022-02-11T19:16:59.876Z",
       "key-id": "32966F3FB5AC1129",
-      "protocols": ["4.0"],
+      "protocols": ["5.0"],
       "permissions": {
         "can-delete": true,
         "can-upload-asset": true

--- a/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
@@ -77,7 +77,9 @@ Properties without a default value are required.
 | `data.type`                 | string |         | Must be `"registry-provider-versions"`.                           |
 | `data.attributes.version`   | string |         | A valid semver version string.                                    |
 | `data.attributes.key-id`    | string |         | A valid gpg-key string.                                           |
-| `data.attributes.protocols` | array  |         | Must be one or all of the following values `["4.0","5.0","6.0"]`. |
+| `data.attributes.protocols` | array  |         | An array of Terraform provider API versions that this version supports. Must be one or all of the following values `["4.0","5.0","6.0"]`. |
+
+**Note:** Only Terraform 0.13 and later support third-party provider registries and that Terraform version requires provider API version 5.0 or later, so in practice it isn't useful to list major versions 4 or earlier in the `protocols` attribute.
 
 ### Sample Payload
 


### PR DESCRIPTION
I'd like to propose updating the value for the  'protocols' attribute in the examples for creating a private provider version. The current value - `["4.0"]` is valid but it will not work if used in practice. I tested this and also found that it is stated in the provider registry protocol [docs](https://www.terraform.io/internals/provider-registry-protocol#protocols).

> Only Terraform 0.13 and later support third-party provider registries and that Terraform version requires API version 5.0 or later, so in practice it isn't useful to list major versions 4 or earlier in a third-party provider registry.

I hope this will help avoid situations like:

* A user has a custom provider that they use locally and decide to publish it
* They are unclear about the 'protocols' attribute and so copy/paste the example from the docs
* They finish the provider publishing process successfully

When they attempt to use the published provider the Terraform CLI will return an error saying that "no suitable version of the provider are available" and it is not quite apparent why that is.