### PR TITLE
fix: use filterVersions from hashicorp/dev-portal#231

### DIFF
--- a/lib/filter-versions.ts
+++ b/lib/filter-versions.ts
@@ -1,0 +1,98 @@
+/**
+ * NOTE: also used in hashicorp/dev-portal
+ */
+
+import semverSatisfies from 'semver/functions/satisfies'
+import semverMajor from 'semver/functions/major'
+import semverMinor from 'semver/functions/minor'
+import semverPatch from 'semver/functions/patch'
+
+import { Products as HashiCorpProduct } from '@hashicorp/platform-product-meta'
+
+export type OperatingSystem =
+  | 'darwin'
+  | 'freebsd'
+  | 'openbsd'
+  | 'netbsd'
+  | 'archlinux'
+  | 'linux'
+  | 'windows'
+
+export type Version = string
+
+export interface ReleaseVersion {
+  name: HashiCorpProduct
+  version: Version
+  shasums: string
+  shasums_signature: string
+  builds: {
+    name: HashiCorpProduct
+    version: Version
+    os: OperatingSystem
+    arch: string
+    filename: string
+    url: string
+  }[]
+}
+export interface ReleasesAPIResponse {
+  name: HashiCorpProduct
+  versions: {
+    [versionNumber: string]: ReleaseVersion
+  }
+}
+
+/**
+ * Filter versions based on a semver range,
+ * and also only return the latest patch releases
+ * (rather than every single patch release).
+ *
+ * Note: also used in dev-portal
+ */
+function filterVersions(
+  versions: ReleasesAPIResponse['versions'],
+  versionRange: string
+): ReleasesAPIResponse['versions'] {
+  // Filter by arbitrary & reasonable version cutoff
+  const filteredVersions = Object.keys(versions).filter(
+    (versionNumber: string) => {
+      return semverSatisfies(versionNumber, versionRange)
+    }
+  )
+
+  /**
+   * Computes the latest patch versions for each major/minor
+   * e.g. given [1.1.2, 1.1.1, 1.1.0, 1.0.9, 1.0.8]
+   * return [1.1.2, 1.0.9]
+   */
+  const tree: { [x: number]: { [y: number]: number } } = {}
+  filteredVersions.forEach((v: string) => {
+    const x = semverMajor(v)
+    const y = semverMinor(v)
+    const z = semverPatch(v)
+
+    if (!tree[x]) {
+      tree[x] = { [y]: z }
+    } else if (!tree[x][y]) {
+      tree[x][y] = z
+    } else {
+      tree[x][y] = Math.max(tree[x][y], z)
+    }
+  })
+
+  // Turn the reduced tree of latest patches only into an array
+  const latestPatchesOnly = []
+  Object.entries(tree).forEach(([x, xObj]) => {
+    Object.entries(xObj).forEach(([y, z]) => {
+      latestPatchesOnly.push(`${x}.${y}.${z}`)
+    })
+  })
+
+  // Turn the array of latest patches only into an object with release data
+  const filteredVersionsObj = {}
+  latestPatchesOnly.forEach((versionNumber: string) => {
+    filteredVersionsObj[versionNumber] = versions[versionNumber]
+  })
+  return filteredVersionsObj
+}
+
+export default filterVersions

--- a/pages/downloads/index.jsx
+++ b/pages/downloads/index.jsx
@@ -1,8 +1,3 @@
-import semverGte from 'semver/functions/gte'
-import semverMajor from 'semver/functions/major'
-import semverMinor from 'semver/functions/minor'
-import semverPatch from 'semver/functions/patch'
-
 import VERSION from 'data/version'
 import { productSlug } from 'data/metadata'
 import Logo from '@hashicorp/mktg-assets/dist/product/terraform-logo/color'
@@ -10,8 +5,9 @@ import ProductDownloadsPage from '@hashicorp/react-product-downloads-page'
 import Button from '@hashicorp/react-button'
 import { generateStaticProps } from '@hashicorp/react-product-downloads-page/server'
 import s from './style.module.css'
+import filterVersions from 'lib/filter-versions'
 
-const VERSION_DOWNLOAD_CUTOFF = '1.0.11'
+const VERSION_DOWNLOAD_CUTOFF = '>=1.0.11'
 
 export default function DownloadsPage(staticProps) {
   return (
@@ -52,58 +48,16 @@ export default function DownloadsPage(staticProps) {
   )
 }
 
-function filterOldVersions(props) {
-  if (!props?.props?.releases?.versions) return props
-
-  const versions = props.props.releases.versions
-
-  // versions is in the form of { [version]: { ...metadata } }
-  // Filter by arbitrary & reasonable version cutoff
-  const filteredVersions = Object.keys(versions).filter((version) => {
-    if (!semverGte(version, VERSION_DOWNLOAD_CUTOFF)) return false
-    return true
-  })
-
-  /** @type {{[x: string]:{ [y: string]: any}}} */
-  const tree = {}
-
-  /**
-   * Computes the latest patch versions for each major/minor
-   * e.g. given [1.1.2, 1.1.1, 1.1.0, 1.0.9, 1.0.8] -> return [1.1.2, 1.0.9]
-   */
-  filteredVersions.forEach((v) => {
-    const x = semverMajor(v)
-    const y = semverMinor(v)
-    const z = semverPatch(v)
-
-    if (!tree[x]) {
-      tree[x] = { [y]: z }
-    } else if (!tree[x][y]) {
-      tree[x][y] = z
-    } else {
-      tree[x][y] = Math.max(tree[x][y], z)
-    }
-  })
-
-  const newVersions = {}
-
-  Object.entries(tree).forEach(([x, xObj]) => {
-    Object.entries(xObj).forEach(([y, z]) => {
-      const version = `${x}.${y}.${z}`
-      newVersions[version] = versions[version]
-    })
-  })
-
-  props.props.releases.versions = newVersions
-}
-
 export async function getStaticProps() {
   const props = await generateStaticProps({
     product: productSlug,
     latestVersion: VERSION,
   })
 
-  filterOldVersions(props)
+  // Filter versions based on VERSION_DOWNLOAD_CUTOFF
+  const rawVersions = props.props?.releases?.versions
+  const filteredVersions = filterVersions(rawVersions, VERSION_DOWNLOAD_CUTOFF)
+  props.props.releases.versions = filteredVersions
 
   return props
 }


### PR DESCRIPTION
👀 [Preview](https://terraform-website-git-zsfix-version-filter-hashicorp.vercel.app/downloads)

This PR fixes an issue with the Terraform `/downloads` page. Pre-release versions were previously not filtered as expected, causing build errors. See hashicorp/dev-portal#231 for details.