### PR TITLE
correct case of X-Tfc-Task-Signature

### DIFF
--- a/content/cloud-docs/integrations/run-tasks/index.mdx
+++ b/content/cloud-docs/integrations/run-tasks/index.mdx
@@ -70,7 +70,7 @@ Here's what the data flow looks like:
 
 ## Securing your Run Task
 
-When creating your run task, you can supply an HMAC key which Terraform Cloud will use to create a signature of the payload in the `x-tfc-task-signature` header when calling your service.
+When creating your run task, you can supply an HMAC key which Terraform Cloud will use to create a signature of the payload in the `X-Tfc-Task-Signature` header when calling your service.
 
 The signature is a sha512 sum of the webhook body using the provided HMAC key. The generation of the signature depends on your implementation, however an example of how to generate a signature in bash is provided below.
 


### PR DESCRIPTION
This can be case sensitive
<img width="455" alt="Screen Shot 2022-03-29 at 11 11 00 AM" src="https://user-images.githubusercontent.com/9982159/160678677-3a471de7-6b54-4828-a704-7bb5c6b69dc9.png">
