### PR TITLE
Updating HCP Packer documentation link

### DIFF
--- a/content/cloud-docs/integrations/run-tasks/index.mdx
+++ b/content/cloud-docs/integrations/run-tasks/index.mdx
@@ -85,7 +85,7 @@ $ echo -n $WEBHOOK_BODY | openssl dgst -sha512 -hmac "$HMAC_KEY"
 
 The HCP Packer validation run task checks the image artifacts within a Terraform configuration. If the configuration references images marked as unusable (revoked), the run task fails and provides an error message containing the number of revoked artifacts and whether HCP Packer has metadata for newer versions. For HCP Packer Plus registries, run tasks also help you identify hardcoded and untracked images that may not meet security and compliance requirements.
 
-To get started, [create an HCP Packer account](/products/packer) and follow the instructions in the [HCP Packer Run Task](/docs/packer/manage-image-use/terraform-cloud-run-tasks) documentation.
+To get started, [create an HCP Packer account](/products/packer) and follow the instructions in the [HCP Packer Run Task](https://cloud.hashicorp.com/docs/packer/manage-image-use/terraform-cloud-run-tasks) documentation.
 
 ## Run Tasks Technology Partners
 


### PR DESCRIPTION
Updating the HCP Packer documentation link to be over on the cloud.hashicorp.com site, instead of nested within the terraform.io site which currently 404's. 