### PR TITLE
Update permissions required to create configuration versions

### DIFF
--- a/content/cloud-docs/api-docs/configuration-versions.mdx
+++ b/content/cloud-docs/api-docs/configuration-versions.mdx
@@ -42,7 +42,7 @@ page_title: Configuration Versions - API Docs - Terraform Cloud and Terraform En
 
 A configuration version (`configuration-version`) is a resource used to reference the uploaded configuration files. It is associated with the run to use the uploaded configuration files for performing the plan and apply.
 
-You need read runs permission to list and view configuration versions for a workspace, and you need apply runs permission to create new configuration versions. Refer to the [permissions](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) documentation for more details.
+You need read runs permission to list and view configuration versions for a workspace, and you need queue plans permission to create new configuration versions. Refer to the [permissions](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) documentation for more details.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/cloud-docs/run/api.mdx
+++ b/content/cloud-docs/run/api.mdx
@@ -29,7 +29,7 @@ The most significant difference in this workflow is that Terraform Cloud _does n
 
 Pushing a new configuration to an existing workspace is a multi-step process. This section walks through each step in detail, using an example bash script to illustrate.
 
-You need apply runs permission to create new configuration versions for the workspace. Refer to the [permissions](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) documentation for more details.
+You need queue plans permission to create new configuration versions for the workspace. Refer to the [permissions](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) documentation for more details.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 


### PR DESCRIPTION
The permissions required to create a configuration version have been relaxed slightly.  Whereas previously configuration version creation required the apply runs permission, they can now be created by users with the queue plans permission.  Resulting runs will still follow the previous model (runs created by users with the queue plans permission will still need to be confirmed by a user with the apply runs permission).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201972896866661