### PR TITLE
feat: terraform content split

### DIFF
--- a/content/cli
+++ b/content/cli
@@ -1,1 +1,0 @@
-../ext/terraform/website/docs/cli

--- a/content/configuration
+++ b/content/configuration
@@ -1,1 +1,0 @@
-../ext/terraform/website/docs/configuration

--- a/content/guides
+++ b/content/guides
@@ -1,1 +1,0 @@
-../ext/terraform/website/guides

--- a/content/internals
+++ b/content/internals
@@ -1,1 +1,0 @@
-../ext/terraform/website/docs/internals

--- a/content/intro
+++ b/content/intro
@@ -1,1 +1,0 @@
-../ext/terraform/website/intro

--- a/content/language
+++ b/content/language
@@ -1,1 +1,0 @@
-../ext/terraform/website/docs/language

--- a/data/cli-nav-data.json
+++ b/data/cli-nav-data.json
@@ -1,1 +1,0 @@
-../ext/terraform/website/data/cli-nav-data.json

--- a/data/configuration-nav-data.json
+++ b/data/configuration-nav-data.json
@@ -1,1 +1,0 @@
-../ext/terraform/website/data/configuration-nav-data.json

--- a/data/guides-nav-data.json
+++ b/data/guides-nav-data.json
@@ -1,1 +1,0 @@
-../ext/terraform/website/data/guides-nav-data.json

--- a/data/internals-nav-data.json
+++ b/data/internals-nav-data.json
@@ -1,1 +1,0 @@
-../ext/terraform/website/data/internals-nav-data.json

--- a/data/intro-nav-data.json
+++ b/data/intro-nav-data.json
@@ -1,1 +1,0 @@
-../ext/terraform/website/data/intro-nav-data.json

--- a/data/language-nav-data.json
+++ b/data/language-nav-data.json
@@ -1,1 +1,0 @@
-../ext/terraform/website/data/language-nav-data.json

--- a/lib/remark-rewrite-assets.ts
+++ b/lib/remark-rewrite-assets.ts
@@ -11,15 +11,15 @@ import type { Image } from 'mdast'
 export function remarkRewriteAssets(args: {
   product: string
   version: string
-  assetPathBuilder?: (nodeUrl: string) => string[]
+  getAssetPathParts?: (nodeUrl: string) => string[]
 }): Plugin {
-  const { product, version, assetPathBuilder = (nodeUrl) => [nodeUrl] } = args
+  const { product, version, getAssetPathParts = (nodeUrl) => [nodeUrl] } = args
 
   return function plugin() {
     return function transform(tree) {
       visit<Image>(tree, 'image', (node) => {
         const originalUrl = node.url
-        const asset = path.posix.join(...assetPathBuilder(originalUrl))
+        const asset = path.posix.join(...getAssetPathParts(originalUrl))
 
         const url = new URL('https://mktg-content-api.vercel.app/api/assets')
         url.searchParams.append('asset', asset)

--- a/lib/remark-rewrite-assets.ts
+++ b/lib/remark-rewrite-assets.ts
@@ -27,12 +27,23 @@ export function remarkRewriteAssets(args: {
         url.searchParams.append('product', product)
 
         node.url = url.toString()
-        console.log(`Rewriting asset url for local preview:
+        logOnce(
+          node.url,
+          `Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, you'll need to commit and push it to GitHub.\n`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.\n`
+        )
       })
     }
   }
+}
+
+// A simple cache & util to prevent logging the same message multiple times
+const cache = new Map<string, boolean>()
+const logOnce = (id: string, message: string) => {
+  if (cache.get(id)) return
+  cache.set(id, true)
+  console.log(message)
 }

--- a/lib/remark-rewrite-assets.ts
+++ b/lib/remark-rewrite-assets.ts
@@ -1,0 +1,38 @@
+import * as path from 'path'
+import visit from 'unist-util-visit'
+
+import type { Plugin } from 'unified'
+import type { Image } from 'mdast'
+
+/**
+ * This is a generator function that returns a remark plugin
+ * to rewrite asset urls in markdown files.
+ */
+export function remarkRewriteAssets(args: {
+  product: string
+  version: string
+  assetPathBuilder?: (nodeUrl: string) => string[]
+}): Plugin {
+  const { product, version, assetPathBuilder = (nodeUrl) => [nodeUrl] } = args
+
+  return function plugin() {
+    return function transform(tree) {
+      visit<Image>(tree, 'image', (node) => {
+        const originalUrl = node.url
+        const asset = path.posix.join(...assetPathBuilder(originalUrl))
+
+        const url = new URL('https://mktg-content-api.vercel.app/api/assets')
+        url.searchParams.append('asset', asset)
+        url.searchParams.append('version', version)
+        url.searchParams.append('product', product)
+
+        node.url = url.toString()
+        console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
+
+If this is a net-new asset, you'll need to commit and push it to GitHub.\n`)
+      })
+    }
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -21,8 +21,13 @@ module.exports = withHashicorp({
     BUGSNAG_CLIENT_KEY: 'eab8d5350ab3b12d77b7498b23f9a89a',
     BUGSNAG_SERVER_KEY: '1f55a49019f70f94a17dd6d93210f09d',
     IS_CONTENT_PREVIEW: process.env.IS_CONTENT_PREVIEW || false,
+    PREVIEW_FROM_REPO: process.env.PREVIEW_FROM_REPO,
+    // for terraform-cdk
     NAV_DATA_PATH: process.env.NAV_DATA_PATH,
     CONTENT_DIR: process.env.CONTENT_DIR,
+    // for terraform
+    NAV_DATA_DIRNAME: process.env.NAV_DATA_DIRNAME,
+    CONTENT_DIRNAME: process.env.CONTENT_DIRNAME,
   },
   images: {
     domains: ['www.datocms-assets.com'],

--- a/next.config.js
+++ b/next.config.js
@@ -22,8 +22,9 @@ module.exports = withHashicorp({
     BUGSNAG_SERVER_KEY: '1f55a49019f70f94a17dd6d93210f09d',
     IS_CONTENT_PREVIEW: process.env.IS_CONTENT_PREVIEW || false,
     PREVIEW_FROM_REPO: process.env.PREVIEW_FROM_REPO,
-    NAV_DATA_DIRNAME: process.env.NAV_DATA_DIRNAME || "",
-    CONTENT_DIRNAME: process.env.CONTENT_DIRNAME || "",
+    NAV_DATA_DIRNAME: process.env.NAV_DATA_DIRNAME || '',
+    CONTENT_DIRNAME: process.env.CONTENT_DIRNAME || '',
+    CURRENT_GIT_BRANCH: process.env.CURRENT_GIT_BRANCH || 'main',
   },
   images: {
     domains: ['www.datocms-assets.com'],

--- a/next.config.js
+++ b/next.config.js
@@ -22,12 +22,8 @@ module.exports = withHashicorp({
     BUGSNAG_SERVER_KEY: '1f55a49019f70f94a17dd6d93210f09d',
     IS_CONTENT_PREVIEW: process.env.IS_CONTENT_PREVIEW || false,
     PREVIEW_FROM_REPO: process.env.PREVIEW_FROM_REPO,
-    // for terraform-cdk
-    NAV_DATA_PATH: process.env.NAV_DATA_PATH,
-    CONTENT_DIR: process.env.CONTENT_DIR,
-    // for terraform
-    NAV_DATA_DIRNAME: process.env.NAV_DATA_DIRNAME,
-    CONTENT_DIRNAME: process.env.CONTENT_DIRNAME,
+    NAV_DATA_DIRNAME: process.env.NAV_DATA_DIRNAME || "",
+    CONTENT_DIRNAME: process.env.CONTENT_DIRNAME || "",
   },
   images: {
     domains: ['www.datocms-assets.com'],

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "generate:component": "next-hashicorp generate component",
     "generate:readme": "next-hashicorp markdown-blocks README.md",
     "lint": "next-hashicorp lint",
-    "start": "next-remote-watch './content/**/*.mdx'",
+    "start": "next dev",
     "static": "npm run build && npm run export",
     "linkcheck": "linkcheck <website url>"
   }

--- a/pages/cdktf/[[...page]].jsx
+++ b/pages/cdktf/[[...page]].jsx
@@ -8,8 +8,8 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'cdktf'
-const NAV_DATA = process.env.NAV_DATA_PATH || '../data/cdktf-nav-data.json'
-const CONTENT_DIR = process.env.CONTENT_DIR || '../docs/cdktf'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: 'terraform-cdk' }
 
 export default function CDKLayout(props) {

--- a/pages/cdktf/[[...page]].jsx
+++ b/pages/cdktf/[[...page]].jsx
@@ -48,7 +48,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) =>
+            getAssetPathParts: (nodeUrl) =>
               params.page
                 ? [
                     'website/docs/cdktf',

--- a/pages/cdktf/[[...page]].jsx
+++ b/pages/cdktf/[[...page]].jsx
@@ -27,7 +27,7 @@ export default function CDKLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform-cdk'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/cdktf/[[...page]].jsx
+++ b/pages/cdktf/[[...page]].jsx
@@ -3,8 +3,9 @@ import DocsPage from '@hashicorp/react-docs-page'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
-import visit from 'unist-util-visit'
 import path from 'path'
+
+import { remarkRewriteAssets } from 'lib/remark-rewrite-assets'
 
 //  Configure the docs path
 const BASE_ROUTE = 'cdktf'
@@ -44,37 +45,18 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
         },
         remarkPlugins: (params) => [
-          () => {
-            const product = PRODUCT.slug
-            const version = process.env.CURRENT_GIT_BRANCH
-            return function transform(tree) {
-              visit(tree, 'image', (node) => {
-                const originalUrl = node.url
-                const assetPath = params.page
-                  ? path.posix.join(
-                      ...params.page,
-                      node.url.startsWith('.')
-                        ? `.${node.url}`
-                        : `../${node.url}`
-                    )
-                  : node.url
-                const asset = path.posix.join('website/docs/cdktf', assetPath)
-                const url = new URL(
-                  `https://mktg-content-api.vercel.app/api/assets`
-                )
-                url.searchParams.append('asset', asset)
-                url.searchParams.append('version', version)
-                url.searchParams.append('product', product)
-
-                node.url = url.toString()
-                console.log(`Rewriting asset url for local preview:
-- Found: ${originalUrl}
-- Replaced with: ${node.url}
-
-If this is a net-new asset, you'll need to commit and push it to GitHub.`)
-              })
-            }
-          },
+          remarkRewriteAssets({
+            product: PRODUCT.slug,
+            version: process.env.CURRENT_GIT_BRANCH,
+            assetPathBuilder: (nodeUrl) =>
+              params.page
+                ? [
+                    'website/docs/cdktf',
+                    ...params.page,
+                    nodeUrl.startsWith('.') ? `.${nodeUrl}` : `../${nodeUrl}`,
+                  ]
+                : ['website/docs/cdktf', nodeUrl],
+          }),
         ],
       }
     : {

--- a/pages/cdktf/[[...page]].jsx
+++ b/pages/cdktf/[[...page]].jsx
@@ -8,7 +8,10 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'cdktf'
-const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const NAV_DATA = path.join(
+  process.env.NAV_DATA_DIRNAME,
+  BASE_ROUTE + '-nav-data.json'
+)
 const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: 'terraform-cdk' }
 
@@ -27,7 +30,8 @@ export default function CDKLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform-cdk'
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === 'terraform-cdk'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,
@@ -42,7 +46,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
         remarkPlugins: (params) => [
           () => {
             const product = PRODUCT.slug
-            const version = 'main'
+            const version = process.env.CURRENT_GIT_BRANCH
             return function transform(tree) {
               visit(tree, 'image', (node) => {
                 const originalUrl = node.url
@@ -55,7 +59,14 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
                     )
                   : node.url
                 const asset = path.posix.join('website/docs/cdktf', assetPath)
-                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                const url = new URL(
+                  `https://mktg-content-api.vercel.app/api/assets`
+                )
+                url.searchParams.append('asset', asset)
+                url.searchParams.append('version', version)
+                url.searchParams.append('product', product)
+
+                node.url = url.toString()
                 console.log(`Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}

--- a/pages/cdktf/[[...page]].jsx
+++ b/pages/cdktf/[[...page]].jsx
@@ -71,7 +71,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/cli/[[...page]].jsx
+++ b/pages/cli/[[...page]].jsx
@@ -48,7 +48,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }

--- a/pages/cli/[[...page]].jsx
+++ b/pages/cli/[[...page]].jsx
@@ -8,8 +8,8 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'cli'
-const NAV_DATA = process.env.NAV_DATA_PATH || '../data/cli-nav-data.json'
-const CONTENT_DIR = process.env.CONTENT_DIR || '../content/cdktf'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function CLILayout(props) {
@@ -27,7 +27,7 @@ export default function CLILayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/cli/[[...page]].jsx
+++ b/pages/cli/[[...page]].jsx
@@ -2,15 +2,14 @@ import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
-import {
-  generateStaticPaths,
-  generateStaticProps,
-} from '@hashicorp/react-docs-page/server'
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+import visit from 'unist-util-visit'
+import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'cli'
-const NAV_DATA = 'data/cli-nav-data.json'
-const CONTENT_DIR = 'content/cli'
+const NAV_DATA = process.env.NAV_DATA_PATH || '../data/cli-nav-data.json'
+const CONTENT_DIR = process.env.CONTENT_DIR || '../content/cdktf'
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function CLILayout(props) {
@@ -27,25 +26,51 @@ export default function CLILayout(props) {
   )
 }
 
-export async function getStaticPaths() {
-  const paths = await generateStaticPaths({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    product: PRODUCT,
-  })
-  return { paths, fallback: false }
-}
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW
+    ? {
+        strategy: 'fs',
+        basePath: BASE_ROUTE,
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: PRODUCT.slug,
+        githubFileUrl(filepath) {
+          // This path rewriting is meant for local preview from `terraform`.
+          filepath = filepath.replace('preview/', '')
+          return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
+        },
+        remarkPlugins: (params) => [
+          () => {
+            const product = PRODUCT.slug
+            const version = 'main'
+            return function transform(tree) {
+              visit(tree, 'image', (node) => {
+                const originalUrl = node.url
+                const assetPath = params.page
+                  ? path.posix.join(
+                      ...params.page,
+                      node.url.startsWith('.')
+                        ? `.${node.url}`
+                        : `../${node.url}`
+                    )
+                  : node.url
+                const asset = path.posix.join('website/docs/cli', assetPath)
+                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
 
-export async function getStaticProps({ params }) {
-  const props = await generateStaticProps({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    params,
-    product: PRODUCT,
-    githubFileUrl(path) {
-      const filepath = path.replace('content/', '')
-      return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/docs/${filepath}`
-    },
-  })
-  return { props }
-}
+If this is a net-new asset, it may not be available in the preview yet.`)
+              })
+            }
+          },
+        ],
+      }
+    : {
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: PRODUCT.slug,
+      }
+)
+
+export { getStaticPaths, getStaticProps }

--- a/pages/cli/[[...page]].jsx
+++ b/pages/cli/[[...page]].jsx
@@ -8,7 +8,10 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'cli'
-const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const NAV_DATA = path.join(
+  process.env.NAV_DATA_DIRNAME,
+  BASE_ROUTE + '-nav-data.json'
+)
 const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
@@ -27,7 +30,8 @@ export default function CLILayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,
@@ -42,20 +46,19 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
         remarkPlugins: (params) => [
           () => {
             const product = PRODUCT.slug
-            const version = 'main'
+            const version = process.env.CURRENT_GIT_BRANCH
             return function transform(tree) {
               visit(tree, 'image', (node) => {
                 const originalUrl = node.url
-                const assetPath = params.page
-                  ? path.posix.join(
-                      ...params.page,
-                      node.url.startsWith('.')
-                        ? `.${node.url}`
-                        : `../${node.url}`
-                    )
-                  : node.url
-                const asset = path.posix.join('website/docs/cli', assetPath)
-                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                const asset = path.posix.join('website', originalUrl)
+                const url = new URL(
+                  'https://mktg-content-api.vercel.app/api/assets'
+                )
+                url.searchParams.append('asset', asset)
+                url.searchParams.append('version', version)
+                url.searchParams.append('product', product)
+
+                node.url = url.toString()
                 console.log(`Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}

--- a/pages/cli/[[...page]].jsx
+++ b/pages/cli/[[...page]].jsx
@@ -63,7 +63,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/configuration/[[...page]].jsx
+++ b/pages/configuration/[[...page]].jsx
@@ -1,15 +1,15 @@
 import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
+import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
-import {
-  generateStaticPaths,
-  generateStaticProps,
-} from '@hashicorp/react-docs-page/server'
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+import visit from 'unist-util-visit'
+import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'configuration'
-const NAV_DATA = 'data/configuration-nav-data.json'
-const CONTENT_DIR = 'content/configuration'
+const NAV_DATA = process.env.NAV_DATA_PATH || '../data/configuration-nav-data.json'
+const CONTENT_DIR = process.env.CONTENT_DIR || '../content/configuration'
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function ConfigurationLayout(props) {
@@ -18,25 +18,51 @@ export default function ConfigurationLayout(props) {
   )
 }
 
-export async function getStaticPaths() {
-  const paths = await generateStaticPaths({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    product: PRODUCT,
-  })
-  return { paths, fallback: false }
-}
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW
+    ? {
+        strategy: 'fs',
+        basePath: BASE_ROUTE,
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: PRODUCT.slug,
+        githubFileUrl(filepath) {
+          // This path rewriting is meant for local preview from `terraform`.
+          filepath = filepath.replace('preview/', '')
+          return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
+        },
+        remarkPlugins: (params) => [
+          () => {
+            const product = PRODUCT.slug
+            const version = 'main'
+            return function transform(tree) {
+              visit(tree, 'image', (node) => {
+                const originalUrl = node.url
+                const assetPath = params.page
+                  ? path.posix.join(
+                      ...params.page,
+                      node.url.startsWith('.')
+                        ? `.${node.url}`
+                        : `../${node.url}`
+                    )
+                  : node.url
+                const asset = path.posix.join('website/docs/cli', assetPath)
+                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
 
-export async function getStaticProps({ params }) {
-  const props = await generateStaticProps({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    params,
-    product: PRODUCT,
-    githubFileUrl(path) {
-      const filepath = path.replace('content/', '')
-      return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/docs/${filepath}`
-    },
-  })
-  return { props }
-}
+If this is a net-new asset, it may not be available in the preview yet.`)
+              })
+            }
+          },
+        ],
+      }
+    : {
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: PRODUCT.slug,
+      }
+)
+
+export { getStaticPaths, getStaticProps }

--- a/pages/configuration/[[...page]].jsx
+++ b/pages/configuration/[[...page]].jsx
@@ -39,7 +39,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }

--- a/pages/configuration/[[...page]].jsx
+++ b/pages/configuration/[[...page]].jsx
@@ -55,7 +55,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/configuration/[[...page]].jsx
+++ b/pages/configuration/[[...page]].jsx
@@ -8,8 +8,8 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'configuration'
-const NAV_DATA = process.env.NAV_DATA_PATH || '../data/configuration-nav-data.json'
-const CONTENT_DIR = process.env.CONTENT_DIR || '../content/configuration'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function ConfigurationLayout(props) {
@@ -19,7 +19,7 @@ export default function ConfigurationLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/configuration/[[...page]].jsx
+++ b/pages/configuration/[[...page]].jsx
@@ -3,8 +3,8 @@ import DocsPage from '@hashicorp/react-docs-page'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
-import visit from 'unist-util-visit'
 import path from 'path'
+import { remarkRewriteAssets } from 'lib/remark-rewrite-assets'
 
 //  Configure the docs path
 const BASE_ROUTE = 'configuration'
@@ -36,29 +36,11 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
         },
         remarkPlugins: (params) => [
-          () => {
-            const product = PRODUCT.slug
-            const version = process.env.CURRENT_GIT_BRANCH
-            return function transform(tree) {
-              visit(tree, 'image', (node) => {
-                const originalUrl = node.url
-                const asset = path.posix.join('website', originalUrl)
-                const url = new URL(
-                  'https://mktg-content-api.vercel.app/api/assets'
-                )
-                url.searchParams.append('asset', asset)
-                url.searchParams.append('version', version)
-                url.searchParams.append('product', product)
-
-                node.url = url.toString()
-                console.log(`Rewriting asset url for local preview:
-- Found: ${originalUrl}
-- Replaced with: ${node.url}
-
-If this is a net-new asset, you'll need to commit and push it to GitHub.`)
-              })
-            }
-          },
+          remarkRewriteAssets({
+            product: PRODUCT.slug,
+            version: process.env.CURRENT_GIT_BRANCH,
+            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+          }),
         ],
       }
     : {

--- a/pages/guides/[[...page]].jsx
+++ b/pages/guides/[[...page]].jsx
@@ -8,7 +8,10 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'guides'
-const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const NAV_DATA = path.join(
+  process.env.NAV_DATA_DIRNAME,
+  BASE_ROUTE + '-nav-data.json'
+)
 const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
@@ -24,7 +27,8 @@ export default function GuidesLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,
@@ -39,20 +43,19 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
         remarkPlugins: (params) => [
           () => {
             const product = PRODUCT.slug
-            const version = 'main'
+            const version = process.env.CURRENT_GIT_BRANCH
             return function transform(tree) {
               visit(tree, 'image', (node) => {
                 const originalUrl = node.url
-                const assetPath = params.page
-                  ? path.posix.join(
-                      ...params.page,
-                      node.url.startsWith('.')
-                        ? `.${node.url}`
-                        : `../${node.url}`
-                    )
-                  : node.url
-                const asset = path.posix.join('website/docs/cli', assetPath)
-                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                const asset = path.posix.join('website', originalUrl)
+                const url = new URL(
+                  'https://mktg-content-api.vercel.app/api/assets'
+                )
+                url.searchParams.append('asset', asset)
+                url.searchParams.append('version', version)
+                url.searchParams.append('product', product)
+
+                node.url = url.toString()
                 console.log(`Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}

--- a/pages/guides/[[...page]].jsx
+++ b/pages/guides/[[...page]].jsx
@@ -44,7 +44,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }

--- a/pages/guides/[[...page]].jsx
+++ b/pages/guides/[[...page]].jsx
@@ -2,16 +2,14 @@ import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
 // Imports below are only used server-side
-import {
-  generateStaticPaths,
-  generateStaticProps,
-} from '@hashicorp/react-docs-page/server'
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 import visit from 'unist-util-visit'
+import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'guides'
-const NAV_DATA = 'data/guides-nav-data.json'
-const CONTENT_DIR = 'content/guides'
+const NAV_DATA = process.env.NAV_DATA_PATH ||  '../data/guides-nav-data.json'
+const CONTENT_DIR = process.env.CONTENT_DIR || '../content/guides'
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function GuidesLayout(props) {
@@ -25,25 +23,51 @@ export default function GuidesLayout(props) {
   )
 }
 
-export async function getStaticPaths() {
-  const paths = await generateStaticPaths({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    product: PRODUCT
-  })
-  return { paths, fallback: false }
-}
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW
+    ? {
+        strategy: 'fs',
+        basePath: BASE_ROUTE,
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: PRODUCT.slug,
+        githubFileUrl(filepath) {
+          // This path rewriting is meant for local preview from `terraform`.
+          filepath = filepath.replace('preview/', '')
+          return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
+        },
+        remarkPlugins: (params) => [
+          () => {
+            const product = PRODUCT.slug
+            const version = 'main'
+            return function transform(tree) {
+              visit(tree, 'image', (node) => {
+                const originalUrl = node.url
+                const assetPath = params.page
+                  ? path.posix.join(
+                      ...params.page,
+                      node.url.startsWith('.')
+                        ? `.${node.url}`
+                        : `../${node.url}`
+                    )
+                  : node.url
+                const asset = path.posix.join('website/docs/cli', assetPath)
+                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
 
-export async function getStaticProps({ params }) {
-  const props = await generateStaticProps({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    params,
-    product: PRODUCT,
-    githubFileUrl(path) {
-      const filepath = path.replace('content/', '')
-      return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
-    },
-  })
-  return { props }
-}
+If this is a net-new asset, it may not be available in the preview yet.`)
+              })
+            }
+          },
+        ],
+      }
+    : {
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: PRODUCT.slug,
+      }
+)
+
+export { getStaticPaths, getStaticProps }

--- a/pages/guides/[[...page]].jsx
+++ b/pages/guides/[[...page]].jsx
@@ -8,8 +8,8 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'guides'
-const NAV_DATA = process.env.NAV_DATA_PATH ||  '../data/guides-nav-data.json'
-const CONTENT_DIR = process.env.CONTENT_DIR || '../content/guides'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function GuidesLayout(props) {
@@ -24,7 +24,7 @@ export default function GuidesLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/guides/[[...page]].jsx
+++ b/pages/guides/[[...page]].jsx
@@ -60,7 +60,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/guides/[[...page]].jsx
+++ b/pages/guides/[[...page]].jsx
@@ -3,8 +3,8 @@ import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
-import visit from 'unist-util-visit'
 import path from 'path'
+import { remarkRewriteAssets } from 'lib/remark-rewrite-assets'
 
 //  Configure the docs path
 const BASE_ROUTE = 'guides'
@@ -41,29 +41,11 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
         },
         remarkPlugins: (params) => [
-          () => {
-            const product = PRODUCT.slug
-            const version = process.env.CURRENT_GIT_BRANCH
-            return function transform(tree) {
-              visit(tree, 'image', (node) => {
-                const originalUrl = node.url
-                const asset = path.posix.join('website', originalUrl)
-                const url = new URL(
-                  'https://mktg-content-api.vercel.app/api/assets'
-                )
-                url.searchParams.append('asset', asset)
-                url.searchParams.append('version', version)
-                url.searchParams.append('product', product)
-
-                node.url = url.toString()
-                console.log(`Rewriting asset url for local preview:
-- Found: ${originalUrl}
-- Replaced with: ${node.url}
-
-If this is a net-new asset, you'll need to commit and push it to GitHub.`)
-              })
-            }
-          },
+          remarkRewriteAssets({
+            product: PRODUCT.slug,
+            version: process.env.CURRENT_GIT_BRANCH,
+            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+          }),
         ],
       }
     : {

--- a/pages/internals/[[...page]].jsx
+++ b/pages/internals/[[...page]].jsx
@@ -7,8 +7,8 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'internals'
-const NAV_DATA = process.env.NAV_DATA_PATH || '../data/internals-nav-data.json'
-const CONTENT_DIR =  process.env.CONTENT_DIR || '../content/internals'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function InternalsLayout(props) {
@@ -18,7 +18,7 @@ export default function InternalsLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/internals/[[...page]].jsx
+++ b/pages/internals/[[...page]].jsx
@@ -7,7 +7,10 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'internals'
-const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const NAV_DATA = path.join(
+  process.env.NAV_DATA_DIRNAME,
+  BASE_ROUTE + '-nav-data.json'
+)
 const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
@@ -18,7 +21,8 @@ export default function InternalsLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,
@@ -33,25 +37,24 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
         remarkPlugins: (params) => [
           () => {
             const product = PRODUCT.slug
-            const version = 'main'
+            const version = process.env.CURRENT_GIT_BRANCH
             return function transform(tree) {
               visit(tree, 'image', (node) => {
                 const originalUrl = node.url
-                const assetPath = params.page
-                  ? path.posix.join(
-                      ...params.page,
-                      node.url.startsWith('.')
-                        ? `.${node.url}`
-                        : `../${node.url}`
-                    )
-                  : node.url
-                const asset = path.posix.join('website/docs/cli', assetPath)
-                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                const asset = path.posix.join('website', originalUrl)
+                const url = new URL(
+                  'https://mktg-content-api.vercel.app/api/assets'
+                )
+                url.searchParams.append('asset', asset)
+                url.searchParams.append('version', version)
+                url.searchParams.append('product', product)
+
+                node.url = url.toString()
                 console.log(`Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/internals/[[...page]].jsx
+++ b/pages/internals/[[...page]].jsx
@@ -38,7 +38,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }

--- a/pages/internals/[[...page]].jsx
+++ b/pages/internals/[[...page]].jsx
@@ -1,15 +1,14 @@
 import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 // Imports below are only used server-side
-import {
-  generateStaticPaths,
-  generateStaticProps,
-} from '@hashicorp/react-docs-page/server'
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+import visit from 'unist-util-visit'
+import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'internals'
-const NAV_DATA = 'data/internals-nav-data.json'
-const CONTENT_DIR = 'content/internals'
+const NAV_DATA = process.env.NAV_DATA_PATH || '../data/internals-nav-data.json'
+const CONTENT_DIR =  process.env.CONTENT_DIR || '../content/internals'
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function InternalsLayout(props) {
@@ -18,25 +17,51 @@ export default function InternalsLayout(props) {
   )
 }
 
-export async function getStaticPaths() {
-  const paths = await generateStaticPaths({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    product: PRODUCT,
-  })
-  return { paths, fallback: false }
-}
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW
+    ? {
+        strategy: 'fs',
+        basePath: BASE_ROUTE,
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: PRODUCT.slug,
+        githubFileUrl(filepath) {
+          // This path rewriting is meant for local preview from `terraform`.
+          filepath = filepath.replace('preview/', '')
+          return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
+        },
+        remarkPlugins: (params) => [
+          () => {
+            const product = PRODUCT.slug
+            const version = 'main'
+            return function transform(tree) {
+              visit(tree, 'image', (node) => {
+                const originalUrl = node.url
+                const assetPath = params.page
+                  ? path.posix.join(
+                      ...params.page,
+                      node.url.startsWith('.')
+                        ? `.${node.url}`
+                        : `../${node.url}`
+                    )
+                  : node.url
+                const asset = path.posix.join('website/docs/cli', assetPath)
+                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
 
-export async function getStaticProps({ params }) {
-  const props = await generateStaticProps({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    params,
-    product: PRODUCT,
-    githubFileUrl(path) {
-      const filepath = path.replace('content/', '')
-      return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/docs/${filepath}`
-    },
-  })
-  return { props }
-}
+If this is a net-new asset, it may not be available in the preview yet.`)
+              })
+            }
+          },
+        ],
+      }
+    : {
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: PRODUCT.slug,
+      }
+)
+
+export { getStaticPaths, getStaticProps }

--- a/pages/internals/[[...page]].jsx
+++ b/pages/internals/[[...page]].jsx
@@ -2,8 +2,8 @@ import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
-import visit from 'unist-util-visit'
 import path from 'path'
+import { remarkRewriteAssets } from 'lib/remark-rewrite-assets'
 
 //  Configure the docs path
 const BASE_ROUTE = 'internals'
@@ -35,29 +35,11 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
         },
         remarkPlugins: (params) => [
-          () => {
-            const product = PRODUCT.slug
-            const version = process.env.CURRENT_GIT_BRANCH
-            return function transform(tree) {
-              visit(tree, 'image', (node) => {
-                const originalUrl = node.url
-                const asset = path.posix.join('website', originalUrl)
-                const url = new URL(
-                  'https://mktg-content-api.vercel.app/api/assets'
-                )
-                url.searchParams.append('asset', asset)
-                url.searchParams.append('version', version)
-                url.searchParams.append('product', product)
-
-                node.url = url.toString()
-                console.log(`Rewriting asset url for local preview:
-- Found: ${originalUrl}
-- Replaced with: ${node.url}
-
-If this is a net-new asset, you'll need to commit and push it to GitHub.`)
-              })
-            }
-          },
+          remarkRewriteAssets({
+            product: PRODUCT.slug,
+            version: process.env.CURRENT_GIT_BRANCH,
+            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+          }),
         ],
       }
     : {

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -2,15 +2,14 @@ import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
-import {
-  generateStaticPaths,
-  generateStaticProps,
-} from '@hashicorp/react-docs-page/server'
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+import visit from 'unist-util-visit'
+import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'intro'
-const NAV_DATA = 'data/intro-nav-data.json'
-const CONTENT_DIR = 'content/intro'
+const NAV_DATA = process.env.NAV_DATA_PATH || '../data/intro-nav-data.json'
+const CONTENT_DIR = process.env.CONTENT_DIR || '../content/intro'
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function IntroLayout(props) {
@@ -27,25 +26,51 @@ export default function IntroLayout(props) {
   )
 }
 
-export async function getStaticPaths() {
-  const paths = await generateStaticPaths({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    product: PRODUCT,
-  })
-  return { paths, fallback: false }
-}
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW
+    ? {
+        strategy: 'fs',
+        basePath: BASE_ROUTE,
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: PRODUCT.slug,
+        githubFileUrl(filepath) {
+          // This path rewriting is meant for local preview from `terraform`.
+          filepath = filepath.replace('preview/', '')
+          return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
+        },
+        remarkPlugins: (params) => [
+          () => {
+            const product = PRODUCT.slug
+            const version = 'main'
+            return function transform(tree) {
+              visit(tree, 'image', (node) => {
+                const originalUrl = node.url
+                const assetPath = params.page
+                  ? path.posix.join(
+                      ...params.page,
+                      node.url.startsWith('.')
+                        ? `.${node.url}`
+                        : `../${node.url}`
+                    )
+                  : node.url
+                const asset = path.posix.join('website/docs/cli', assetPath)
+                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
 
-export async function getStaticProps({ params }) {
-  const props = await generateStaticProps({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    params,
-    product: PRODUCT,
-    githubFileUrl(path) {
-      const filepath = path.replace('content/', '')
-      return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
-    },
-  })
-  return { props }
-}
+If this is a net-new asset, it may not be available in the preview yet.`)
+              })
+            }
+          },
+        ],
+      }
+    : {
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: PRODUCT.slug,
+      }
+)
+
+export { getStaticPaths, getStaticProps }

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -49,7 +49,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -8,8 +8,8 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'intro'
-const NAV_DATA = process.env.NAV_DATA_PATH || '../data/intro-nav-data.json'
-const CONTENT_DIR = process.env.CONTENT_DIR || '../content/intro'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function IntroLayout(props) {
@@ -27,7 +27,7 @@ export default function IntroLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -8,7 +8,10 @@ import path from 'path'
 
 //  Configure the docs path
 const BASE_ROUTE = 'intro'
-const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const NAV_DATA = path.join(
+  process.env.NAV_DATA_DIRNAME,
+  BASE_ROUTE + '-nav-data.json'
+)
 const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
@@ -27,7 +30,8 @@ export default function IntroLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,
@@ -42,20 +46,19 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
         remarkPlugins: (params) => [
           () => {
             const product = PRODUCT.slug
-            const version = 'main'
+            const version = process.env.CURRENT_GIT_BRANCH
             return function transform(tree) {
               visit(tree, 'image', (node) => {
                 const originalUrl = node.url
-                const assetPath = params.page
-                  ? path.posix.join(
-                      ...params.page,
-                      node.url.startsWith('.')
-                        ? `.${node.url}`
-                        : `../${node.url}`
-                    )
-                  : node.url
-                const asset = path.posix.join('website/docs/cli', assetPath)
-                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                const asset = path.posix.join('website', originalUrl)
+                const url = new URL(
+                  'https://mktg-content-api.vercel.app/api/assets'
+                )
+                url.searchParams.append('asset', asset)
+                url.searchParams.append('version', version)
+                url.searchParams.append('product', product)
+
+                node.url = url.toString()
                 console.log(`Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -63,7 +63,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/intro/[[...page]].jsx
+++ b/pages/intro/[[...page]].jsx
@@ -6,6 +6,8 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 import visit from 'unist-util-visit'
 import path from 'path'
 
+import { remarkRewriteAssets } from 'lib/remark-rewrite-assets'
+
 //  Configure the docs path
 const BASE_ROUTE = 'intro'
 const NAV_DATA = path.join(
@@ -44,29 +46,11 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
         },
         remarkPlugins: (params) => [
-          () => {
-            const product = PRODUCT.slug
-            const version = process.env.CURRENT_GIT_BRANCH
-            return function transform(tree) {
-              visit(tree, 'image', (node) => {
-                const originalUrl = node.url
-                const asset = path.posix.join('website', originalUrl)
-                const url = new URL(
-                  'https://mktg-content-api.vercel.app/api/assets'
-                )
-                url.searchParams.append('asset', asset)
-                url.searchParams.append('version', version)
-                url.searchParams.append('product', product)
-
-                node.url = url.toString()
-                console.log(`Rewriting asset url for local preview:
-- Found: ${originalUrl}
-- Replaced with: ${node.url}
-
-If this is a net-new asset, you'll need to commit and push it to GitHub.`)
-              })
-            }
-          },
+          remarkRewriteAssets({
+            product: PRODUCT.slug,
+            version: process.env.CURRENT_GIT_BRANCH,
+            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+          }),
         ],
       }
     : {

--- a/pages/language/[[...page]].jsx
+++ b/pages/language/[[...page]].jsx
@@ -4,8 +4,8 @@ import ProviderTable from 'components/provider-table'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
-import visit from 'unist-util-visit'
 import path from 'path'
+import { remarkRewriteAssets } from 'lib/remark-rewrite-assets'
 
 //  Configure the path
 const BASE_ROUTE = 'language'
@@ -46,29 +46,11 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
         },
         remarkPlugins: (params) => [
-          () => {
-            const product = PRODUCT.slug
-            const version = process.env.CURRENT_GIT_BRANCH
-            return function transform(tree) {
-              visit(tree, 'image', (node) => {
-                const originalUrl = node.url
-                const asset = path.posix.join('website', originalUrl)
-                const url = new URL(
-                  'https://mktg-content-api.vercel.app/api/assets'
-                )
-                url.searchParams.append('asset', asset)
-                url.searchParams.append('version', version)
-                url.searchParams.append('product', product)
-
-                node.url = url.toString()
-                console.log(`Rewriting asset url for local preview:
-- Found: ${originalUrl}
-- Replaced with: ${node.url}
-
-If this is a net-new asset, you'll need to commit and push it to GitHub.`)
-              })
-            }
-          },
+          remarkRewriteAssets({
+            product: PRODUCT.slug,
+            version: process.env.CURRENT_GIT_BRANCH,
+            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+          }),
         ],
       }
     : {

--- a/pages/language/[[...page]].jsx
+++ b/pages/language/[[...page]].jsx
@@ -65,7 +65,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
 - Found: ${originalUrl}
 - Replaced with: ${node.url}
 
-If this is a net-new asset, it may not be available in the preview yet.`)
+If this is a net-new asset, you'll need to commit and push it to GitHub.`)
               })
             }
           },

--- a/pages/language/[[...page]].jsx
+++ b/pages/language/[[...page]].jsx
@@ -9,8 +9,8 @@ import path from 'path'
 
 //  Configure the path
 const BASE_ROUTE = 'language'
-const NAV_DATA = process.env.NAV_DATA_PATH || '../data/language-nav-data.json'
-const CONTENT_DIR = process.env.CONTENT_DIR || '../content/language'
+const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
 export default function LanguageLayout(props) {
@@ -29,7 +29,7 @@ export default function LanguageLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW
+  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,

--- a/pages/language/[[...page]].jsx
+++ b/pages/language/[[...page]].jsx
@@ -49,7 +49,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: PRODUCT.slug,
             version: process.env.CURRENT_GIT_BRANCH,
-            assetPathBuilder: (nodeUrl) => ['website', nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }

--- a/pages/language/[[...page]].jsx
+++ b/pages/language/[[...page]].jsx
@@ -3,18 +3,17 @@ import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
-import {
-  generateStaticPaths,
-  generateStaticProps,
-} from '@hashicorp/react-docs-page/server'
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+import visit from 'unist-util-visit'
+import path from 'path'
 
 //  Configure the path
 const BASE_ROUTE = 'language'
-const NAV_DATA = 'data/language-nav-data.json'
-const CONTENT_DIR = 'content/language'
+const NAV_DATA = process.env.NAV_DATA_PATH || '../data/language-nav-data.json'
+const CONTENT_DIR = process.env.CONTENT_DIR || '../content/language'
 const PRODUCT = { name: productName, slug: productSlug }
 
-function LanguageLayout(props) {
+export default function LanguageLayout(props) {
   // add the "other docs" section to the bottom of the nav data
   const modifiedProps = Object.assign({}, props)
   modifiedProps.navData = modifiedProps.navData.concat(otherDocsData)
@@ -29,27 +28,51 @@ function LanguageLayout(props) {
   )
 }
 
-export async function getStaticPaths() {
-  const paths = await generateStaticPaths({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    product: PRODUCT
-  })
-  return { paths, fallback: false }
-}
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW
+    ? {
+        strategy: 'fs',
+        basePath: BASE_ROUTE,
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: PRODUCT.slug,
+        githubFileUrl(filepath) {
+          // This path rewriting is meant for local preview from `terraform`.
+          filepath = filepath.replace('preview/', '')
+          return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/${filepath}`
+        },
+        remarkPlugins: (params) => [
+          () => {
+            const product = PRODUCT.slug
+            const version = 'main'
+            return function transform(tree) {
+              visit(tree, 'image', (node) => {
+                const originalUrl = node.url
+                const assetPath = params.page
+                  ? path.posix.join(
+                      ...params.page,
+                      node.url.startsWith('.')
+                        ? `.${node.url}`
+                        : `../${node.url}`
+                    )
+                  : node.url
+                const asset = path.posix.join('website/docs/cli', assetPath)
+                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                console.log(`Rewriting asset url for local preview:
+- Found: ${originalUrl}
+- Replaced with: ${node.url}
 
-export async function getStaticProps({ params }) {
-  const props = await generateStaticProps({
-    navDataFile: NAV_DATA,
-    localContentDir: CONTENT_DIR,
-    params,
-    product: PRODUCT,
-    githubFileUrl(path) {
-      const filepath = path.replace('content/', '')
-      return `https://github.com/hashicorp/${PRODUCT.slug}/blob/main/website/docs/${filepath}`
-    },
-  })
-  return { props }
-}
+If this is a net-new asset, it may not be available in the preview yet.`)
+              })
+            }
+          },
+        ],
+      }
+    : {
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: PRODUCT.slug,
+      }
+)
 
-export default LanguageLayout
+export { getStaticPaths, getStaticProps }

--- a/pages/language/[[...page]].jsx
+++ b/pages/language/[[...page]].jsx
@@ -9,7 +9,10 @@ import path from 'path'
 
 //  Configure the path
 const BASE_ROUTE = 'language'
-const NAV_DATA = path.join(process.env.NAV_DATA_DIRNAME, BASE_ROUTE + '-nav-data.json')
+const NAV_DATA = path.join(
+  process.env.NAV_DATA_DIRNAME,
+  BASE_ROUTE + '-nav-data.json'
+)
 const CONTENT_DIR = path.join(process.env.CONTENT_DIRNAME, BASE_ROUTE)
 const PRODUCT = { name: productName, slug: productSlug }
 
@@ -29,7 +32,8 @@ export default function LanguageLayout(props) {
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
-  process.env.IS_CONTENT_PREVIEW && process.env.PREVIEW_FROM_REPO === 'terraform'
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === 'terraform'
     ? {
         strategy: 'fs',
         basePath: BASE_ROUTE,
@@ -44,20 +48,19 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
         remarkPlugins: (params) => [
           () => {
             const product = PRODUCT.slug
-            const version = 'main'
+            const version = process.env.CURRENT_GIT_BRANCH
             return function transform(tree) {
               visit(tree, 'image', (node) => {
                 const originalUrl = node.url
-                const assetPath = params.page
-                  ? path.posix.join(
-                      ...params.page,
-                      node.url.startsWith('.')
-                        ? `.${node.url}`
-                        : `../${node.url}`
-                    )
-                  : node.url
-                const asset = path.posix.join('website/docs/cli', assetPath)
-                node.url = `https://mktg-content-api.vercel.app/api/assets?product=${product}&version=${version}&asset=${asset}`
+                const asset = path.posix.join('website', originalUrl)
+                const url = new URL(
+                  'https://mktg-content-api.vercel.app/api/assets'
+                )
+                url.searchParams.append('asset', asset)
+                url.searchParams.append('version', version)
+                url.searchParams.append('product', product)
+
+                node.url = url.toString()
                 console.log(`Rewriting asset url for local preview:
 - Found: ${originalUrl}
 - Replaced with: ${node.url}

--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 function checkEnvVars() {
   // Filter out defined env vars, leaving only the missing ones
-  const missingEnvVars = ['REPO', 'IS_CONTENT_PREVIEW'].filter(
+  const missingEnvVars = ['IS_CONTENT_PREVIEW'].filter(
     (key) => !process.env[key]
   )
 
@@ -26,8 +26,6 @@ async function main() {
     return
   }
 
-  const repo = process.env.REPO
-
   // our CWD
   const cwd = process.cwd()
 
@@ -41,36 +39,19 @@ async function main() {
   }
 
   // copy public files
-  console.log('📝 copying files in the public folder')
+  console.log('📝 Copying files from "./public" to "../"')
   execFileSync('cp', ['-R', './public', '../'])
-
-  /**
-   * Remove dirs in `src/pages` which are not associated with the product
-   */
-  const pagesDir = path.join(cwd, 'pages')
-
-  const pagesDirs = (
-    await fs.promises.readdir(pagesDir, { withFileTypes: true })
-  ).filter((ent) => ent.isDirectory())
-
-  // TODO(kevinwang): temporarily disabling this to test `terraform` deploy previews
-  // for (const dir of pagesDirs) {
-  //   if (!dir.name.includes(repo) && dir.name !== 'home') {
-  //     console.log(`🧹 removing pages for ${dir.name}`)
-  //     await fs.promises.rm(path.join(pagesDir, dir.name), {
-  //       recursive: true,
-  //     })
-  //   }
-  // }
 
   /** Install deps */
   console.log('📦 Installing dependencies')
   execFileSync('npm', ['install', '--production=false'], { stdio: 'inherit' })
 
   /** Build */
+  console.log('🏗️  Building project')
   execFileSync('npm', ['run', 'build'], { stdio: 'inherit' })
 
   // Put node_modules into .next/cache so we can retrieve them on subsequent builds
+  console.log('🐿 Copying "node_modules" to ".next/cache"')
   execFileSync('cp', ['-R', 'node_modules', '.next/cache'], {
     stdio: 'inherit',
   })

--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -53,14 +53,15 @@ async function main() {
     await fs.promises.readdir(pagesDir, { withFileTypes: true })
   ).filter((ent) => ent.isDirectory())
 
-  for (const dir of pagesDirs) {
-    if (!dir.name.includes(repo) && dir.name !== 'home') {
-      console.log(`🧹 removing pages for ${dir.name}`)
-      await fs.promises.rm(path.join(pagesDir, dir.name), {
-        recursive: true,
-      })
-    }
-  }
+  // TODO(kevinwang): temporarily disabling this to test `terraform` deploy previews
+  // for (const dir of pagesDirs) {
+  //   if (!dir.name.includes(repo) && dir.name !== 'home') {
+  //     console.log(`🧹 removing pages for ${dir.name}`)
+  //     await fs.promises.rm(path.join(pagesDir, dir.name), {
+  //       recursive: true,
+  //     })
+  //   }
+  // }
 
   /** Install deps */
   console.log('📦 Installing dependencies')


### PR DESCRIPTION
# Description

This removes the `ext/terraform` submodule
This removes symlinks to `ext/terraform` in `data` and `content`

This updates the following pages to use remote content
- cli/
- configuration/
- guides/
- internals/
- intro/
- language/

---

Blocks
- https://github.com/hashicorp/terraform/pull/30814
- https://github.com/hashicorp/terraform-cdk/pull/1693
- https://github.com/hashicorp/terraform-website/pull/2244