### PR TITLE
Fix Broken Links

### DIFF
--- a/content/cloud-docs/api-docs/changelog.mdx
+++ b/content/cloud-docs/api-docs/changelog.mdx
@@ -22,7 +22,7 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 * Introduced [Archiving Configuration Versions](/cloud-docs/workspaces/configurations#archiving-configuration-versions).
   * Updated [Configuration Versions](/cloud-docs/api-docs/configuration-versions#attributes) to add new `fetching` and `archived` states.
-  * Updated [Runs](/cloud-docs/api-docs/runs#attributes) to add new `fetching` state.
+  * Updated [Runs](/cloud-docs/api-docs/run#attributes) to add new `fetching` state.
   * Added the [Archive a Configuration Version](/cloud-docs/api-docs/configuration-versions#archive-a-configuration-version) endpoint.
 
 ### 2021-12-09

--- a/content/cloud-docs/api-docs/private-registry/gpg-keys.mdx
+++ b/content/cloud-docs/api-docs/private-registry/gpg-keys.mdx
@@ -38,7 +38,7 @@ description: >-
 
 # GPG Keys API
 
-These endpoints are only relevant to private providers. When you [publish a private provider](/cloud-docs/registry/publish-providers) to the Terraform Cloud private registry, you must upload the public key of the GPG keypair used to sign the release. Refer to [Preparing and Adding a Signing Key](registry/providers/publishing#preparing-and-adding-a-signing-key) for more details.
+These endpoints are only relevant to private providers. When you [publish a private provider](/cloud-docs/registry/publish-providers) to the Terraform Cloud private registry, you must upload the public key of the GPG keypair used to sign the release. Refer to [Preparing and Adding a Signing Key](/registry/providers/publishing#preparing-and-adding-a-signing-key) for more details.
 
 
 You need [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or [Manage Private Registry](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) permissions to add, update, or delete GPG keys in a private registry.
@@ -53,7 +53,7 @@ You need [owners team](/cloud-docs/users-teams-organizations/permissions#organiz
 | -------------------- | -------------------- |
 | `:registry_name`     | Must be `private`.   |
 
-Uploads a GPG Key to a private registry scoped with a namespace. The response will provide a "key-id", which is required to [Create a Provider Version](#create-a-provider-version) (see below).
+Uploads a GPG Key to a private registry scoped with a namespace. The response will provide a "key-id", which is required to [Create a Provider Version](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version).
 
 | Status  | Response                                                   | Reason                                                         |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------- |

--- a/content/cloud-docs/api-docs/private-registry/providers.mdx
+++ b/content/cloud-docs/api-docs/private-registry/providers.mdx
@@ -181,7 +181,7 @@ curl \
 
 The private provider record will be available in the organization's registry provider list immediately after creation, but you must create a version and upload all necessary release assets before consumers can use the provider in configurations. Release assets include the `SHA256SUMS` file, the `SHA256SUMS.sig` file, and the GPG signing key. Refer to the [Publishing a Private Provider](/cloud-docs/registry/publish-providers) documentation for more details.
 
-The private registry does not automatically update private providers when you release new versions. You must explicitly create and upload each new version with the [Create a Provider Version](/cloud-docs/api-docs-private-registry/provider-versions-and-platforms#create-a-provider-version-private-provider) endpoint.
+The private registry does not automatically update private providers when you release new versions. You must explicitly create and upload each new version with the [Create a Provider Version](/cloud-docs/api-docs/private-registry/provider-versions-and-platforms#create-a-provider-version) endpoint.
 
 #### Public Providers
 

--- a/content/cloud-docs/api-docs/private-registry/providers.mdx
+++ b/content/cloud-docs/api-docs/private-registry/providers.mdx
@@ -181,7 +181,7 @@ curl \
 
 The private provider record will be available in the organization's registry provider list immediately after creation, but you must create a version and upload all necessary release assets before consumers can use the provider in configurations. Release assets include the `SHA256SUMS` file, the `SHA256SUMS.sig` file, and the GPG signing key. Refer to the [Publishing a Private Provider](/cloud-docs/registry/publish-providers) documentation for more details.
 
-The private registry does not automatically update private providers when you release new versions. You must explicitly create and upload each new version with the [Create a Provider Version](/cloud-docs/api-docs/private-registry/provider-versions-and-platforms#create-a-provider-version) endpoint.
+The private registry does not automatically update private providers when you release new versions. You must explicitly create and upload each new version with the [Create a Provider Version](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) endpoint.
 
 #### Public Providers
 

--- a/content/cloud-docs/integrations/run-tasks/index.mdx
+++ b/content/cloud-docs/integrations/run-tasks/index.mdx
@@ -85,11 +85,11 @@ $ echo -n $WEBHOOK_BODY | openssl dgst -sha512 -hmac "$HMAC_KEY"
 ## HCP Packer Run Task
 > **Hands On:** Try the [Set Up Terraform Cloud Run Task for HCP Packer](https://learn.hashicorp.com/tutorials/packer/setup-tfc-run-task), [Standard tier run task image validation](https://learn.hashicorp.com/tutorials/packer/run-tasks-data-source-image-validation), and [Plus tier run task image validation](https://learn.hashicorp.com/tutorials/packer/run-tasks-resource-image-validation) tutorials on HashiCorp Learn to set up and test the Terraform Cloud Run Task integration end to end.
 
-[Packer](https://www.packer.io/) lets you create identical machine images for multiple platforms from a single source template. The [HCP Packer registry](docs/packer) lets you track golden images, designate images for test and production environments, and query images to use in Packer and Terraform configurations.
+[Packer](https://www.packer.io/) lets you create identical machine images for multiple platforms from a single source template. The [HCP Packer registry](https://cloud.hashicorp.com/docs/packer) lets you track golden images, designate images for test and production environments, and query images to use in Packer and Terraform configurations.
 
 The HCP Packer validation run task checks the image artifacts within a Terraform configuration. If the configuration references images marked as unusable (revoked), the run task fails and provides an error message containing the number of revoked artifacts and whether HCP Packer has metadata for newer versions. For HCP Packer Plus registries, run tasks also help you identify hardcoded and untracked images that may not meet security and compliance requirements.
 
-To get started, [create an HCP Packer account](/products/packer) and follow the instructions in the [HCP Packer Run Task](https://cloud.hashicorp.com/docs/packer/manage-image-use/terraform-cloud-run-tasks) documentation.
+To get started, [create an HCP Packer account](https://cloud.hashicorp.com/products/packer) and follow the instructions in the [HCP Packer Run Task](https://cloud.hashicorp.com/docs/packer/manage-image-use/terraform-cloud-run-tasks) documentation.
 
 ## Run Tasks Technology Partners
 

--- a/content/enterprise/user-management/saml/idp-configuration/onelogin.mdx
+++ b/content/enterprise/user-management/saml/idp-configuration/onelogin.mdx
@@ -31,10 +31,8 @@ Verify the endpoint URLs, certificate, and attribute mappings are correct in the
 
 ## Additional Resources
 
-The following pages in the OneLogin documentation are relevant to using SAML SSO with Terraform Enterprise:
+[Create Mappings to Automatically Assign Roles to Users](https://onelogin.service-now.com/kb_view_customer.do?sysparm_article=KB0010625)
 
-* [Create Mappings to Automatically Assign Roles to Users](https://support.onelogin.com/hc/en-us/articles/211531266-User-Provisioning-An-End-to-End-Flow#create-mappings)
-* [Using Regex to Provision Members of AD/LDAP Groups to New App Groups](https://support.onelogin.com/hc/en-us/articles/209887623-Using-Regex-to-Provision-Members-of-AD-LDAP-Groups-to-New-App-Groups)
 
 ## Example SAMLResponse
 


### PR DESCRIPTION
Monthly manual link check - this PR fixes all of the broken links that I found. In one case, it removes an article mention from TFE OneLogin documentation as that article appears to no longer exist (the link to it from the OneLogin site also produces a "page not found" error). 