### PR TITLE
fix(redirects): check for absolute URLs

### DIFF
--- a/pages/docs/_middleware.ts
+++ b/pages/docs/_middleware.ts
@@ -22,7 +22,7 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
 
     for (const key of [path, pathIndexHtml, pathHtml]) {
       if (key in docsRedirects) {
-        const destination = doscRedirects[key]
+        const destination = docsRedirects[key]
         
         if (destination.startsWith('https://')) {
           // If the URL is NOT relative, don't construct a new URL from the current one. This prevents

--- a/pages/docs/_middleware.ts
+++ b/pages/docs/_middleware.ts
@@ -24,7 +24,7 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
       if (key in docsRedirects) {
         const destination = docsRedirects[key]
         
-        if (destination.startsWith('https://')) {
+        if (destination.startsWith('https://') || destination.startsWith('http://')) {
           // If the URL is NOT relative, don't construct a new URL from the current one. This prevents
           // learn redirects from going to https://terraform.io/https://learn.hashicorp.com/..., for example.
           return NextResponse.redirect(destination, 308)

--- a/pages/docs/_middleware.ts
+++ b/pages/docs/_middleware.ts
@@ -33,7 +33,7 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
         // cloning the URL so we can provide an absolute URL to the .redirect() call,
         // per: https://nextjs.org/docs/messages/middleware-relative-urls
         const newUrl = req.nextUrl.clone()
-        newUrl.pathname = docsRedirects[key]
+        newUrl.pathname = destination
         return NextResponse.redirect(newUrl, 308)
       }
     }

--- a/pages/docs/_middleware.ts
+++ b/pages/docs/_middleware.ts
@@ -22,6 +22,14 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
 
     for (const key of [path, pathIndexHtml, pathHtml]) {
       if (key in docsRedirects) {
+        const destination = doscRedirects[key]
+        
+        if (destination.startsWith('https://')) {
+          // If the URL is NOT relative, don't construct a new URL from the current one. This prevents
+          // learn redirects from going to https://terraform.io/https://learn.hashicorp.com/..., for example.
+          return NextResponse.redirect(destination, 308)
+        }
+        
         // cloning the URL so we can provide an absolute URL to the .redirect() call,
         // per: https://nextjs.org/docs/messages/middleware-relative-urls
         const newUrl = req.nextUrl.clone()


### PR DESCRIPTION
Correctly handle absolute URL redirect destinations, instead of appending them to the current domain.

* Navigate to: https://terraform-website-git-brkfix-middleware-redire-62e8ae-hashicorp.vercel.app/guides/writing-custom-terraform-providers.html
* Validate that you correctly get redirected to learn

closes #2230