### PR TITLE
Update API docs and Publishing Private Providers to make process clearer

### DIFF
--- a/content/cloud-docs/api-docs/private-registry/gpg-keys.mdx
+++ b/content/cloud-docs/api-docs/private-registry/gpg-keys.mdx
@@ -40,7 +40,6 @@ description: >-
 
 These endpoints are only relevant to private providers. When you [publish a private provider](/cloud-docs/registry/publish-providers) to the Terraform Cloud private registry, you must upload the public key of the GPG keypair used to sign the release. Refer to [Preparing and Adding a Signing Key](/registry/providers/publishing#preparing-and-adding-a-signing-key) for more details.
 
-
 You need [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or [Manage Private Registry](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) permissions to add, update, or delete GPG keys in a private registry.
 
 ## Add a GPG Key

--- a/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
@@ -47,6 +47,8 @@ All members of an organization can view and use both public and private provider
 
 `POST /organizations/:organization_name/registry-providers/:registry_name/:namespace/:name/versions`
 
+The private registry does not automatically update private providers when you release new versions. You must use this endpoint to add each new version. Consumers cannot use new versions until you upload all [required release files](/cloud-docs/registry/publish-providers#release-files) and [Create a Provider Platform](#create-a-provider-platform).
+
 ### Parameters
 
 | Parameter            | Description                                                                                                                                                                                                |
@@ -396,6 +398,12 @@ curl \
 ## Create a Provider Platform
 
 `POST /organizations/:organization_name/registry-providers/:registry_name/:namespace/:name/versions/:version/platforms`
+
+Platforms are binaries that allow the provider to run on a particular operating system and architecture combination (e.g., Linux and AMD64). GoReleaser creates binaries automatically when you [create a release on GitHub](/registry/providers/publishing#creating-a-github-release) or [create a release locally](/registry/providers/publishing#using-goreleaser-locally).
+
+You must upload one or more platforms for each version of a private provider. After you create a platform, you must upload the platform binary file to the `provider-binary-upload` URL.
+
+
 
 ### Parameters
 

--- a/content/cloud-docs/api-docs/private-registry/providers.mdx
+++ b/content/cloud-docs/api-docs/private-registry/providers.mdx
@@ -169,6 +169,12 @@ curl \
 
 `POST /organizations/:organization_name/registry-providers`
 
+Use this endpoint to create both public and private providers:
+
+- **Public providers:** The public provider record will be available in the organization's registry provider list immediately after creation. You cannot create versions for public providers; you must use the versions available on the Terraform Registry.
+- **Private providers:** The private provider record will be available in the organization's registry provider list immediately after creation, but you must [create a version and upload release assets](/cloud-docs/registry/publish-providers#publishing-a-provider-and-creating-a-version) before consumers can use it. The private registry does not automatically update private providers when you release new versions. You must add each new version with the [Create a Provider Version](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) endpoint.
+
+
 ### Parameters
 
 | Parameter            | Description                                                                                                                                                                                                |
@@ -177,15 +183,6 @@ curl \
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-#### Private Providers
-
-The private provider record will be available in the organization's registry provider list immediately after creation, but you must create a version and upload all necessary release assets before consumers can use the provider in configurations. Release assets include the `SHA256SUMS` file, the `SHA256SUMS.sig` file, and the GPG signing key. Refer to the [Publishing a Private Provider](/cloud-docs/registry/publish-providers) documentation for more details.
-
-The private registry does not automatically update private providers when you release new versions. You must explicitly create and upload each new version with the [Create a Provider Version](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) endpoint.
-
-#### Public Providers
-
-When created, the public provider record will be available in the organization's registry provider list. You cannot create versions for public providers; you must use the versions available on the Terraform Registry.
 
 | Status  | Response                                             | Reason                                                         |
 | ------- | ---------------------------------------------------- | -------------------------------------------------------------- |
@@ -195,6 +192,8 @@ When created, the public provider record will be available in the organization's
 | [404][] | [JSON API error object][]                            | User not authorized                                            |
 
 ### Request Body
+
+~> **Important:** For private providers, you must also create a version, a platform, and upload release assets before consumers can use the provider. Refer to [Publishing a Private Provider](/cloud-docs/registry/publish-providers) for more details.
 
 This POST endpoint requires a JSON object with the following properties as a request payload.
 

--- a/content/cloud-docs/registry/publish-providers.mdx
+++ b/content/cloud-docs/registry/publish-providers.mdx
@@ -13,7 +13,7 @@ In addition to [curating public providers from the Terraform Registry](/cloud-do
 
 ## Requirements
 
-Review the following before publishing a new provider.
+Review the following before publishing a new provider or provider version.
 
 ### Permissions
 
@@ -29,18 +29,27 @@ Private providers do not currently support documentation.
 
 GPG signing is required for private providers, and you must upload the public key of the GPG keypair used to sign the release. Refer to [Preparing and Adding a Signing Key](/registry/providers/publishing#preparing-and-adding-a-signing-key) for more details. Unlike the public Terraform Registry, the private registry does not automatically upload new releases. You must manually add new provider versions and the associated release files.
 
-## Publishing a Provider and Creating a Version
+## Publishing a Provider
 
-You must create a provider, at least one version, and at least one platform for that version before consumers can use the provider in configurations. Before you begin, confirm that you can access the provider binaries, public GPG signing key, `SHA256SUMS` file, and `SHA256SUMS.sig` file from at least one release. You will upload these artifacts in the following steps.
+Before consumers can use a private provider, you must create the provider, upload a GPG signing key, create at least one version, create at least one platform for that version, and upload release files.
 
-To publish a new provider through the Terraform Cloud API:
+### Create a Provider
+
+Use the [Create a Provider endpoint](/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in Terraform Cloud.
+
+The provider is available in your organization’s Terraform Cloud private registry, but consumers cannot use it until you add a version and a platform.
+
+### Create a Version and Platform
+
+To create a version, a platform, and upload the required release files:
+
+1. Confirm that you can access the provider binaries, public GPG signing key, `SHA256SUMS` file, and `SHA256SUMS.sig` file from at least one release.
 
 1. Use the [Add a GPG key endpoint](/cloud-docs/api-docs/private-registry/gpg-keys#add-a-gpg-key) to add the public key that matches the signing key for the release. The response contains a `key-id` that you will use to create a provider version.
 
     ```json
     "key-id": "32966F3FB5AC1129"
     ```
-1. Use the [Create a Provider endpoint](/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in Terraform Cloud. 
 
 1. Use the [Create a Provider Version endpoint](/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version with the `key-id` from the previous step. The response includes URL links that you will use to upload the `SHA256SUMS` and `SHA256.sig` files.
 
@@ -75,7 +84,7 @@ To publish a new provider through the Terraform Cloud API:
 
 1. (Optional) Repeat steps 4 and 5 to add additional platform binaries for the release.
 
-The provider is available in your organization’s Terraform Cloud private registry. Users can search for it in the private registry UI and begin using it in configurations.
+The version is available in the Terraform Cloud UI. Consumers can begin using this provider version in configurations.
 
 ## Checking Release Files
 


### PR DESCRIPTION
Adding a private provider is a more complex process than most users would expect. In order to make the provider usable, users need to:
- Release their provider with certain release artifacts
- Create the provider
- Create a provider version
- Create a provider platform
- Upload all the required release files

While we have a documentation page on this topic, recent user feedback let us know that many users skip right to the API endpoints (which makes total sense). Once they get there, the endpoints don't have enough context to help them understand the other process steps they must complete to make a private provider usable, leading to confusion down the line. 

This PR updates the API documentation and our existing "Publishing a Private Provider" page to hopefully help make the process clearer and lead users who skip right to the API endpoints through the process a bit more seamlessly.