### PR TITLE
Update variable-sets.mdx

### DIFF
--- a/content/cloud-docs/api-docs/variable-sets.mdx
+++ b/content/cloud-docs/api-docs/variable-sets.mdx
@@ -9,7 +9,7 @@ description: >-
 
 A [variable set](/cloud-docs/workspaces/variables#scope) is a resource that allows you to reuse the same variables across multiple workspaces. For example, you could define a variable set of provider credentials and automatically apply it to one or all workspaces.
 
-You need [`read variables` permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) to view the variables for a particular workspace and to view the variable sets in the owning organization. In order to create or edit variable sets a team, the user account is part of, needs to have at least `Manage Workspace` organizational access. A team's organizational access can be managed via the [Team Management](https://www.terraform.io/cloud-docs/users-teams-organizations/teams#managing-teams) settings page of the organization.
+You need [`read variables` permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) to view the variables for a particular workspace and to view the variable sets in the owning organization. To create or edit variable sets, your team must have [`Manage Workspace` organization access](/cloud-docs/users-teams-organizations/teams#managing-organization-access). 
 
 ## Create a Variable Set
 

--- a/content/cloud-docs/api-docs/variable-sets.mdx
+++ b/content/cloud-docs/api-docs/variable-sets.mdx
@@ -9,7 +9,7 @@ description: >-
 
 A [variable set](/cloud-docs/workspaces/variables#scope) is a resource that allows you to reuse the same variables across multiple workspaces. For example, you could define a variable set of provider credentials and automatically apply it to one or all workspaces.
 
-You need [`read variables` permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) to view the variables for a particular workspace and to view the variable sets in the owning organization. You need [read and write variables permissions](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) to create and edit variable sets.
+You need [`read variables` permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) to view the variables for a particular workspace and to view the variable sets in the owning organization. In order to create or edit variable sets a team, the user account is part of, needs to have at least `Manage Workspace` organizational access. A team's organizational access can be managed via the [Team Management](https://www.terraform.io/cloud-docs/users-teams-organizations/teams#managing-teams) settings page of the organization.
 
 ## Create a Variable Set
 


### PR DESCRIPTION
There is a small inaccuracy in the Variable Sets API docs.

Users with `read and write variables` team access cannot edit variable sets.

Variable sets themselves can be managed at the organizational level. A team needs to have at least Manage Workspaces organizational access to be able to edit variable sets. The read and write permissions in the workspace will allow the team to access the variables tab in the workspace and the variable sets could be edited from there thanks to the Manage Workspaces access.