### PR TITLE
plugin: Rework Documentation for Debugging Providers

### DIFF
--- a/content/plugin/debugging.mdx
+++ b/content/plugin/debugging.mdx
@@ -1,0 +1,163 @@
+---
+page_title: Plugin Development - Debugging Providers
+description: How to use both logs and debugging tools to debug Terraform providers.
+---
+
+# Debugging Providers
+
+This guide documents a few different ways to access more information about the
+runtime operations of Terraform providers. It is intended for Terraform
+provider developers, though sufficiently advanced users may also be able to use
+it.
+
+There are multiple available approaches to debugging Terraform providers, such as logging, using Terraform CLI development overrides, or debuggers.
+
+## Log-Based Debugging
+
+Log-based debugging is a method of using logging calls to record what is
+happening in a provider and then examining that record to diagnose issues. Logs can help you debug your provider without access to the environment or configuration.
+
+When developing your provider, think carefully about what information you will need for debugging. Log lines cannot be inserted into the binary after it has been built. You will need to add a new log line and recompile your provider for new information to be surfaced in log output.
+
+- [Managing Log Output](/plugin/log/managing) explains how to turn on logging, filter log output, choose the log format, and specify the log output path.
+- [Writing Log Output](/plugin/log/writing) contains details about how to use the [`tflog` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog) to write log output at varying verbosity levels, add variables to logs, and create subsystems to group logs that relate to distinct sections of code (e.g., the API client).
+
+## Terraform CLI Development Overrides
+
+Development overrides is a method of using a specified local filesystem Terraform provider binary with Terraform CLI, such as one locally built with updated code, rather than a released binary. This method of debugging allows the use of real-world configurations and Terraform CLI commands for reproduction. For automated testing, implement [acceptance testing](/plugin/sdkv2/testing/acceptance-tests) instead.
+
+To start, create a [Terraform CLI Configuration File](/cli/config/config-file) that includes a `provider_installation` block with a `dev_overrides` block. If the configuration file is created in your operating system user directory with the name `.terraformrc`, it will always be used, otherwise the `TF_CLI_CONFIG_FILE` environment variable must be set to the file location for the configuration to take effect.
+
+In this example, the `hashicorp/example` provider binary will be sourced from the local filesystem path `/home/example/go/bin/terraform-provider-example`, while others will be sourced normally:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "hashicorp/example" = "/home/example/go/bin"
+  }
+
+  direct {}
+}
+```
+
+Terraform CLI commands, such as `terraform apply`, will now use the specified provider binary. It is not necessary to run the `terraform init` command to use development overrides.
+
+Refer to the [Terraform CLI Configuration File documentation](/cli/config/config-file#development-overrides-for-provider-developers) for additional information about the configuration file and the developement overrides functionality.
+
+## Debugger-Based Debugging
+
+Debugger-based debugging is a method of using a debugging tool similar to
+[delve](https://github.com/go-delve/delve) to inspect what is happening in a
+provider as it is happening, often using breakpoints to pause execution of the
+provider and examine the values of variables. This method of debugging must be
+done contemporaneously; the developer doing the debugging needs to actively run
+Terraform using the appropriate configuration and in the appropriate
+environment to induce the behavior being examined. It is therefore most useful
+when a bug is reliably reproducible. This level of analysis enables developers to
+ask arbitrary questions and step through provider executions, allowing them to
+explore what is happening in the provider during runtime.
+
+-> **Note**: Debugger-based debugging only works with Terraform versions
+0.12.26 and higher.
+
+### Enabling Debugging In A Provider
+
+The code for enabling debugging is dependent on the provider implementation:
+
+* [terraform-plugin-framework](/plugin/framework/debugging): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
+* [terraform-plugin-go tf5server.WithManagedDebug()](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server#WithManagedDebug): A lower-level SDK to develop Terraform providers for more advanced use cases.
+* [terraform-plugin-go tf6server.WithManagedDebug()](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server#WithManagedDebug): A lower-level SDK to develop Terraform providers for more advanced use cases.
+* [terraform-plugin-sdk/v2](/plugin/sdkv2/debugging): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
+
+If the provider is using [combining and translating functionality](/plugin/mux), refer to these code implementation sections instead:
+
+* [tf5muxserver](/plugin/mux/combining-protocol-version-5-providers#code-implementation): A package to combine multiple protocol version 5 providers.
+* [tf5to6server](/plugin/mux/translating-protocol-version-5-to-6#code-implementation): A package to translate protocol version 5 providers into protocol version 6.
+* [tf6muxserver](/plugin/mux/combining-protocol-version-6-providers#code-implementation): A package to combine multiple protocol version 6 providers.
+* [tf6to5server](/plugin/mux/translating-protocol-version-6-to-5#code-implementation): A package to translate protocol version 6 providers into protocol version 5.
+
+It is important to start a provider in debug mode only when you intend
+to debug it, as its behavior will change in minor ways from normal operation of
+providers. The main differences are:
+
+* Terraform will not start the provider process; it must be run manually.
+* The provider's constraints will no longer be checked as part of `terraform
+  init`.
+* The provider will no longer be restarted once per walk of the Terraform
+  graph; instead the same provider process will be reused until the command is
+  completed.
+
+~> **Important:** You may need to disable compiler optimization and
+[inlining](https://en.wikipedia.org/wiki/Inline_expansion)
+to have the debugger work efficiently with the provider binary.
+To do so, build the provider binary with the necessary
+[Go compiler flags (gcflags)](https://golang.org/cmd/compile/):
+`go build -gcflags="all=-N -l"`
+
+### Starting A Provider In Debug Mode
+
+After you add a debug mode to your provider's `main` function, you can activate the debugger, which is typically built into an editor or the Delve CLI. To run your debugger, pass it the provider binary as the command to execute. Specify flags, environment variables, and any other input your provider needs to run.
+
+#### Visual Studio Code
+
+Visual Studio Code (VS Code) features native [debugging](https://code.visualstudio.com/docs/editor/debugging) support with the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go). You can create the necessary launch configuration within the repository as a `.vscode/launch.json` file, [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration), or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
+
+An example `.vscode/launch.json` configuration file:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}
+```
+
+Running the editor debugger will output the reattach configuration to the debug console.
+
+#### Delve CLI
+
+Start a [`delve`](https://github.com/go-delve/delve) debugging session:
+
+```sh
+$ dlv exec --accept-multiclient --continue --headless ./terraform-provider-example -- -debug
+```
+
+It will print output like the following to `stdout`:
+
+```
+Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:
+
+        TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}'
+```
+
+Connect your debugger, such as your editor or another delve CLI process, to the debugger server.
+
+For example with Delve CLI, using the server address and port output by `dlv exec` such as `API server listening at: 127.0.0.1:55413`:
+
+```shell
+dlv connect 127.0.0.1:55413
+```
+
+### Running Terraform With A Provider In Debug Mode
+
+Copy the line starting with `TF_REATTACH_PROVIDERS` from your provider's
+output. Either export it, or prefix every Terraform command with it:
+
+```sh
+TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}' terraform apply
+```
+
+Run Terraform as usual. Any breakpoints you have set will halt execution and
+show you the current variable values.

--- a/content/plugin/framework/debugging.mdx
+++ b/content/plugin/framework/debugging.mdx
@@ -1,0 +1,34 @@
+---
+page_title: Plugin Development - Debugging Framework Providers
+description: How to implement debugger support in Framework Terraform providers.
+---
+
+# Debugging Framework Providers
+
+This page contains implementation details for inspecting runtime information of a Terraform provider developed with Framework via a debugger tool. Review the top level [Debugging](/plugin/debugging) page for information pertaining to the overall Terraform provider debugging process and other inspection options, such as log-based debugging.
+
+## Code Implementation
+
+Update the `main` function for the project to conditionally enable the [`tfsdk/ServeOpts.Debug` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#ServeOpts.Debug). Conventionally, a `-debug` flag is used to control the `Debug` value.
+
+This example uses a `-debug` flag to enable debugging, otherwise starting the provider normally:
+
+```go
+func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := tfsdk.ServeOpts{
+		Debug: debug,
+		Name:  "registry.terraform.io/example-namespace/example",
+	}
+
+	err := tfsdk.Serve(context.Background(), provider.New(), opts)
+
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+```

--- a/content/plugin/sdkv2/debugging.mdx
+++ b/content/plugin/sdkv2/debugging.mdx
@@ -1,156 +1,31 @@
 ---
-page_title: Plugin Development - Debugging Providers
-description: How to use both logs and debugging tools to debug Terraform providers.
+page_title: Plugin Development - Debugging SDKv2 Providers
+description: How to implement debugger support in SDKv2 Terraform providers.
 ---
 
-# Debugging Providers
+# Debugging SDKv2 Providers
 
-This guide documents a few different ways to access more information about the
-runtime operations of Terraform providers. It is intended for Terraform
-provider developers, though sufficiently advanced users may also be able to use
-it.
+This page contains implementation details for inspecting runtime information of a Terraform provider developed with SDKv2 via a debugger tool. Review the top level [Debugging](/plugin/debugging) page for information pertaining to the overall Terraform provider debugging process and other inspection options, such as log-based debugging.
 
-There are two available approaches to debugging Terraform providers. We'll talk
-about each of them separately and in turn.
+## Code Implementation
 
-## Log-Based Debugging
+Update the `main` function for the project to conditionally enable the [`plugin/ServeOpts.Debug` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/plugin#ServeOpts.Debug). Conventionally, a `-debug` flag is used to control the `Debug` value.
 
-Log-based debugging is a method of using logging calls to record what is
-happening in a provider and then examining that record to diagnose issues. Logs can help you debug your provider without access to the environment or configuration.
-
-When developing your provider, think carefully about what information you will need for debugging. Log lines cannot be inserted into the binary after it has been built. You will need to add a new log line and recompile your provider for new information to be surfaced in log output.
-
-- [Managing Log Output](/plugin/log/managing) explains how to turn on logging, filter log output, choose the log format, and specify the log output path.
-- [Writing Log Output](/plugin/log/writing) contains details about how to use the [`tflog` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog) to write log output at varying verbosity levels, add variables to logs, and create subsystems to group logs that relate to distinct sections of code (e.g., the API client).
-
-## Debugger-Based Debugging
-
-Debugger-based debugging is a method of using a debugging tool similar to
-[delve](https://github.com/go-delve/delve) to inspect what is happening in a
-provider as it is happening, often using breakpoints to pause execution of the
-provider and examine the values of variables. This method of debugging must be
-done contemporaneously; the developer doing the debugging needs to actively run
-Terraform using the appropriate configuration and in the appropriate
-environment to induce the behavior being examined. It is therefore most useful
-when a bug is reliably reproducible. This level of analysis enables developers to
-ask arbitrary questions and step through provider executions, allowing them to
-explore what is happening in the provider during runtime.
-
--> **Note**: Debugger-based debugging only works with Terraform versions
-0.12.26 and higher.
-
-### Enabling Debugging In A Provider
-
-Debugging is available for providers using Terraform Plugin SDK versions 2.0.0
-and above. The plugin must also be started in debug
-mode, called `plugin.Debug` instead of `plugin.Serve`. We recommend that you
-enable this using a flag, as the provider should use `plugin.Serve` under
-normal operation, when not being debugged.
+This example uses a `-debug` flag to enable debugging, otherwise starting the provider normally:
 
 ```go
 func main() {
-	var debugMode bool
+	var debug bool
 
-	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	opts := &plugin.ServeOpts{ProviderFunc: provider.New}
-
-	if debugMode {
-		// TODO: update this string with the full name of your provider as used in your configs
-		err := plugin.Debug(context.Background(), "registry.terraform.io/my-org/my-provider", opts)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-		return
+	opts := &plugin.ServeOpts{
+		Debug:        debug,
+		ProviderAddr: "registry.terraform.io/example-namespace/example",
+		ProviderFunc: provider.New(),
 	}
 
 	plugin.Serve(opts)
 }
 ```
-
-It is important to start a provider in debug mode only when you intend
-to debug it, as its behavior will change in minor ways from normal operation of
-providers. The main differences are:
-
-* Terraform will not start the provider process; it must be run manually.
-* The provider's constraints will no longer be checked as part of `terraform
-  init`.
-* The provider will no longer be restarted once per walk of the Terraform
-  graph; instead the same provider process will be reused until the command is
-  completed.
-
-~> **Important:** You may need to disable compiler optimization and
-[inlining](https://en.wikipedia.org/wiki/Inline_expansion)
-to have the debugger work efficiently with the provider binary.
-To do so, build the provider binary with the necessary
-[Go compiler flags (gcflags)](https://golang.org/cmd/compile/):
-`go build -gcflags="all=-N -l"`
-
-### Starting A Provider In Debug Mode
-
-After you add a debug mode to your provider's `main` function, you can activate the debugger, which is typically built into an editor or the Delve CLI. To run your debugger, pass it the provider binary as the command to execute. Specify flags, environment variables, and any other input your provider needs to run.
-
-#### Visual Studio Code
-
-Visual Studio Code (VS Code) features native [debugging](https://code.visualstudio.com/docs/editor/debugging) support with the [Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go). You can create the necessary launch configuration within the repository as a `.vscode/launch.json` file, [user settings](https://code.visualstudio.com/docs/editor/debugging#_global-launch-configuration), or [workspace settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-launch-configurations).
-
-An example `.vscode/launch.json` configuration file:
-
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Debug Terraform Provider",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            // this assumes your workspace is the root of the repo
-            "program": "${workspaceFolder}",
-            "env": {},
-            "args": [
-                "-debug",
-            ]
-        }
-    ]
-}
-```
-
-Running the editor debugger will output the reattach configuration to the debug console.
-
-#### Delve CLI
-
-Start a [`delve`](https://github.com/go-delve/delve) debugging session:
-
-```sh
-$ dlv exec --accept-multiclient --continue --headless ./terraform-provider-example -- -debug
-```
-
-It will print output like the following to `stdout`:
-
-```
-Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:
-
-        TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}'
-```
-
-Connect your debugger, such as your editor or another delve CLI process, to the debugger server.
-
-For example with Delve CLI, using the server address and port output by `dlv exec` such as `API server listening at: 127.0.0.1:55413`:
-
-```shell
-dlv connect 127.0.0.1:55413
-```
-
-### Running Terraform With A Provider In Debug Mode
-
-Copy the line starting with `TF_REATTACH_PROVIDERS` from your provider's
-output. Either export it, or prefix every Terraform command with it:
-
-```sh
-TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}' terraform apply
-```
-
-Run Terraform as usual. Any breakpoints you have set will halt execution and
-show you the current variable values.

--- a/data/plugin-nav-data.json
+++ b/data/plugin-nav-data.json
@@ -215,6 +215,10 @@
       {
         "title": "Acceptance Tests",
         "path": "framework/acctests"
+      },
+      {
+        "title": "Debugging",
+        "path": "framework/debugging"
       }
     ]
   },
@@ -230,6 +234,10 @@
         "path": "log/writing"
       }
     ]
+  },
+  {
+    "title": "Debugging",
+    "path": "debugging"
   },
   {
     "title": "Combining and Translating",


### PR DESCRIPTION
### What

This includes the following changes:

- Lift and shift of /plugin/sdkv2/debugging to /plugin/debugging
- Recreate /plugin/sdkv2/debugging with specific code implementation
- Create /plugin/framework/debugging similar to /plugin/sdkv2/debugging
- Add Terraform CLI Develoment Overrides section to /plugin/debugging
- Replace SDKv2 code in Enabling Debugging In A Provider section of /plugin/debugging with links to all specific code implementations

### Why

Closes #2131

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.