### PR TITLE
Add log message

### DIFF
--- a/content/enterprise/releases/2022/v202204-1.mdx
+++ b/content/enterprise/releases/2022/v202204-1.mdx
@@ -21,11 +21,15 @@ The Terraform Enterprise May 2022 release will change the names of application c
 1. Added the ability to specify an ['SSO team ID'](https://www.terraform.io/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for teams that Terraform Enterprise can use to map teams to non-human readable 'MemberOf' values in SAML assertions.
 1. Updated display of download count metrics for modules in the private registry
 1. Added an API endpoint to fetch a workspace's current state version outputs. Refer to https://www.terraform.io/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace for details
-1. Updated the default `json-file` log rotation settings for all containers.
-    - Values of `max-size: 10m` and `max-file: 3` were changed to `max-size: 8m` and `max-file: 4`
-    - Values of `max-size: 10m` and `max-file: 10` were changed to `max-size: 32m` and `max-file: 4`
-    - Values of `max-size: 100m` and `max-file: 10` were changed to `max-size: 64m` and `max-file: 8`
-    - Values of `max-size: 100m` and `max-file: 200` were changed to `max-size: 50m` and `max-file: 20`
+1. Updated the default `json-file` log rotation settings for all containers in order to improve the performance of support bundle generation.
+
+       | Previous Settings | New Settings  |
+       | :-:               |       :-:     |
+       | `max-size: 10m` and `max-file: 3`| `max-size: 8m` and `max-file: 4`|
+       | `max-size: 10m` and `max-file: 10` | `max-size: 32m` and `max-file: 4`|
+       | `max-size: 100m` and `max-file: 10`| `max-size: 64m` and `max-file: 8`|
+       | `max-size: 100m` and `max-file: 200`| `max-size: 50m` and `max-file: 20`|
+
 
 ## APPLICATION LEVEL BUG FIXES
 

--- a/content/enterprise/releases/2022/v202204-1.mdx
+++ b/content/enterprise/releases/2022/v202204-1.mdx
@@ -21,6 +21,7 @@ The Terraform Enterprise May 2022 release will change the names of application c
 1. Added the ability to specify an ['SSO team ID'](https://www.terraform.io/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for teams that Terraform Enterprise can use to map teams to non-human readable 'MemberOf' values in SAML assertions.
 1. Updated display of download count metrics for modules in the private registry
 1. Added an API endpoint to fetch a workspace's current state version outputs. Refer to https://www.terraform.io/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace for details
+1. Updated the default `json-file` log rotation settings for all containers. The previous default values of `max-size: 10m` and `max-file: 3` were changed to `max-size: 8m` and `max-file: 3`, `max-size: 10m` and `max-file: 10` was changed to `max-size: 8m` and `max-file: 3`, `max-size: 100m` and `max-file: 10` was changed to `max-size: 64m` and `max-file: 8`, `max-size: 100m` and `max-file: 10` was changed to `max-size: 64m` and `max-file: 8`
 
 
 ## APPLICATION LEVEL BUG FIXES

--- a/content/enterprise/releases/2022/v202204-1.mdx
+++ b/content/enterprise/releases/2022/v202204-1.mdx
@@ -21,8 +21,11 @@ The Terraform Enterprise May 2022 release will change the names of application c
 1. Added the ability to specify an ['SSO team ID'](https://www.terraform.io/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for teams that Terraform Enterprise can use to map teams to non-human readable 'MemberOf' values in SAML assertions.
 1. Updated display of download count metrics for modules in the private registry
 1. Added an API endpoint to fetch a workspace's current state version outputs. Refer to https://www.terraform.io/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace for details
-1. Updated the default `json-file` log rotation settings for all containers. The previous default values of `max-size: 10m` and `max-file: 3` were changed to `max-size: 8m` and `max-file: 3`, `max-size: 10m` and `max-file: 10` was changed to `max-size: 8m` and `max-file: 3`, `max-size: 100m` and `max-file: 10` was changed to `max-size: 64m` and `max-file: 8`, `max-size: 100m` and `max-file: 10` was changed to `max-size: 64m` and `max-file: 8`
-
+1. Updated the default `json-file` log rotation settings for all containers.
+    - Values of `max-size: 10m` and `max-file: 3` were changed to `max-size: 8m` and `max-file: 4`
+    - Values of `max-size: 10m` and `max-file: 10` were changed to `max-size: 32m` and `max-file: 4`
+    - Values of `max-size: 100m` and `max-file: 10` were changed to `max-size: 64m` and `max-file: 8`
+    - Values of `max-size: 100m` and `max-file: 200` were changed to `max-size: 50m` and `max-file: 20`
 
 ## APPLICATION LEVEL BUG FIXES
 


### PR DESCRIPTION
### What
I forgot to add a release note about the S/M/L/XL default log-rotation setting changes. This adds that note to the `v202204-1` release notes. 

### Why
It's a pretty large change that we should let users know about. I want to get the release notes updated sooner rather than later.

### Screenshots
![Screen Shot 2022-04-20 at 3 59 57 PM](https://user-images.githubusercontent.com/5195704/164338486-3c153a85-3cfb-41df-97f3-7457791a42c0.png)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.