### PR TITLE
mvp for plugin/ content split

### DIFF
--- a/content/plugin/log/index.mdx
+++ b/content/plugin/log/index.mdx
@@ -5,4 +5,7 @@ This is a placeholder page.
 This could be:
 - plugin/log/index.mdx
 - plugin/log.mdx
+
+If you wish to leverage this file, remove the associated redirect from
+`pluginRedirects` in `redirects.next.js`
 -->

--- a/content/plugin/log/index.mdx
+++ b/content/plugin/log/index.mdx
@@ -1,0 +1,8 @@
+<!--
+This is a placeholder page.
+`docs-sidenav` expects an MDX file to exist for a /<base>
+
+This could be:
+- plugin/log/index.mdx
+- plugin/log.mdx
+-->

--- a/content/plugin/sdkv2/index.mdx
+++ b/content/plugin/sdkv2/index.mdx
@@ -5,4 +5,7 @@ This is a placeholder page.
 This could be:
 - plugin/log/index.mdx
 - plugin/log.mdx
+
+If you wish to leverage this file, remove the associated redirect from
+`pluginRedirects` in `redirects.next.js`
 -->

--- a/content/plugin/sdkv2/index.mdx
+++ b/content/plugin/sdkv2/index.mdx
@@ -1,0 +1,8 @@
+<!--
+This is a placeholder page.
+`docs-sidenav` expects an MDX file to exist for a /<base>
+
+This could be:
+- plugin/log/index.mdx
+- plugin/log.mdx
+-->

--- a/data/other-plugins-nav-data.json
+++ b/data/other-plugins-nav-data.json
@@ -1,0 +1,8 @@
+[
+  { "heading": "Other Plugin Docs" },
+  { "title": "Plugin Development", "href": "/plugin" },
+  { "title": "SDKv2", "href": "/plugin/sdkv2/sdkv2-intro" },
+  { "title": "Framework", "href": "/plugin/framework" },
+  { "title": "Logging", "href": "/plugin/log/managing" },
+  { "title": "Combining and Translating", "href": "/plugin/mux" }
+]

--- a/data/plugin-framework-nav-data.json
+++ b/data/plugin-framework-nav-data.json
@@ -1,0 +1,64 @@
+[
+  {
+    "heading": "Framework"
+  },
+
+  {
+    "title": "Overview",
+    "path": ""
+  },
+  {
+    "title": "Tutorial: Implement Create and Read",
+    "href": "https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS"
+  },
+  {
+    "title": "Providers",
+    "path": "providers"
+  },
+  {
+    "title": "Resources",
+    "routes": [
+      { "title": "Overview", "path": "resources" },
+      {
+        "title": "Import",
+        "path": "resources/import"
+      },
+      {
+        "title": "Plan Modification",
+        "path": "resources/plan-modification"
+      }
+    ]
+  },
+  {
+    "title": "Data Sources",
+    "path": "data-sources"
+  },
+  {
+    "title": "Schemas",
+    "path": "schemas"
+  },
+  {
+    "title": "Attribute Types",
+    "path": "types"
+  },
+  {
+    "title": "Accessing State, Config, and Plan",
+    "path": "accessing-values"
+  },
+  {
+    "title": "Writing State",
+    "path": "writing-state"
+  },
+  {
+    "title": "Returning Errors and Warnings",
+    "path": "diagnostics"
+  },
+  {
+    "title": "Validation",
+    "path": "validation"
+  },
+  {
+    "title": "Acceptance Tests",
+    "path": "acctests"
+  }
+]

--- a/data/plugin-framework-nav-data.json
+++ b/data/plugin-framework-nav-data.json
@@ -26,6 +26,10 @@
       {
         "title": "Plan Modification",
         "path": "resources/plan-modification"
+      },
+      {
+        "title": "State Upgrade",
+        "path": "resources/state-upgrade"
       }
     ]
   },

--- a/data/plugin-framework-nav-data.json
+++ b/data/plugin-framework-nav-data.json
@@ -60,5 +60,9 @@
   {
     "title": "Acceptance Tests",
     "path": "acctests"
+  },
+  {
+    "title": "Debugging",
+    "path": "debugging"
   }
 ]

--- a/data/plugin-log-nav-data.json
+++ b/data/plugin-log-nav-data.json
@@ -1,6 +1,5 @@
 [
   { "heading": "Logging" },
-  { "title": "Placeholder", "path": "", "hidden": true },
   {
     "title": "Managing Log Output",
     "path": "managing"

--- a/data/plugin-log-nav-data.json
+++ b/data/plugin-log-nav-data.json
@@ -1,5 +1,6 @@
 [
   { "heading": "Logging" },
+  { "title": "Placeholder", "path": "", "hidden": true },
   {
     "title": "Managing Log Output",
     "path": "managing"

--- a/data/plugin-log-nav-data.json
+++ b/data/plugin-log-nav-data.json
@@ -1,0 +1,11 @@
+[
+  { "heading": "Logging" },
+  {
+    "title": "Managing Log Output",
+    "path": "managing"
+  },
+  {
+    "title": "Writing Log Output",
+    "path": "writing"
+  }
+]

--- a/data/plugin-mux-nav-data.json
+++ b/data/plugin-mux-nav-data.json
@@ -1,0 +1,26 @@
+[
+  {
+    "heading": "Combining and Translating (mux)"
+  },
+
+  {
+    "title": "Overview",
+    "path": ""
+  },
+  {
+    "title": "Combining Protocol v5 Providers",
+    "path": "combining-protocol-version-5-providers"
+  },
+  {
+    "title": "Combining Protocol v6 Providers",
+    "path": "combining-protocol-version-6-providers"
+  },
+  {
+    "title": "Translating Protocol v5 to v6",
+    "path": "translating-protocol-version-5-to-6"
+  },
+  {
+    "title": "Translating Protocol v6 to v5",
+    "path": "translating-protocol-version-6-to-5"
+  }
+]

--- a/data/plugin-mux-nav-data.json
+++ b/data/plugin-mux-nav-data.json
@@ -1,8 +1,7 @@
 [
   {
-    "heading": "Combining and Translating (mux)"
+    "heading": "Combining and Translating"
   },
-
   {
     "title": "Overview",
     "path": ""

--- a/data/plugin-nav-data.json
+++ b/data/plugin-nav-data.json
@@ -31,7 +31,8 @@
   },
   { "title": "SDKv2", "href": "sdkv2/sdkv2-intro" },
   { "title": "Framework", "href": "framework" },
-  { "title": "Logging", "href": "log" },
+  { "title": "Logging", "href": "log/managing" },
+  { "title": "Combining and Translating", "href": "mux" },
   {
     "title": "SDKv2",
     "hidden": true,

--- a/data/plugin-nav-data.json
+++ b/data/plugin-nav-data.json
@@ -14,7 +14,27 @@
     "path": "which-sdk"
   },
   {
+    "title": "Publishing to the Registry",
+    "href": "/registry/providers/publishing"
+  },
+  {
+    "title": "Terraform Integration Program",
+    "href": "/docs/partnerships"
+  },
+  {
+    "title": "Community Forum",
+    "href": "https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk/43"
+  },
+
+  {
+    "heading": "Plugin SDKs and Libraries"
+  },
+  { "title": "SDKv2", "href": "sdkv2/sdkv2-intro" },
+  { "title": "Framework", "href": "framework" },
+  { "title": "Logging", "href": "log" },
+  {
     "title": "SDKv2",
+    "hidden": true,
     "routes": [
       { "title": "Overview", "path": "sdkv2/sdkv2-intro" },
       {
@@ -157,6 +177,7 @@
   },
   {
     "title": "Framework",
+    "hidden": true,
     "routes": [
       {
         "title": "Overview",
@@ -228,6 +249,7 @@
   },
   {
     "title": "Logging",
+    "hidden": true,
     "routes": [
       {
         "title": "Managing Log Output",
@@ -245,6 +267,7 @@
   },
   {
     "title": "Combining and Translating",
+    "hidden": true,
     "routes": [
       {
         "title": "Overview",
@@ -267,17 +290,5 @@
         "path": "mux/translating-protocol-version-6-to-5"
       }
     ]
-  },
-  {
-    "title": "Publishing to the Registry",
-    "href": "/registry/providers/publishing"
-  },
-  {
-    "title": "Terraform Integration Program",
-    "href": "/docs/partnerships"
-  },
-  {
-    "title": "Community Forum",
-    "href": "https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk/43"
   }
 ]

--- a/data/plugin-nav-data.json
+++ b/data/plugin-nav-data.json
@@ -36,6 +36,7 @@
     "title": "SDKv2",
     "hidden": true,
     "routes": [
+      { "title": "Placeholder", "path": "sdkv2", "hidden": true },
       { "title": "Overview", "path": "sdkv2/sdkv2-intro" },
       {
         "title": "Tutorials: Custom Providers",
@@ -251,6 +252,7 @@
     "title": "Logging",
     "hidden": true,
     "routes": [
+      { "title": "Placeholder", "path": "log", "hidden": true },
       {
         "title": "Managing Log Output",
         "path": "log/managing"

--- a/data/plugin-nav-data.json
+++ b/data/plugin-nav-data.json
@@ -25,7 +25,10 @@
     "title": "Community Forum",
     "href": "https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk/43"
   },
-
+  {
+    "title": "Debugging",
+    "path": "debugging"
+  },
   {
     "heading": "Plugin SDKs and Libraries"
   },
@@ -263,10 +266,6 @@
         "path": "log/writing"
       }
     ]
-  },
-  {
-    "title": "Debugging",
-    "path": "debugging"
   },
   {
     "title": "Combining and Translating",

--- a/data/plugin-sdk-nav-data.json
+++ b/data/plugin-sdk-nav-data.json
@@ -1,6 +1,6 @@
 [
   { "heading": "SDKv2" },
-
+  { "title": "Placeholder", "path": "", "hidden": true },
   { "title": "Overview", "path": "sdkv2-intro" },
   {
     "title": "Tutorials: Custom Providers",

--- a/data/plugin-sdk-nav-data.json
+++ b/data/plugin-sdk-nav-data.json
@@ -1,0 +1,141 @@
+[
+  { "heading": "SDKv2" },
+
+  { "title": "Overview", "path": "sdkv2-intro" },
+  {
+    "title": "Tutorials: Custom Providers",
+    "href": "https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS"
+  },
+  {
+    "title": "Schemas",
+    "routes": [
+      { "title": "Overview", "path": "schemas" },
+      { "title": "Schema Types", "path": "schemas/schema-types" },
+      {
+        "title": "Schema Behaviors",
+        "path": "schemas/schema-behaviors"
+      },
+      {
+        "title": "Schema Methods",
+        "path": "schemas/schema-methods",
+        "hidden": true
+      }
+    ]
+  },
+  {
+    "title": "Resources",
+    "routes": [
+      { "title": "Overview", "path": "resources" },
+      {
+        "title": "Customizing Differences",
+        "path": "resources/customizing-differences"
+      },
+      { "title": "Import", "path": "resources/import" },
+      {
+        "title": "Retries and Customizable Timeouts",
+        "path": "resources/retries-and-customizable-timeouts"
+      },
+      {
+        "title": "State Migration",
+        "path": "resources/state-migration"
+      }
+    ]
+  },
+  { "title": "Debugging Providers", "path": "debugging" },
+  {
+    "title": "Upgrade Guides",
+    "routes": [
+      {
+        "title": "Compatibility with Terraform 0.12",
+        "path": "guides/terraform-0.12-compatibility"
+      },
+      {
+        "title": "Switching to the standalone SDK",
+        "path": "guides/v1-upgrade-guide"
+      },
+      {
+        "title": "v2 Upgrade Guide",
+        "path": "guides/v2-upgrade-guide"
+      }
+    ]
+  },
+  {
+    "title": "Best Practices",
+    "routes": [
+      { "title": "Overview", "path": "best-practices" },
+      {
+        "title": "Naming",
+        "path": "best-practices/naming"
+      },
+      {
+        "title": "Depending on Providers",
+        "path": "best-practices/depending-on-providers"
+      },
+      {
+        "title": "Deprecations, Removals, and Renames",
+        "path": "best-practices/deprecations"
+      },
+      {
+        "title": "Detecting Drift",
+        "path": "best-practices/detecting-drift"
+      },
+      {
+        "title": "Handling Sensitive Data",
+        "path": "best-practices/sensitive-state"
+      },
+      {
+        "title": "Testing Patterns",
+        "path": "best-practices/testing"
+      },
+      {
+        "title": "Versioning and Changelog",
+        "path": "best-practices/versioning"
+      },
+      {
+        "title": "Writing Non-Go Providers",
+        "path": "best-practices/other-languages"
+      }
+    ]
+  },
+  {
+    "title": "Testing",
+    "routes": [
+      { "title": "Overview", "path": "testing" },
+      {
+        "title": "Acceptance Testing",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "testing/acceptance-tests"
+          },
+          {
+            "title": "Test Cases",
+            "path": "testing/acceptance-tests/testcase"
+          },
+          {
+            "title": "Test Steps",
+            "path": "testing/acceptance-tests/teststep"
+          },
+          {
+            "title": "Sweepers",
+            "path": "testing/acceptance-tests/sweepers"
+          }
+        ]
+      },
+      {
+        "title": "Testing API",
+        "path": "testing/testing-api",
+        "hidden": true
+      },
+      {
+        "title": "Testing Patterns",
+        "path": "testing/testing-patterns",
+        "hidden": true
+      },
+      {
+        "title": "Unit Testing",
+        "path": "testing/unit-testing"
+      }
+    ]
+  }
+]

--- a/data/plugin-sdk-nav-data.json
+++ b/data/plugin-sdk-nav-data.json
@@ -1,5 +1,6 @@
 [
   { "heading": "SDKv2" },
+  { "title": "Placeholder", "path": "", "hidden": true },
   { "title": "Overview", "path": "sdkv2-intro" },
   {
     "title": "Tutorials: Custom Providers",

--- a/data/plugin-sdk-nav-data.json
+++ b/data/plugin-sdk-nav-data.json
@@ -1,6 +1,5 @@
 [
   { "heading": "SDKv2" },
-  { "title": "Placeholder", "path": "", "hidden": true },
   { "title": "Overview", "path": "sdkv2-intro" },
   {
     "title": "Tutorials: Custom Providers",

--- a/pages/plugin/[[...page]].tsx
+++ b/pages/plugin/[[...page]].tsx
@@ -4,6 +4,7 @@ import ProviderTable from 'components/provider-table'
 import otherDocsData from 'data/other-docs-nav-data.json'
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+import type { NextParsedUrlQuery } from 'next/dist/server/request-meta'
 
 //  Configure the docs path
 const BASE_ROUTE = 'plugin'
@@ -52,15 +53,9 @@ const getStaticPaths = async (ctx) => {
   const res = await _getStaticPaths(ctx)
 
   // remove paths for "framework", "log", "mux", and "sdkv2"
-  const paths = res.paths.reduce((acc, p) => {
-    if (typeof p !== 'string') {
-      if (/framework|log|mux|sdkv2/.test(p.params.page?.[0])) {
-        return acc
-      }
-      return acc.concat(p)
-    }
-    return acc
-  }, [] as typeof res.paths)
+  const paths = res.paths.filter((p: { params: NextParsedUrlQuery }) => {
+    return /framework|log|mux|sdkv2/i.test(p.params.page?.[0])
+  })
 
   // update getStaticPaths object before returning it to Next.js
   res.paths = paths

--- a/pages/plugin/[[...page]].tsx
+++ b/pages/plugin/[[...page]].tsx
@@ -11,6 +11,7 @@ const NAV_DATA = 'data/plugin-nav-data.json'
 const CONTENT_DIR = 'content/plugin'
 const PRODUCT = { name: productName, slug: 'terraform' } as const
 
+// TODO: update to terraform-plugin-common
 const SOURCE_REPO = 'terraform-website'
 const DEFAULT_BRANCH = 'master'
 

--- a/pages/plugin/[[...page]].tsx
+++ b/pages/plugin/[[...page]].tsx
@@ -54,7 +54,7 @@ const getStaticPaths = async (ctx) => {
 
   // remove paths for "framework", "log", "mux", and "sdkv2"
   const paths = res.paths.filter((p: { params: NextParsedUrlQuery }) => {
-    return /framework|log|mux|sdkv2/i.test(p.params.page?.[0])
+    return !/framework|log|mux|sdkv2/i.test(p.params.page?.[0])
   })
 
   // update getStaticPaths object before returning it to Next.js

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -18,7 +18,7 @@ export default function PluginFrameworkLayout(props) {
     { heading: 'Other Plugin Docs' },
     { title: 'Plugin Development', href: '/plugin' },
     { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
-    { title: 'Logging', href: '/plugin/log' },
+    { title: 'Logging', href: '/plugin/log/managing' },
   ])
   return (
     <>

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -18,7 +18,9 @@ export default function PluginFrameworkLayout(props) {
     { heading: 'Other Plugin Docs' },
     { title: 'Plugin Development', href: '/plugin' },
     { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
-    { title: 'Logging', href: '/plugin/log/managing' },
+    // { title: 'Framework', href: '/plugin/framework' },
+    { title: 'Logging', href: '/plugin/log' },
+    { title: 'Combining and Translating', href: '/plugin/mux' },
   ])
   return (
     <>

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -1,6 +1,7 @@
 import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
+import otherPluginsData from 'data/other-plugins-nav-data.json'
 
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
@@ -15,16 +16,12 @@ const PRODUCT = { name: productName, slug: 'terraform' } as const
 const SOURCE_REPO = 'terraform-website'
 
 export default function PluginFrameworkLayout(props) {
-  // add the "other docs" section to the bottom of the nav data
+  // display "Other Plugin Docs" section
   const modifiedProps = Object.assign({}, props)
-  modifiedProps.navData = modifiedProps.navData.concat([
-    { heading: 'Other Plugin Docs' },
-    { title: 'Plugin Development', href: '/plugin' },
-    { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
-    // { title: 'Framework', href: '/plugin/framework' },
-    { title: 'Logging', href: '/plugin/log' },
-    { title: 'Combining and Translating', href: '/plugin/mux' },
-  ])
+  // filter out the link for this page
+  modifiedProps.navData = modifiedProps.navData.concat(
+    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+  )
   return (
     <>
       <DocsPage

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -9,7 +9,10 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/framework'
 const NAV_DATA = 'data/plugin-framework-nav-data.json'
 const CONTENT_DIR = 'content/plugin/framework'
-const PRODUCT = { name: productName, slug: 'terraform-website' }
+const PRODUCT = { name: productName, slug: 'terraform' }
+
+// TODO: update to terraform-plugin-framework
+const SOURCE_REPO = 'terraform-website'
 
 export default function PluginFrameworkLayout(props) {
   // add the "other docs" section to the bottom of the nav data
@@ -38,9 +41,9 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   strategy: 'fs',
   localContentDir: CONTENT_DIR,
   navDataFile: NAV_DATA,
-  product: PRODUCT.slug,
+  product: SOURCE_REPO,
   githubFileUrl(path) {
-    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+    return `https://github.com/hashicorp/${SOURCE_REPO}/blob/master/${path}`
   },
 })
 

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -9,7 +9,7 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/framework'
 const NAV_DATA = 'data/plugin-framework-nav-data.json'
 const CONTENT_DIR = 'content/plugin/framework'
-const PRODUCT = { name: productName, slug: 'terraform' }
+const PRODUCT = { name: productName, slug: 'terraform' } as const
 
 // TODO: update to terraform-plugin-framework
 const SOURCE_REPO = 'terraform-website'

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -22,17 +22,6 @@ export default function PluginFrameworkLayout(props) {
   ])
   return (
     <>
-      <div>
-        pages / plugin / framework / [[...page]].tsx
-        <style jsx>{`
-          div {
-            color: green;
-            font-family: var(--font-monospace);
-            border: 1px solid green;
-            text-align: center;
-          }
-        `}</style>
-      </div>
       <DocsPage
         additionalComponents={{ ProviderTable }}
         baseRoute={BASE_ROUTE}

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -20,7 +20,7 @@ export default function PluginFrameworkLayout(props) {
   const modifiedProps = Object.assign({}, props)
   // filter out the link for this page
   modifiedProps.navData = modifiedProps.navData.concat(
-    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+    otherPluginsData.filter(({ href }) => !href?.includes(BASE_ROUTE))
   )
   return (
     <>

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -1,0 +1,56 @@
+import { productName, productSlug } from 'data/metadata'
+import DocsPage from '@hashicorp/react-docs-page'
+import ProviderTable from 'components/provider-table'
+
+// Imports below are only used server-side
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+
+//  Configure the docs path
+const BASE_ROUTE = 'plugin/framework'
+const NAV_DATA = 'data/plugin-framework-nav-data.json'
+const CONTENT_DIR = 'content/plugin/framework'
+const PRODUCT = { name: productName, slug: 'terraform-website' }
+
+export default function PluginFrameworkLayout(props) {
+  // add the "other docs" section to the bottom of the nav data
+  const modifiedProps = Object.assign({}, props)
+  modifiedProps.navData = modifiedProps.navData.concat([
+    { heading: 'Other Plugin Docs' },
+    { title: 'Plugin Development', href: '/plugin' },
+    { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
+    { title: 'Logging', href: '/plugin/log' },
+  ])
+  return (
+    <>
+      <div>
+        pages / plugin / framework / [[...page]].tsx
+        <style jsx>{`
+          div {
+            color: green;
+            font-family: var(--font-monospace);
+            border: 1px solid green;
+            text-align: center;
+          }
+        `}</style>
+      </div>
+      <DocsPage
+        additionalComponents={{ ProviderTable }}
+        baseRoute={BASE_ROUTE}
+        product={PRODUCT}
+        staticProps={modifiedProps}
+      />
+    </>
+  )
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  strategy: 'fs',
+  localContentDir: CONTENT_DIR,
+  navDataFile: NAV_DATA,
+  product: PRODUCT.slug,
+  githubFileUrl(path) {
+    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+  },
+})
+
+export { getStaticPaths, getStaticProps }

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -9,7 +9,10 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/log'
 const NAV_DATA = 'data/plugin-log-nav-data.json'
 const CONTENT_DIR = 'content/plugin/log'
-const PRODUCT = { name: productName, slug: 'terraform-website' }
+const PRODUCT = { name: productName, slug: 'terraform' }
+
+// TODO: update to terraform-plugin-log
+const SOURCE_REPO = 'terraform-website'
 
 export default function PluginLogLayout(props) {
   // add the "other docs" section to the bottom of the nav data
@@ -38,9 +41,9 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   strategy: 'fs',
   localContentDir: CONTENT_DIR,
   navDataFile: NAV_DATA,
-  product: PRODUCT.slug,
+  product: SOURCE_REPO,
   githubFileUrl(path) {
-    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+    return `https://github.com/hashicorp/${SOURCE_REPO}/blob/master/${path}`
   },
 })
 

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -9,7 +9,7 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/log'
 const NAV_DATA = 'data/plugin-log-nav-data.json'
 const CONTENT_DIR = 'content/plugin/log'
-const PRODUCT = { name: productName, slug: 'terraform' }
+const PRODUCT = { name: productName, slug: 'terraform' } as const
 
 // TODO: update to terraform-plugin-log
 const SOURCE_REPO = 'terraform-website'

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -19,6 +19,8 @@ export default function PluginLogLayout(props) {
     { title: 'Plugin Development', href: '/plugin' },
     { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
     { title: 'Framework', href: '/plugin/framework' },
+    // { title: 'Logging', href: '/plugin/log' },
+    { title: 'Combining and Translating', href: '/plugin/mux' },
   ])
   return (
     <>

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -1,7 +1,8 @@
 import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
-import otherDocsData from 'data/other-docs-nav-data.json'
+import otherPluginsData from 'data/other-plugins-nav-data.json'
+
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 
@@ -15,16 +16,12 @@ const PRODUCT = { name: productName, slug: 'terraform' } as const
 const SOURCE_REPO = 'terraform-website'
 
 export default function PluginLogLayout(props) {
-  // add the "other docs" section to the bottom of the nav data
+  // display "Other Plugin Docs" section
   const modifiedProps = Object.assign({}, props)
-  modifiedProps.navData = modifiedProps.navData.concat([
-    { heading: 'Other Plugin Docs' },
-    { title: 'Plugin Development', href: '/plugin' },
-    { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
-    { title: 'Framework', href: '/plugin/framework' },
-    // { title: 'Logging', href: '/plugin/log' },
-    { title: 'Combining and Translating', href: '/plugin/mux' },
-  ])
+  // filter out the link for this page
+  modifiedProps.navData = modifiedProps.navData.concat(
+    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+  )
   return (
     <>
       <DocsPage

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -1,0 +1,56 @@
+import { productName, productSlug } from 'data/metadata'
+import DocsPage from '@hashicorp/react-docs-page'
+import ProviderTable from 'components/provider-table'
+import otherDocsData from 'data/other-docs-nav-data.json'
+// Imports below are only used server-side
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+
+//  Configure the docs path
+const BASE_ROUTE = 'plugin/log'
+const NAV_DATA = 'data/plugin-log-nav-data.json'
+const CONTENT_DIR = 'content/plugin/log'
+const PRODUCT = { name: productName, slug: 'terraform-website' }
+
+export default function PluginLogLayout(props) {
+  // add the "other docs" section to the bottom of the nav data
+  const modifiedProps = Object.assign({}, props)
+  modifiedProps.navData = modifiedProps.navData.concat([
+    { heading: 'Other Plugin Docs' },
+    { title: 'Plugin Development', href: '/plugin' },
+    { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
+    { title: 'Framework', href: '/plugin/framework' },
+  ])
+  return (
+    <>
+      <div>
+        pages / plugin / log / [[...page]].tsx
+        <style jsx>{`
+          div {
+            color: rebeccapurple;
+            font-family: var(--font-monospace);
+            border: 1px solid rebeccapurple;
+            text-align: center;
+          }
+        `}</style>
+      </div>
+      <DocsPage
+        additionalComponents={{ ProviderTable }}
+        baseRoute={BASE_ROUTE}
+        product={PRODUCT}
+        staticProps={modifiedProps}
+      />
+    </>
+  )
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  strategy: 'fs',
+  localContentDir: CONTENT_DIR,
+  navDataFile: NAV_DATA,
+  product: PRODUCT.slug,
+  githubFileUrl(path) {
+    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+  },
+})
+
+export { getStaticPaths, getStaticProps }

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -20,7 +20,7 @@ export default function PluginLogLayout(props) {
   const modifiedProps = Object.assign({}, props)
   // filter out the link for this page
   modifiedProps.navData = modifiedProps.navData.concat(
-    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+    otherPluginsData.filter(({ href }) => !href?.includes(BASE_ROUTE))
   )
   return (
     <>

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -22,17 +22,6 @@ export default function PluginLogLayout(props) {
   ])
   return (
     <>
-      <div>
-        pages / plugin / log / [[...page]].tsx
-        <style jsx>{`
-          div {
-            color: rebeccapurple;
-            font-family: var(--font-monospace);
-            border: 1px solid rebeccapurple;
-            text-align: center;
-          }
-        `}</style>
-      </div>
       <DocsPage
         additionalComponents={{ ProviderTable }}
         baseRoute={BASE_ROUTE}

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -9,7 +9,7 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/mux'
 const NAV_DATA = 'data/plugin-mux-nav-data.json'
 const CONTENT_DIR = 'content/plugin/mux'
-const PRODUCT = { name: productName, slug: 'terraform' }
+const PRODUCT = { name: productName, slug: 'terraform' } as const
 
 // TODO: update to terraform-plugin-mux
 const SOURCE_REPO = 'terraform-website'

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -18,17 +18,6 @@ export default function PluginMuxLayout(props) {
 
   return (
     <>
-      <div>
-        pages / plugin / mux / [[...page]].tsx
-        <style jsx>{`
-          div {
-            color: orange;
-            font-family: var(--font-monospace);
-            border: 1px solid orange;
-            text-align: center;
-          }
-        `}</style>
-      </div>
       <DocsPage
         additionalComponents={{ ProviderTable }}
         baseRoute={BASE_ROUTE}

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -20,7 +20,7 @@ export default function PluginMuxLayout(props) {
   const modifiedProps = Object.assign({}, props)
   // filter out the link for this page
   modifiedProps.navData = modifiedProps.navData.concat(
-    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+    otherPluginsData.filter(({ href }) => !href?.includes(BASE_ROUTE))
   )
 
   return (

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -1,0 +1,52 @@
+import { productName, productSlug } from 'data/metadata'
+import DocsPage from '@hashicorp/react-docs-page'
+import ProviderTable from 'components/provider-table'
+import otherDocsData from 'data/other-docs-nav-data.json'
+// Imports below are only used server-side
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+
+//  Configure the docs path
+const BASE_ROUTE = 'plugin/mux'
+const NAV_DATA = 'data/plugin-mux-nav-data.json'
+const CONTENT_DIR = 'content/plugin/mux'
+const PRODUCT = { name: productName, slug: 'terraform-website' }
+
+export default function PluginMuxLayout(props) {
+  // add the "other docs" section to the bottom of the nav data
+  const modifiedProps = Object.assign({}, props)
+  modifiedProps.navData = modifiedProps.navData.concat([])
+
+  return (
+    <>
+      <div>
+        pages / plugin / mux / [[...page]].tsx
+        <style jsx>{`
+          div {
+            color: orange;
+            font-family: var(--font-monospace);
+            border: 1px solid orange;
+            text-align: center;
+          }
+        `}</style>
+      </div>
+      <DocsPage
+        additionalComponents={{ ProviderTable }}
+        baseRoute={BASE_ROUTE}
+        product={PRODUCT}
+        staticProps={modifiedProps}
+      />
+    </>
+  )
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  strategy: 'fs',
+  localContentDir: CONTENT_DIR,
+  navDataFile: NAV_DATA,
+  product: PRODUCT.slug,
+  githubFileUrl(path) {
+    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+  },
+})
+
+export { getStaticPaths, getStaticProps }

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -9,7 +9,10 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/mux'
 const NAV_DATA = 'data/plugin-mux-nav-data.json'
 const CONTENT_DIR = 'content/plugin/mux'
-const PRODUCT = { name: productName, slug: 'terraform-website' }
+const PRODUCT = { name: productName, slug: 'terraform' }
+
+// TODO: update to terraform-plugin-mux
+const SOURCE_REPO = 'terraform-website'
 
 export default function PluginMuxLayout(props) {
   // add the "other docs" section to the bottom of the nav data
@@ -39,9 +42,9 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   strategy: 'fs',
   localContentDir: CONTENT_DIR,
   navDataFile: NAV_DATA,
-  product: PRODUCT.slug,
+  product: SOURCE_REPO,
   githubFileUrl(path) {
-    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+    return `https://github.com/hashicorp/${SOURCE_REPO}/blob/master/${path}`
   },
 })
 

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -1,7 +1,8 @@
 import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
-import otherDocsData from 'data/other-docs-nav-data.json'
+import otherPluginsData from 'data/other-plugins-nav-data.json'
+
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 
@@ -15,16 +16,12 @@ const PRODUCT = { name: productName, slug: 'terraform' } as const
 const SOURCE_REPO = 'terraform-website'
 
 export default function PluginMuxLayout(props) {
-  // add the "other docs" section to the bottom of the nav data
+  // display "Other Plugin Docs" section
   const modifiedProps = Object.assign({}, props)
-  modifiedProps.navData = modifiedProps.navData.concat([
-    { heading: 'Other Plugin Docs' },
-    { title: 'Plugin Development', href: '/plugin' },
-    { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
-    { title: 'Framework', href: '/plugin/framework' },
-    { title: 'Logging', href: '/plugin/log' },
-    // { title: 'Combining and Translating', href: '/plugin/mux' },
-  ])
+  // filter out the link for this page
+  modifiedProps.navData = modifiedProps.navData.concat(
+    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+  )
 
   return (
     <>

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -14,7 +14,14 @@ const PRODUCT = { name: productName, slug: 'terraform-website' }
 export default function PluginMuxLayout(props) {
   // add the "other docs" section to the bottom of the nav data
   const modifiedProps = Object.assign({}, props)
-  modifiedProps.navData = modifiedProps.navData.concat([])
+  modifiedProps.navData = modifiedProps.navData.concat([
+    { heading: 'Other Plugin Docs' },
+    { title: 'Plugin Development', href: '/plugin' },
+    { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
+    { title: 'Framework', href: '/plugin/framework' },
+    { title: 'Logging', href: '/plugin/log' },
+    // { title: 'Combining and Translating', href: '/plugin/mux' },
+  ])
 
   return (
     <>

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -16,8 +16,10 @@ export default function PluginSdkv2Layout(props) {
   modifiedProps.navData = modifiedProps.navData.concat([
     { heading: 'Other Plugin Docs' },
     { title: 'Plugin Development', href: '/plugin' },
+    // { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
     { title: 'Framework', href: '/plugin/framework' },
-    { title: 'Logging', href: '/plugin/log/managing' },
+    { title: 'Logging', href: '/plugin/log' },
+    { title: 'Combining and Translating', href: '/plugin/mux' },
   ])
 
   return (

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -1,6 +1,8 @@
 import { productName, productSlug } from 'data/metadata'
 import DocsPage from '@hashicorp/react-docs-page'
 import ProviderTable from 'components/provider-table'
+import otherPluginsData from 'data/other-plugins-nav-data.json'
+
 // Imports below are only used server-side
 import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 
@@ -14,16 +16,12 @@ const PRODUCT = { name: productName, slug: 'terraform' } as const
 const SOURCE_REPO = 'terraform-website'
 
 export default function PluginSdkv2Layout(props) {
-  // add the "other docs" section to the bottom of the nav data
+  // display "Other Plugin Docs" section
   const modifiedProps = Object.assign({}, props)
-  modifiedProps.navData = modifiedProps.navData.concat([
-    { heading: 'Other Plugin Docs' },
-    { title: 'Plugin Development', href: '/plugin' },
-    // { title: 'SDKv2', href: '/plugin/sdkv2/sdkv2-intro' },
-    { title: 'Framework', href: '/plugin/framework' },
-    { title: 'Logging', href: '/plugin/log' },
-    { title: 'Combining and Translating', href: '/plugin/mux' },
-  ])
+  // filter out the link for this page
+  modifiedProps.navData = modifiedProps.navData.concat(
+    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+  )
 
   return (
     <>

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -8,7 +8,10 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/sdkv2'
 const NAV_DATA = 'data/plugin-sdk-nav-data.json'
 const CONTENT_DIR = 'content/plugin/sdkv2'
-const PRODUCT = { name: productName, slug: 'terraform-website' }
+const PRODUCT = { name: productName, slug: 'terraform' }
+
+// TODO: update to terraform-plugin-sdk
+const SOURCE_REPO = 'terraform-website'
 
 export default function PluginSdkv2Layout(props) {
   // add the "other docs" section to the bottom of the nav data
@@ -38,9 +41,9 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   strategy: 'fs',
   localContentDir: CONTENT_DIR,
   navDataFile: NAV_DATA,
-  product: PRODUCT.slug,
+  product: SOURCE_REPO,
   githubFileUrl(path) {
-    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+    return `https://github.com/hashicorp/${SOURCE_REPO}/blob/master/${path}`
   },
 })
 

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -17,7 +17,7 @@ export default function PluginSdkv2Layout(props) {
     { heading: 'Other Plugin Docs' },
     { title: 'Plugin Development', href: '/plugin' },
     { title: 'Framework', href: '/plugin/framework' },
-    { title: 'Logging', href: '/plugin/log' },
+    { title: 'Logging', href: '/plugin/log/managing' },
   ])
 
   return (

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -22,17 +22,6 @@ export default function PluginSdkv2Layout(props) {
 
   return (
     <>
-      <div>
-        pages / plugin / sdkv2 / [[...page]].tsx
-        <style jsx>{`
-          div {
-            color: red;
-            font-family: var(--font-monospace);
-            border: 1px solid red;
-            text-align: center;
-          }
-        `}</style>
-      </div>
       <DocsPage
         additionalComponents={{ ProviderTable }}
         baseRoute={BASE_ROUTE}

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -8,7 +8,7 @@ import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
 const BASE_ROUTE = 'plugin/sdkv2'
 const NAV_DATA = 'data/plugin-sdk-nav-data.json'
 const CONTENT_DIR = 'content/plugin/sdkv2'
-const PRODUCT = { name: productName, slug: 'terraform' }
+const PRODUCT = { name: productName, slug: 'terraform' } as const
 
 // TODO: update to terraform-plugin-sdk
 const SOURCE_REPO = 'terraform-website'

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -20,7 +20,7 @@ export default function PluginSdkv2Layout(props) {
   const modifiedProps = Object.assign({}, props)
   // filter out the link for this page
   modifiedProps.navData = modifiedProps.navData.concat(
-    otherPluginsData.filter(({ href }) => !href?.startsWith(BASE_ROUTE))
+    otherPluginsData.filter(({ href }) => !href?.includes(BASE_ROUTE))
   )
 
   return (

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -1,0 +1,56 @@
+import { productName, productSlug } from 'data/metadata'
+import DocsPage from '@hashicorp/react-docs-page'
+import ProviderTable from 'components/provider-table'
+// Imports below are only used server-side
+import { getStaticGenerationFunctions } from '@hashicorp/react-docs-page/server'
+
+//  Configure the docs path
+const BASE_ROUTE = 'plugin/sdkv2'
+const NAV_DATA = 'data/plugin-sdk-nav-data.json'
+const CONTENT_DIR = 'content/plugin/sdkv2'
+const PRODUCT = { name: productName, slug: 'terraform-website' }
+
+export default function PluginSdkv2Layout(props) {
+  // add the "other docs" section to the bottom of the nav data
+  const modifiedProps = Object.assign({}, props)
+  modifiedProps.navData = modifiedProps.navData.concat([
+    { heading: 'Other Plugin Docs' },
+    { title: 'Plugin Development', href: '/plugin' },
+    { title: 'Framework', href: '/plugin/framework' },
+    { title: 'Logging', href: '/plugin/log' },
+  ])
+
+  return (
+    <>
+      <div>
+        pages / plugin / sdkv2 / [[...page]].tsx
+        <style jsx>{`
+          div {
+            color: red;
+            font-family: var(--font-monospace);
+            border: 1px solid red;
+            text-align: center;
+          }
+        `}</style>
+      </div>
+      <DocsPage
+        additionalComponents={{ ProviderTable }}
+        baseRoute={BASE_ROUTE}
+        product={PRODUCT}
+        staticProps={modifiedProps}
+      />
+    </>
+  )
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  strategy: 'fs',
+  localContentDir: CONTENT_DIR,
+  navDataFile: NAV_DATA,
+  product: PRODUCT.slug,
+  githubFileUrl(path) {
+    return `https://github.com/hashicorp/${PRODUCT.slug}/blob/master/${path}`
+  },
+})
+
+export { getStaticPaths, getStaticProps }

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -198,9 +198,19 @@ module.exports = (async () => {
     }
   )
 
+  // /plugin content split
+  // https://github.com/hashicorp/terraform-website/pull/2258
+  //
+  // these are redirects for /index pages that are required but not yet leveraged
+  const pluginRedirects = [
+    { source: '/plugin/log', destination: '/plugin/log/managing', permanent: false },
+    { source: '/plugin/sdkv2', destination: '/plugin/sdkv2/sdkv2-intro', permanent: false },
+  ]
+
   return [
     ...registryTopLevelRedirects,
     ...registryDocsRedirects,
     ...miscRedirects,
+    ...pluginRedirects,
   ]
 })()


### PR DESCRIPTION
https://terraform-website-git-test-plugin-split-hashicorp.vercel.app/


### What

This splits nested, to-be-versioned `/plugin/*`'s into their own **page** components. This is required for remote content & versioned docs to work.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.