### PR TITLE
Fix flag usage

### DIFF
--- a/content/plugin/debugging.mdx
+++ b/content/plugin/debugging.mdx
@@ -117,7 +117,7 @@ An example `.vscode/launch.json` configuration file:
             "program": "${workspaceFolder}",
             "env": {},
             "args": [
-                "-debug",
+                "-debuggable",
             ]
         }
     ]


### PR DESCRIPTION
### What

Change the flag used

### Why

When I'm using `-debug` I get the following errors:

```
flag provided but not defined: -debug
Usage of /workspaces/terraform-provider-scaleway/__debug_bin:
  -debuggable
    	set to true to run the provider with support for debuggers like delve
  -sweep string
    	List of Regions to run available Sweepers
  -sweep-allow-failures
    	Enable to allow Sweeper Tests to continue after failures
  -sweep-run string
    	Comma seperated list of Sweeper Tests to run
```

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.