### PR TITLE
Add note to cloud-docs that inactive agents can now be deregistered

### DIFF
--- a/content/cloud-docs/agents/index.mdx
+++ b/content/cloud-docs/agents/index.mdx
@@ -281,6 +281,8 @@ Agents in the **Unknown** state continue to be counted against the organization'
 
 Agents may have an **Unknown** status if they are terminated without gracefully exiting. Agents should always be shut down according to the [Stopping the Agent](#stopping-the-agent) section to allow them to deregister from Terraform Cloud. We strongly recommend ensuring that any process supervisor, application scheduler, or other runtime manager is configured to follow this procedure to minimize **Unknown** agent statuses.
 
+-> **Note:** **Unknown** agents, as well as **Errored** or **Exited** agents, can be deregistered through the **Organization Settings > Agents** page, or through the [Agent API](/cloud-docs/api-docs/agents#delete-an-agent). Agents deregisted this way will no longer appear in settings page, or count against the organization's agent allowance.
+
 ### Viewing Agent Logs
 
 Output from the Terraform execution will be visible on the run’s page within Terraform Cloud. For more in-depth debugging, you may wish to view the agent’s logs, which are sent to `stdout` and configurable via the `-log-level` command line argument. By default, these logs are not persisted in any way. It is the responsibility of the operator to collect and store these logs if they are needed.


### PR DESCRIPTION
### What

Inactive agents can now be removed through the Organization Settings > Agents page (previously this was only possible through an API call, or waiting for a timeout to occur).

The main use of this is to remove inactive agents which are eating into an organization's agent allowance. Add a note to the section of the cloud docs which address inactive agents eating into agent allowance.

### Screenshots

<img width="917" alt="Screen Shot 2022-04-28 at 1 22 08 PM" src="https://user-images.githubusercontent.com/10147422/165811296-aada6f97-6e5b-419b-a7ad-23d564b7dc2c.png">

### Links
 - Implementation: https://github.com/hashicorp/atlas/pull/12250

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.