### PR TITLE
plugin+registry: Capture pre-step with GitHub Actions usage to ensure its allowed

### DIFF
--- a/content/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -124,6 +124,8 @@ make testacc
 
 If using [GitHub](https://github.com/), run acceptance testing via [GitHub Actions](https://github.com/features/actions). Other continuous integration runners, while not exhaustively documented, are also supported.
 
+Ensure the [GitHub Organization settings for GitHub Actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) and [GitHub Repository settings for GitHub Actions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) allows running workflows and allows the `actions/checkout`, `actions/setup-go`, and `hashicorp/setup-terraform` actions.
+
 Create a [GitHub Actions workflow](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) file, such as `.github/workflows/test.yaml`, that does the following:
 
 - Runs when pull requests are submitted or on [other events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) as appropriate.

--- a/content/registry/providers/publishing.mdx
+++ b/content/registry/providers/publishing.mdx
@@ -75,6 +75,7 @@ We have a list of [recommend OS / architecture combinations](/registry/providers
 
 To use GitHub Actions to publish new provider releases to the Terraform Registry:
 
+1. Ensure the [GitHub Organization settings for GitHub Actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) and [GitHub Repository settings for GitHub Actions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) allows running workflows and allows the actions specified in the [GitHub Actions workflow from the terraform-provider-scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml).
 1. Create and export a signing key that you plan on using to sign your provider releases. See [Preparing and Adding a Signing Key](#preparing-and-adding-a-signing-key) for more information.
 1. Copy the [GoReleaser configuration from the terraform-provider-scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml) to the root of your repository.
 1. Copy the [GitHub Actions workflow from the terraform-provider-scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml) to `.github/workflows/release.yml` in your repository.


### PR DESCRIPTION
### What

- Update registry publishing for providers page to mention GitHub Organization/Repository settings
- Update provider testing page to mention GitHub Organization/Repository settings

### Why

This will help provider developers prevent GitHub Actions errors such as:

```text
actions/checkout@v3, actions/setup-go@v3, hashicorp/ghaction-import-gpg@v2.1.0, and goreleaser/goreleaser-action@v2.9.1 are not allowed to be used in example-org/terraform-provider-example. Actions in this workflow must be: within a repository that belongs to your Enterprise account.
```

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.