### PR TITLE
Fix Broken Markdown on Sentinel Docs Page

### DIFF
--- a/content/cloud-docs/sentinel/import/tfconfig-v2.mdx
+++ b/content/cloud-docs/sentinel/import/tfconfig-v2.mdx
@@ -231,13 +231,9 @@ main = rule {
 }
 ```
 
--> **NOTE:** The expression representation currently does not account for
+-> **Note:** The representation does not account for
 complex interpolations or other expressions that combine constants with other
-expression data. An example would be something like `"foo${var.bar}"` or \`"foo"
-
-* var.bar`.  In this situation, the partially constant data would be lost. We
-  will be working to resolve this within future versions of the `tfconfig/v2\`
-  import.
+expression data. For example, the partially constant data in `"foo${var.bar}"` would be lost.
 
 ### Block Expression Representation
 


### PR DESCRIPTION
### What
Fixed [this Sentinel documentation page](https://www.terraform.io/cloud-docs/sentinel/import/tfconfig-v2#expression-representations) with broken markdown. An escape character broke up a note block. This PR fixes this issue and copyedits the note to make it more concise.

### Screenshots
**Before**
<img width="854" alt="Screen Shot 2022-04-29 at 3 25 09 PM" src="https://user-images.githubusercontent.com/83350965/166055237-7c3b58ec-d865-43a4-ac5c-e867a2811889.png">

**After**
<img width="958" alt="Screen Shot 2022-04-29 at 3 25 28 PM" src="https://user-images.githubusercontent.com/83350965/166055370-31dc4a84-4263-4dcf-aeda-02fc9b977c83.png">

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.