### PR TITLE
Add notes on run tasks token permissions

### DIFF
--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -201,5 +201,8 @@ Since Terraform Cloud integrates with other systems, the permissions models of t
 
 - When a workspace is connected to a VCS repository, anyone who can merge changes to that repository's main branch can indirectly queue plans in that workspace, regardless of whether they have explicit permission to queue plans or are even a member of your Terraform Cloud organization. (And when auto-apply is enabled, merging changes will indirectly apply runs.)
 - If you use Terraform Cloud's API to create a Slack bot for provisioning infrastructure, anyone able to issue commands to that Slack bot can implicitly act with that bot's permissions, regardless of their own membership and permissions in the Terraform Cloud organization.
+- When a run task sends a request to an integrator, it provides an access token that provides access depending on the run task stage:
+  - For post-plan, it provides access to the runs plan json and the run task callback
+  - All access tokens created for run tasks have a lifetime of 10 minutes
 
 When integrating Terraform Cloud with other systems, you are responsible for understanding the effects on your organization's security. An integrated system is able to delegate any level of access that it has been granted, so carefully consider the conditions and events that will cause it to delegate that access.


### PR DESCRIPTION
### What
Added a note about the run tasks access token and the permissions it allows.

https://www.terraform.io/cloud-docs/users-teams-organizations/permissions#permissions-outside-terraform-cloud-s-scope

### Why
This is an additional security concern that customers need to be aware of when using run tasks.

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.