### PR TITLE
Add messaging around the post-plan stage

### DIFF
--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -48,11 +48,8 @@ _Leaving this stage:_
 
 ## 3. The Post-Plan Stage
 
-This phase only occurs if there are [run tasks](/cloud-docs/workspaces/settings/run-tasks) enabled
-for the workspace, and it executes any configured run tasks after the Plan has completed. This phase
-is entered for all runs, including [speculative](/cloud-docs/run/#speculative-plans) runs. During
-this phase, Terraform Cloud sends information about the run to the configured external system and
-waits for a `passed` or `failed` response to determine whether the run can continue.
+The post-plan phase executes any configured run tasks after the plan is complete, so it only occurs if there are [run tasks](/cloud-docs/workspaces/settings/run-tasks) enabled
+for the workspace. All runs can enter this phase, including [speculative plans](/cloud-docs/run/#speculative-plans). During this phase, Terraform Cloud sends information about the run to the configured external system and waits for a `passed` or `failed` response to determine whether the run can continue.
 
 -> **Note:** The information sent to the configured external system includes the [JSON output](/internals/json-format) of the Terraform plan.
 

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -55,7 +55,7 @@ for the workspace. All runs can enter this phase, including [speculative plans](
 
 _States in this stage:_
 
-- **Running tasks:** Terraform Cloud is currently waiting for a response from the configured external system(s).
+- **Running tasks:** Terraform Cloud is waiting for a response from the configured external system(s).
   - External systems must respond initially with a `200 OK` acknowledging the request is in progress. After that, they have 10 minutes to return a status of `passed`, `running`, or `failed`, or the timeout will expire and the task will be assumed to be in the `failed` status.
 
 _Leaving this stage:_

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -63,7 +63,7 @@ _Leaving this stage:_
 - If any mandatory tasks failed, the run skips to completion (**Plan Errored** state).
 - If any advisory tasks failed, the run proceeds to the **Applying** state, with a visible warning regarding the failed task.
 - If a combination of mandatory and advisory tasks are configured for a single run, Terraform will take the most restrictive action. This means that if there are two advisory tasks that succeed and one mandatory task that failed, the run will fail. If one mandatory task succeeds and two advisory tasks fail, the run will succeed with a warning.
-- If a user canceled the run by pressing the "Cancel Run" button, the run ends in the **Canceled** state.
+- If a user canceled the run, the run ends in the **Canceled** state.
 
 ## 4. The Cost Estimation Stage
 

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -54,7 +54,7 @@ is entered for all runs, including [speculative](/cloud-docs/run/#speculative-pl
 this phase, Terraform Cloud sends information about the run to the configured external system and
 waits for a `passed` or `failed` response to determine whether the run can continue.
 
--> **Note:** The information sent to the configured external system includes the [JSON output](/internals/json-format) of your plan.
+-> **Note:** The information sent to the configured external system includes the [JSON output](/internals/json-format) of the Terraform plan.
 
 _States in this stage:_
 

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -59,7 +59,7 @@ waits for a `passed` or `failed` response to determine whether the run can conti
 _States in this stage:_
 
 - **Running tasks:** Terraform Cloud is currently waiting for a response from the configured external system(s).
-  - External systems must respond initially with a `200 OK` acknowledging the request is in progress. After that, they have 10 minutes to return a status of `passed` or `failed`, or the timeout will expire and the task will be assumed to be in the `failed` status.
+  - External systems must respond initially with a `200 OK` acknowledging the request is in progress. After that, they have 10 minutes to return a status of `passed`, `running`, or `failed`, or the timeout will expire and the task will be assumed to be in the `failed` status.
 
 _Leaving this stage:_
 

--- a/content/cloud-docs/run/states.mdx
+++ b/content/cloud-docs/run/states.mdx
@@ -46,7 +46,29 @@ _Leaving this stage:_
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## 3. The Cost Estimation Stage
+## 3. The Post-Plan Stage
+
+This phase only occurs if there are [run tasks](/cloud-docs/workspaces/settings/run-tasks) enabled
+for the workspace, and it executes any configured run tasks after the Plan has completed. This phase
+is entered for all runs, including [speculative](/cloud-docs/run/#speculative-plans) runs. During
+this phase, Terraform Cloud sends information about the run to the configured external system and
+waits for a `passed` or `failed` response to determine whether the run can continue.
+
+-> **Note:** The information sent to the configured external system includes the [JSON output](/internals/json-format) of your plan.
+
+_States in this stage:_
+
+- **Running tasks:** Terraform Cloud is currently waiting for a response from the configured external system(s).
+  - External systems must respond initially with a `200 OK` acknowledging the request is in progress. After that, they have 10 minutes to return a status of `passed` or `failed`, or the timeout will expire and the task will be assumed to be in the `failed` status.
+
+_Leaving this stage:_
+
+- If any mandatory tasks failed, the run skips to completion (**Plan Errored** state).
+- If any advisory tasks failed, the run proceeds to the **Applying** state, with a visible warning regarding the failed task.
+- If a combination of mandatory and advisory tasks are configured for a single run, Terraform will take the most restrictive action. This means that if there are two advisory tasks that succeed and one mandatory task that failed, the run will fail. If one mandatory task succeeds and two advisory tasks fail, the run will succeed with a warning.
+- If a user canceled the run by pressing the "Cancel Run" button, the run ends in the **Canceled** state.
+
+## 4. The Cost Estimation Stage
 
 This stage only occurs if cost estimation is enabled. After a successful `terraform plan`, Terraform Cloud uses plan data to estimate costs for each resource found in the plan.
 
@@ -60,7 +82,7 @@ _Leaving this stage:_
 - If cost estimation succeeded or errors, the run moves to the next stage.
 - If there are no policy checks or applies, the run does not continue (**Planned and Finished** state).
 
-## 4. The Policy Check Stage
+## 5. The Policy Check Stage
 
 This stage only occurs if [Sentinel policies][] are enabled. After a successful `terraform plan`, Terraform Cloud checks whether the plan obeys policy to determine whether it can be applied.
 
@@ -86,7 +108,7 @@ _Leaving this stage:_
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## 5. The Apply Stage
+## 6. The Apply Stage
 
 _States in this stage:_
 
@@ -100,7 +122,7 @@ After applying, the run proceeds automatically to completion.
 - If the apply failed, the run ends in the **Apply Errored** state.
 - If a user canceled the apply by pressing the "Cancel Run" button, the run ends in the **Canceled** state.
 
-## 6. Completion
+## 7. Completion
 
 A run is considered completed if it finishes applying, if any part of the run fails, if there's nothing to do, or if a user chooses not to continue. Once a run is completed, the next run in the queue can enter the plan stage.
 


### PR DESCRIPTION
### What
Added a section explaining the post-plan stage of the run. This is almost a copy of the original pre-apply docs, with anything removed that did not align with post-plan.

### Why
Run tasks is now GA, so it's time to add this to the page.

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.