### PR TITLE
Add missing run tasks examples

### DIFF
--- a/content/cloud-docs/api-docs/organizations.mdx
+++ b/content/cloud-docs/api-docs/organizations.mdx
@@ -115,7 +115,8 @@ curl \
           "can-create-provider": true,
           "can-manage-public-modules": true,
           "can-manage-custom-providers": false,
-          "can-manage-run-tasks": false
+          "can-manage-run-tasks": false,
+          "can-read-run-tasks": false
         },
         "fair-run-queuing-enabled": true,
         "saml-enabled": false,
@@ -194,7 +195,8 @@ curl \
           "can-create-provider": true,
           "can-manage-public-modules": true,
           "can-manage-custom-providers": false,
-          "can-manage-run-tasks": false
+          "can-manage-run-tasks": false,
+          "can-read-run-tasks": false
         },
         "fair-run-queuing-enabled": true,
         "saml-enabled": false,
@@ -317,6 +319,7 @@ curl \
         "can-manage-public-modules": true,
         "can-manage-public-providers": false,
         "can-manage-run-tasks": false,
+        "can-read-run-tasks": false,
         "can-create-provider": false
       },
       "fair-run-queuing-enabled": true,
@@ -452,6 +455,7 @@ curl \
         "can-manage-public-modules": true,
         "can-manage-public-providers": false,
         "can-manage-run-tasks": false,
+        "can-read-run-tasks": false,
         "can-create-provider": false
       },
       "fair-run-queuing-enabled": true,
@@ -614,6 +618,7 @@ curl \
         "can-manage-public-modules": true,
         "can-manage-public-providers": false,
         "can-manage-run-tasks": false,
+        "can-read-run-tasks": false,
         "can-create-provider": false
       },
       "fair-run-queuing-enabled": true,

--- a/content/cloud-docs/api-docs/team-access.mdx
+++ b/content/cloud-docs/api-docs/team-access.mdx
@@ -89,7 +89,8 @@ $ curl \
         "variables": "none",
         "state-versions": "none",
         "sentinel-mocks": "none",
-        "workspace-locking": false
+        "workspace-locking": false,
+        "run-tasks": false
       },
       "relationships": {
         "team": {
@@ -160,7 +161,8 @@ $ curl \
       "variables": "write",
       "state-versions": "write",
       "sentinel-mocks": "read",
-      "workspace-locking": true
+      "workspace-locking": true,
+      "run-tasks": false
     },
     "relationships": {
       "team": {
@@ -214,6 +216,7 @@ Properties without a default value are required.
 | `data.attributes.state-versions`         | string  | "none"  | If `access` is `custom`, the permission to grant for the workspace's state versions. Can only be used when `access` is `custom`. Valid values include `none`, `read-outputs`, `read`, or `write`. |
 | `data.attributes.sentinel-mocks`         | string  | "none"  | If `access` is `custom`, the permission to grant for the workspace's Sentinel mocks. Can only be used when `access` is `custom`. Valid values include `none`, or `read`.                          |
 | `data.attributes.workspace-locking`      | boolean | false   | If `access` is `custom`, the permission granting the ability to manually lock or unlock the workspace. Can only be used when `access` is `custom`.                                                |
+| `data.attributes.run-tasks`              | boolean | false   | If `access` is `custom`, this permission allows the team to manage run tasks within the workspace.                                                                                                |
 | `data.relationships.workspace.data.type` | string  |         | Must be `workspaces`.                                                                                                                                                                             |
 | `data.relationships.workspace.data.id`   | string  |         | The workspace ID to which the team is to be added.                                                                                                                                                |
 | `data.relationships.team.data.type`      | string  |         | Must be `teams`.                                                                                                                                                                                  |
@@ -231,7 +234,8 @@ Properties without a default value are required.
       "state-versions": "read-outputs",
       "plan-outputs": "none",
       "sentinel-mocks": "read",
-      "workspace-locking": false
+      "workspace-locking": false,
+      "run-tasks": false
     },
     "relationships": {
       "workspace": {
@@ -276,7 +280,8 @@ $ curl \
       "variables": "none",
       "state-versions": "read-outputs",
       "sentinel-mocks": "read",
-      "workspace-locking": false
+      "workspace-locking": false,
+      "run-tasks": false
     },
     "relationships": {
       "team": {
@@ -324,6 +329,7 @@ $ curl \
 | `data.attributes.state-versions`    | string  | "none" | If `access` is `custom`, the permission to grant for the workspace's state versions. Can only be used when `access` is `custom`.                   |
 | `data.attributes.sentinel-mocks`    | string  | "none" | If `access` is `custom`, the permission to grant for the workspace's Sentinel mocks. Can only be used when `access` is `custom`.                   |
 | `data.attributes.workspace-locking` | boolean | false  | If `access` is `custom`, the permission granting the ability to manually lock or unlock the workspace. Can only be used when `access` is `custom`. |
+| `data.attributes.run-tasks`         | boolean | false  | If `access` is `custom`, this permission allows the team to manage run tasks within the workspace.                                                 |
 
 ### Sample Request
 
@@ -362,7 +368,8 @@ $ curl \
       "variables": "write",
       "state-versions": "none",
       "sentinel-mocks": "read",
-      "workspace-locking": true
+      "workspace-locking": true,
+      "run-tasks": true
     },
     "relationships": {
       "team": {

--- a/content/cloud-docs/api-docs/teams.mdx
+++ b/content/cloud-docs/api-docs/teams.mdx
@@ -101,6 +101,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
         "organization-access": {
           "manage-policies": true,
           "manage-policy-overrides": false,
+          "manage-run-tasks": true,
           "manage-workspaces": false,
           "manage-vcs-settings": false
         }
@@ -148,7 +149,7 @@ Properties without a default value are required.
 | `data.type`                             | string |            | Must be `"teams"`.                                                                                                                                                                                                                   |
 | `data.attributes.name`                  | string |            | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.                                                                              |
 | `data.attributes.sso-team-id`           | string | (nothing)  | The unique identifier of the team from the SAML `MemberOf` attribute. Only available in Terraform Enterprise 202204-1 and later, or if the team belongs to an organization in the paid Terraform Cloud Business tier.                |
-| `data.attributes.organization-access`   | object | (nothing)  | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-workspaces`, `manage-vcs-settings`, `manage-providers`, and `manage-modules` properties with boolean values. All properties default to `false`. |
+| `data.attributes.organization-access`   | object | (nothing)  | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-run-tasks`, `manage-workspaces`, `manage-vcs-settings`, `manage-providers`, and `manage-modules` properties with boolean values. All properties default to `false`. |
 | `data.attributes.visibility` **(beta)** | string | `"secret"` | The team's visibility. Must be `"secret"` or `"organization"` (visible).                                                                                                                                                             |
 
 ### Sample Payload
@@ -192,6 +193,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
       "organization-access": {
         "manage-policies": false,
         "manage-policy-overrides": false,
+        "manage-run-tasks": false,
         "manage-vcs-settings": false,
         "manage-workspaces": true,
         "manage-providers": false,
@@ -266,6 +268,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
       "organization-access": {
         "manage-policies": true,
         "manage-policy-overrides": false,
+        "manage-run-tasks": true,
         "manage-workspaces": false,
         "manage-vcs-settings": false,
         "manage-providers": false,
@@ -314,7 +317,7 @@ Properties without a default value are required.
 | `data.type`                             | string |                  | Must be `"teams"`.                                                                                                                                                                                                                   |
 | `data.attributes.name`                  | string | (previous value) | The name of the team, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.                                                                              |
 | `data.attributes.sso-team-id`           | string | (previous value) | The unique identifier of the team from the SAML `MemberOf` attribute. Only available in Terraform Enterprise 202204-1 and later, or if the team belongs to an organization in the paid Terraform Cloud Business tier.                |
-| `data.attributes.organization-access`   | object | (previous value) | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-workspaces`, `manage-vcs-settings`, `manage-providers`, and `manage-modules` properties with boolean values. All properties default to `false`. |
+| `data.attributes.organization-access`   | object | (previous value) | Settings for the team's organization access. This object can include `manage-policies`, `manage-policy-overrides`, `manage-run-tasks`, `manage-workspaces`, `manage-vcs-settings`, `manage-providers`, and `manage-modules` properties with boolean values. All properties default to `false`. |
 | `data.attributes.visibility` **(beta)** | string | (previous value) | The team's visibility. Must be `"secret"` or `"organization"` (visible).                                                                                                                                                             |
 
 ### Sample Payload
@@ -357,6 +360,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
       "organization-access": {
         "manage-policies": false,
         "manage-policy-overrides": false,
+        "manage-run-tasks": true,
         "manage-vcs-settings": true,
         "manage-workspaces": true,
         "manage-providers": false,


### PR DESCRIPTION
### What

Previously the team, team-access and organization (read permission) were missed
when updating the website.  This commit adds the missing entries to the examples
and adds a description for the run-tasks team-access permission.

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.