### PR TITLE
Add a note about GCP Redis in-transit encryption

### DIFF
--- a/content/enterprise/install/automated/active-active.mdx
+++ b/content/enterprise/install/automated/active-active.mdx
@@ -100,13 +100,13 @@ The existing settings for the Terraform Enterprise application (`ptfe-settings.j
 
 The settings for the Terraform Enterprise application must also be expanded to support an external Redis instance:
 
-| **Key**                   | **Required Value**                                                                                           | **Specific Format Required** |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| redis_host                | Hostname of an external Redis instance which is resolvable from the TFE instance                             | **Yes**, string.             |
-| redis_port                | Port number of your external Redis instance                                                                  | **Yes**, string.             |
-| redis_use_password_auth\* | Set to ”1”, if you are using a Redis service that requires a password.                                       | **Yes**, string.             |
-| redis_pass\*              | _Must be set to the password of an external Redis instance if the instance requires password authentication_ | **Yes**, string.             |
-| redis_use_tls\*           | Set to “1” if you are using a Redis service that requires TLS                                                | **Yes**, string.             |
+| **Key**                   | **Required Value**                                                                | **Specific Format Required** |
+| ------------------------- | --------------------------------------------------------------------------------- | ---------------------------- |
+| redis_host                | Hostname of an external Redis instance which is resolvable from the TFE instance. | **Yes**, string.             |
+| redis_port                | Port number of your external Redis instance.                                      | **Yes**, string.             |
+| redis_use_password_auth\* | Set to `1`, if you are using a Redis service that requires a password.            | **Yes**, string.             |
+| redis_pass\*              | Password used to authenticate to Redis.                                           | **Yes**, string.             |
+| redis_use_tls\*           | Set to `1` if you are using a Redis service that requires TLS.                    | **Yes**, string.             |
 
 _\* Fields marked with an asterisk are only necessary if your particular external Redis instance requires them._
 
@@ -132,6 +132,8 @@ For example:
 }
 
 ```
+
+-> **Note:** To use in-transit encryption with GCP Memorystore for Redis you must [download the CA certificate](https://cloud.google.com/memorystore/docs/redis/enabling-in-transit-encryption#downloading_the_certificate_authority) for your Redis instance and configure it within the `ca_certs` Terraform Enterprise application setting.
 
 ##### Add Encryption Password
 

--- a/content/enterprise/install/automated/active-active.mdx
+++ b/content/enterprise/install/automated/active-active.mdx
@@ -133,7 +133,7 @@ For example:
 
 ```
 
--> **Note:** To use in-transit encryption with GCP Memorystore for Redis you must [download the CA certificate](https://cloud.google.com/memorystore/docs/redis/enabling-in-transit-encryption#downloading_the_certificate_authority) for your Redis instance and configure it within the `ca_certs` Terraform Enterprise application setting.
+-> **Note:** To use in-transit encryption with GCP Memorystore for Redis, you must [download the CA certificate](https://cloud.google.com/memorystore/docs/redis/enabling-in-transit-encryption#downloading_the_certificate_authority) for your Redis instance and configure it within the `ca_certs` Terraform Enterprise application setting.
 
 ##### Add Encryption Password
 


### PR DESCRIPTION
### What

Added a note to the automated installation documentation regarding GCP Redis in-transit encryption.

### Why

Longer term we'll want to have better platform specific guidance around configuring Terraform Enterprise. However, Terraform Enterprise Active/Active debuted without support for in-transit encryption with GCP Redis. This note helps clarify that it's now supported, but it requires an additional configuration step when compared with AWS and Azure.

### Screenshots

N/A

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
