### PR TITLE
Non-Interactive Workflows

### DIFF
--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -201,7 +201,7 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
 - **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting for approval.
 
-  ~> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
+  ~> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -47,7 +47,7 @@ To supplement these remote operations, you can also use the optional [Terraform 
 
 To enable the CLI-driven workflow, you must:
 
-1. Run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can [manually configure credentials in the CLI config file](/cli/config/config-file#environment-variable-credentials.
+1. Run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can manually configure credentials in the CLI config file or through environment variables. Refer to [CLI Configuration](/cli/config/config-file#environment-variable-credentials) for details.
 
 1. Add the `cloud` block to your Terraform configuration. You can define its arguments directly in your configuration file or supply them through environment variables, which can be useful for [non-interactive workflows](#non-interactive-workflows). Refer to [Using Terraform Cloud](/cli/cloud) for configuration details.
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -196,7 +196,7 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 External systems cannot run the traditional apply workflow because Terraform requires console input from the user to approve plans. We recommend using the [API-driven Run Workflow](/cloud-docs/run/api) for non-interactive workflows when possible.
 
-If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace.
+If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches with the `-auto-approve` flag based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting you to approve the plan.
 
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
 - **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting for approval.

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -47,7 +47,7 @@ To supplement these remote operations, you can also use the optional [Terraform 
 
 To enable the CLI-driven workflow, you must:
 
-1. Run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can [manually configure credentials in the CLI config file](/cli/config/config-file#credentials).
+1. Run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can [manually configure credentials in the CLI config file](/cli/config/config-file#environment-variable-credentials.
 
 1. Add the `cloud` block to your Terraform configuration. You can define its arguments directly in your configuration file or supply them through environment variables, which can be useful for [non-interactive workflows](#non-interactive-workflows). Refer to [Using Terraform Cloud](/cli/cloud) for configuration details.
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -49,7 +49,9 @@ To enable the CLI-driven workflow, you must:
 
 1. Run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can [manually configure credentials in the CLI config file](/cli/config/config-file#credentials).
 
-1. Add the `cloud` block to your Terraform configuration. The example below shows how you can map your CLI workspaces to Terraform Cloud workspaces that have a specific tag.
+1. Add the `cloud` block to your Terraform configuration. You can define its arguments direcly in your configuration file or supply them through for [non-interactive workflows](#non-interactive-workflows). Refer to [Using Terraform Cloud](/cli/cloud) for configuration details.
+
+   The following example shows how to map CLI workspaces to Terraform Cloud workspaces with a specific tag.
 
    ```
    terraform {
@@ -83,8 +85,6 @@ To enable the CLI-driven workflow, you must:
    If you ever set or change modules or Terraform Settings,
    run "terraform init" again to reinitialize your working directory.
    ```
-
-Refer to [Using Terraform Cloud](/cli/cloud) for more details about how to initialize and configure the integration.
 
 ### Implicit Workspace Creation
 
@@ -124,7 +124,7 @@ you can do so by defining a [`.terraformignore` file in your configuration direc
 
 ## Remote Speculative Plans
 
-You can run speculative plans in any workspace where you have permission to queue plans. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
+You can run speculative plans in any workspace where you have [permission to queue plans](/cloud-docs/users-teams-organizations/permissions). Speculative plans use the configuration code from the local working directory, but will use variable values from the specified workspace.
 
 To run a [speculative plan][] on your configuration, use the `terraform plan` command. The plan will run in Terraform Cloud, and the logs will stream back to the command line along with a URL to view the plan in the Terraform Cloud UI.
 
@@ -151,11 +151,12 @@ Changes to Outputs:
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-Speculative plans use the configuration code from the local working directory, but will use variable values from the specified workspace.
 
 ## Remote Applies
 
-In workspaces that aren't connected to a VCS repository, users with permission to apply runs can trigger remote applies with the CLI. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
+In workspaces that are not connected to a VCS repository, users with [permission to apply runs](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) can use the CLI to trigger remote applies. Remote applies use the configuration code from the local working directory, but use the variable values from the specified workspace.
+
+~> **Important:** You cannot run remote applies in workspaces that are linked to a VCS repository, since the repository serves as the workspace’s source of truth. To apply changes in a VCS-linked workspace, merge your changes to the designated branch.
 
 When you are ready to apply configuration changes, use the `terraform apply` command. Terraform Cloud will plan your changes, and the command line will prompt you for approval before applying them.
 
@@ -191,11 +192,28 @@ Do you want to perform these actions in workspace "docs-workspace"?
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 ```
 
+### Non-Interactive Workflows
+
+You can use [environment variables](/cli/cloud/settings#environment-variables) to configure `cloud` block attributes in non-interactive workflows like Continuous Integration/Continuous Deployment (CI/CD). External systems cannot run the traditional apply workflow because it requires console input from the user to approve plans. Instead, you must choose one of the following approaches.
+
+#### Automatically approve plans
+
+Add the [`-auto-approve`](/cli/commands/apply#auto-approve) flag to skip the plan approval step in the apply workflow.
+```bash
+$ terraform apply -auto-approve
+```
+
+We do not recommend this approach for production use cases because you cannot review proposed changes before Terraform applies them.
+
+#### Run a speculative plan
+
+You can first run and review a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. We recommend the following approaches based on your [execution mode](/cloud-docs/workspaces/settings#execution-mode).
+
+- For local execution, save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
+-  For remote execution, Terraform Cloud does not support uploding a saved plan, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan. The more time passes between the speculative plan and the apply, the more you risk drift. Drift occurs when there are changes to your infrastructure outside of Terraform, and the Terraform plan represents these as diffs. When you auto-approve plans that may contain drift, you risk making unintended changes to your infrastructure. For this reason, we do not recommend this approach for production use cases.
+
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-Remote applies use the configuration code from the local working directory, but use the variable values from the specified workspace.
-
-~> **Important:** You cannot run remote applies in workspaces that are linked to a VCS repository, since the repository serves as the workspace’s source of truth. To apply changes in a VCS-linked workspace, merge your changes to the designated branch.
 
 ## Sentinel Policies
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -49,7 +49,7 @@ To enable the CLI-driven workflow, you must:
 
 1. Run `terraform login` to authenticate with Terraform Cloud. Alternatively, you can [manually configure credentials in the CLI config file](/cli/config/config-file#credentials).
 
-1. Add the `cloud` block to your Terraform configuration. You can define its arguments direcly in your configuration file or supply them through for [non-interactive workflows](#non-interactive-workflows). Refer to [Using Terraform Cloud](/cli/cloud) for configuration details.
+1. Add the `cloud` block to your Terraform configuration. You can define its arguments directly in your configuration file or supply them through environment variables, which can be useful for [non-interactive workflows](#non-interactive-workflows). Refer to [Using Terraform Cloud](/cli/cloud) for configuration details.
 
    The following example shows how to map CLI workspaces to Terraform Cloud workspaces with a specific tag.
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -194,23 +194,14 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 ### Non-Interactive Workflows
 
-You can use [environment variables](/cli/cloud/settings#environment-variables) to configure `cloud` block attributes in non-interactive workflows like Continuous Integration/Continuous Deployment (CI/CD). External systems cannot run the traditional apply workflow because it requires console input from the user to approve plans. Instead, you must choose one of the following approaches.
+External systems cannot run the traditional apply workflow because Terraform requires console input from the user to approve plans. We recommend using the [API-driven Run Workflow](/cloud-docs/run/api) for non-interactive workflows when possible.
 
-#### Automatically approve plans
+If you prefer to use the CLI, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) for your workspaces.
 
-Add the [`-auto-approve`](/cli/commands/apply#auto-approve) flag to skip the plan approval step in the apply workflow.
-```bash
-$ terraform apply -auto-approve
-```
+- **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
+- **Remote Execution:** Terraform Cloud does not support uploding a saved plan, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan to reduce the risk of drift. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips the plan approval step in the apply workflow.
 
-We do not recommend this approach for production use cases because you cannot review proposed changes before Terraform applies them.
-
-#### Run a speculative plan
-
-You can first run and review a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. We recommend the following approaches based on your [execution mode](/cloud-docs/workspaces/settings#execution-mode).
-
-- For local execution, save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
--  For remote execution, Terraform Cloud does not support uploding a saved plan, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan. The more time passes between the speculative plan and the apply, the more you risk drift. Drift occurs when there are changes to your infrastructure outside of Terraform, and the Terraform plan represents these as diffs. When you auto-approve plans that may contain drift, you risk making unintended changes to your infrastructure. For this reason, we do not recommend this approach for production use cases.
+  ~> **Warning:** Remote execution with non-interactive workflows may introduce drift. Drift occurs when there are changes to your infrastructure outside of Terraform. When you auto-approve new, unsaved plans, you risk making unintended changes to your infrastructure.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -201,7 +201,7 @@ If you prefer to use the CLI, we recommend first running a [speculative plan](/c
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
 - **Remote Execution:** Terraform Cloud does not support uploding a saved plan, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan to reduce the risk of drift. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips the plan approval step in the apply workflow.
 
-  ~> **Warning:** Remote execution with non-interactive workflows may introduce drift. Drift occurs when there are changes to your infrastructure outside of Terraform. When you auto-approve new, unsaved plans, you risk making unintended changes to your infrastructure.
+  ~> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -156,7 +156,7 @@ Changes to Outputs:
 
 In workspaces that are not connected to a VCS repository, users with [permission to apply runs](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) can use the CLI to trigger remote applies. Remote applies use the configuration code from the local working directory, but use the variable values from the specified workspace.
 
-~> **Important:** You cannot run remote applies in workspaces that are linked to a VCS repository, since the repository serves as the workspace’s source of truth. To apply changes in a VCS-linked workspace, merge your changes to the designated branch.
+~> **Note:** You cannot run remote applies in workspaces that are linked to a VCS repository, since the repository serves as the workspace’s source of truth. To apply changes in a VCS-linked workspace, merge your changes to the designated branch.
 
 When you are ready to apply configuration changes, use the `terraform apply` command. Terraform Cloud will plan your changes, and the command line will prompt you for approval before applying them.
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -199,7 +199,7 @@ External systems cannot run the traditional apply workflow because Terraform req
 If you prefer to use the CLI, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) for your workspaces.
 
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
-- **Remote Execution:** Terraform Cloud does not support uploding a saved plan, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan to reduce the risk of drift. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips the plan approval step in the apply workflow.
+- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting for approval.
 
   ~> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -196,7 +196,7 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 External systems cannot run the traditional apply workflow because Terraform requires console input from the user to approve plans. We recommend using the [API-driven Run Workflow](/cloud-docs/run/api) for non-interactive workflows when possible.
 
-If you prefer to use the CLI, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) for your workspaces.
+If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace.
 
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
 - **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting for approval.

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -194,6 +194,8 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 ### Non-Interactive Workflows
 
+> **Hands On:** Try the [Deploy Infrastructure with Terraform Cloud and CircleCI](https://learn.hashicorp.com/tutorials/terraform/circle-ci) tutorial on HashiCorp Learn.
+
 External systems cannot run the traditional apply workflow because Terraform requires console input from the user to approve plans. We recommend using the [API-driven Run Workflow](/cloud-docs/run/api) for non-interactive workflows when possible.
 
 If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches with the `-auto-approve` flag based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting you to approve the plan.

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -199,7 +199,7 @@ External systems cannot run the traditional apply workflow because Terraform req
 If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches with the `-auto-approve` flag based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting you to approve the plan.
 
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
-- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting for approval.
+- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. 
 
   !> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -201,7 +201,7 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
 - **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting for approval.
 
-  ~> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
+  !> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/content/cloud-docs/run/cli.mdx
+++ b/content/cloud-docs/run/cli.mdx
@@ -199,7 +199,7 @@ External systems cannot run the traditional apply workflow because Terraform req
 If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches with the `-auto-approve` flag based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting you to approve the plan.
 
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
-- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` **immediately** after approving the speculative plan to prevent the plan from becoming stale. 
+- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan to prevent the plan from becoming stale. 
 
   !> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
 


### PR DESCRIPTION
### What
This PR contains a draft of proposed changes to the documentation to help support users who may want to pair the `cloud` block with a non-interactive workflow. 

Related to :https://github.com/hashicorp/terraform/pull/31058

### Why
Terraform Cloud does not support uploading a saved plan, so we need to explain to users how they can pair the `cloud` block with non-interactive workflows like CI and warn them that doing so introduces the risk of infrastructure drift. 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.