### PR TITLE
Correct typo and inconsistent capitalisation in Terraform Cloud / Enterprise nav menu items

### DIFF
--- a/data/cloud-docs-nav-data.json
+++ b/data/cloud-docs-nav-data.json
@@ -278,7 +278,7 @@
         ]
       },
       {
-        "title": "Splunk integration",
+        "title": "Splunk Integration",
         "path": "integrations/splunk"
       },
       {
@@ -383,7 +383,7 @@
         "path": "api-docs/state-version-outputs"
       },
       { "title": "Subscriptions", "path": "api-docs/subscriptions" },
-      { "title": "Team Acccess", "path": "api-docs/team-access" },
+      { "title": "Team Access", "path": "api-docs/team-access" },
       { "title": "Team Membership", "path": "api-docs/team-members" },
       { "title": "Team Tokens", "path": "api-docs/team-tokens" },
       { "title": "Teams", "path": "api-docs/teams" },


### PR DESCRIPTION
### What

I spotted a typo in the navigation menu on the https://www.terraform.io/cloud-docs pages and some inconsistent capitalisation and wanted to help fix them

- Typo in menu link to https://www.terraform.io/cloud-docs/api-docs/team-access
- Inconsistent capitalisation in menu link to https://www.terraform.io/cloud-docs/integrations/splunk

### Why

Stops spelling/formatting issues interrupting users reading content

### Screenshots

| Issue | Before | After |
| ---- | ---- |---- | 
| Typo | <img width="173" alt="Screenshot 2022-05-11 at 12 56 32" src="https://user-images.githubusercontent.com/15078782/167845082-037f8f5c-6e76-47d0-98f5-5cb9e0274d0f.png"> | <img width="183" alt="Screenshot 2022-05-11 at 12 57 14" src="https://user-images.githubusercontent.com/15078782/167845186-ccf66702-5d98-44e0-a4eb-9107462bfaed.png"> |
| Capitalisation | <img width="241" alt="Screenshot 2022-05-11 at 12 56 42" src="https://user-images.githubusercontent.com/15078782/167844217-91ba7e60-f8c7-4923-9ba7-8b871cd2f292.png"> | <img width="248" alt="Screenshot 2022-05-11 at 12 56 58" src="https://user-images.githubusercontent.com/15078782/167845014-abffdbc4-d745-4b94-a3d3-53ca938a38a0.png"> |

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x]  (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.