### PR TITLE
Update aws.mdx

### DIFF
--- a/content/cloud-docs/cost-estimation/aws.mdx
+++ b/content/cloud-docs/cost-estimation/aws.mdx
@@ -15,7 +15,6 @@ Terraform Cloud can estimate monthly costs for many AWS Terraform resources.
 Below is a list of resources that cost estimation supports:
 
 * aws_alb
-* aws_autoscaling_group
 * aws_cloudhsm_v2_hsm
 * aws_cloudwatch_dashboard
 * aws_cloudwatch_metric_alarm


### PR DESCRIPTION
aws_autoscaling_group should be removed from supported list of resources for cost estimation since it is not a cost carrying resource on AWS

### What
aws_autoscaling_group should be removed from supported list of resources for cost estimation

### Why
aws_autoscaling_group is not a cost carrying resource, cost estimation will return null for this

### Screenshots
![image](https://user-images.githubusercontent.com/32132864/168615649-7c0dc9b8-29b7-4c4c-be9a-5e7dd3be751d.png)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.