### PR TITLE
Clarify that workspace admins cannot manage secret teams

### DIFF
--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -100,9 +100,11 @@ Workspace admins have the following permissions on their workspace:
 - Read and write variables
 - Read and write state versions
 - Read and write workspace settings (workspace admins only) — this includes general settings, notification configurations, run triggers, and more.
-- Set or remove workspace permissions for any team (workspace admins only)
+- Set or remove workspace permissions for visible teams (workspace admins only)
 - Delete workspace (workspace admins only)
 - Manage workspace run tasks
+
+Workspace admins do not implicitly have access to view all teams within their organization. This means that workspace admins are not able to manage workspace permissions for teams which are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organiztion owners.
 
 See [General Workspace Permissions][] above for details about specific permissions.
 

--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -90,7 +90,7 @@ Much like the owners team has full control over an organization, each workspace 
 
 Admin permissions include the highest level of general permissions for the workspace. There are also some permissions that are only available to workspace admins, which generally involve changing the workspace's settings or setting access levels for other teams.
 
-Workspace admins have all the permissions described in [General Workspace Permissions][], as well as the ability to:
+Workspace admins have all [General Workspace Permissions][], as well as the ability to do the following tasks:
 
 - Read and write workspace settings — this includes general settings, notification configurations, run triggers, and more.
 - Set or remove workspace permissions for visible teams. Workspace admins cannot view or manage teams that are are [Secret](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.

--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -93,7 +93,7 @@ Admin permissions include the highest level of general permissions for the works
 Workspace admins have all the permissions described in [General Workspace Permissions][], as well as the ability to:
 
 - Read and write workspace settings — this includes general settings, notification configurations, run triggers, and more.
-- Set or remove workspace permissions for visible teams. Workspace admins cannot view or manage teams that are are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
+- Set or remove workspace permissions for visible teams. Workspace admins cannot view or manage teams that are are [Secret](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
 - Delete the workspace
 
 ### Fixed Permission Sets

--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -101,12 +101,11 @@ Workspace admins have the following permissions on their workspace:
 - Read and write state versions
 - Read and write workspace settings (workspace admins only) — this includes general settings, notification configurations, run triggers, and more.
 - Set or remove workspace permissions for visible teams (workspace admins only)
+  - Workspace admins cannot view or manage teams that are are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
 - Delete workspace (workspace admins only)
 - Manage workspace run tasks
 
-Workspace admins do not implicitly have access to view all teams within their organization. This means that workspace admins are not able to manage workspace permissions for teams which are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organiztion owners.
-
-See [General Workspace Permissions][] above for details about specific permissions.
+Refer to [General Workspace Permissions][] for details about specific permissions.
 
 ### Fixed Permission Sets
 

--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -92,7 +92,7 @@ Admin permissions include the highest level of general permissions for the works
 
 Workspace admins have all [General Workspace Permissions][], as well as the ability to do the following tasks:
 
-- Read and write workspace settings — this includes general settings, notification configurations, run triggers, and more.
+- Read and write workspace settings. This includes general settings, notification configurations, run triggers, and more.
 - Set or remove workspace permissions for visible teams. Workspace admins cannot view or manage teams that are are [Secret](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
 - Delete the workspace
 

--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -90,21 +90,11 @@ Much like the owners team has full control over an organization, each workspace 
 
 Admin permissions include the highest level of general permissions for the workspace. There are also some permissions that are only available to workspace admins, which generally involve changing the workspace's settings or setting access levels for other teams.
 
-Workspace admins have the following permissions on their workspace:
+Workspace admins have all the permissions described in [General Workspace Permissions][], as well as the ability to:
 
-- Apply runs
-- Lock and unlock workspace
-
-  -> **Note**: Typically, only the user who created the lock can unlock a workspace. Administrators and members of the Owners team can use [Force unlock](/docs/cloud/workspaces/settings.html#locking) to override this and unlock a workspace.
-- Download Sentinel mocks
-- Read and write variables
-- Read and write state versions
-- Read and write workspace settings (workspace admins only) — this includes general settings, notification configurations, run triggers, and more.
-- Set or remove workspace permissions for visible teams (workspace admins only). Workspace admins cannot view or manage teams that are are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
-- Delete workspace (workspace admins only)
-- Manage workspace run tasks
-
-Refer to [General Workspace Permissions][] for details about specific permissions.
+- Read and write workspace settings — this includes general settings, notification configurations, run triggers, and more.
+- Set or remove workspace permissions for visible teams. Workspace admins cannot view or manage teams that are are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
+- Delete the workspace
 
 ### Fixed Permission Sets
 

--- a/content/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/content/cloud-docs/users-teams-organizations/permissions.mdx
@@ -100,8 +100,7 @@ Workspace admins have the following permissions on their workspace:
 - Read and write variables
 - Read and write state versions
 - Read and write workspace settings (workspace admins only) — this includes general settings, notification configurations, run triggers, and more.
-- Set or remove workspace permissions for visible teams (workspace admins only)
-  - Workspace admins cannot view or manage teams that are are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
+- Set or remove workspace permissions for visible teams (workspace admins only). Workspace admins cannot view or manage teams that are are ["Secret"](/cloud-docs/users-teams-organizations/teams#team-visibility), unless they are also organization owners.
 - Delete workspace (workspace admins only)
 - Manage workspace run tasks
 


### PR DESCRIPTION
### What
Clarify that workspace admin permissions do not confer the ability to manage the workspace settings of "secret" teams within their organizations

### Why
There was recently some (IMO justified) [confusion around this](https://app.asana.com/0/157256879238414/1202071425828049/f). This is actually already called out in the [Team Visibility](https://www.terraform.io/cloud-docs/users-teams-organizations/teams#team-visibility) section, but adding a note to the workspace permissions side to increase discoverability

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (n/a) Redirects have been added for moved, renamed, or deleted pages.
- [x] (n/a) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (n/a) Pages with related content are updated and link to this content when appropriate.
- [x] (n/a) New pages have metadata (page name and description) at the top.
- [x] (n/a) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (n/a) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (n/a) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.