### PR TITLE
adds message about the audit log bug to TFE v202205-1 release

### DIFF
--- a/content/enterprise/releases/2022/v202205-1.mdx
+++ b/content/enterprise/releases/2022/v202205-1.mdx
@@ -24,6 +24,7 @@ page_title: Releases - Terraform Enterprise
 8. Fixed a bug that caused Git operations to retry unrecoverable authentication errors.
 9. Improved agent dequeueing performance for large agent pools.
 10. Changed Vault CLI commands to Vault API calls for token creation. This will prevent any Vault CLI/Server version mismatch errors.
+11. Fixed issue where log tags such as "[Audit Log]" were not visible in logs.
 
 ## APPLICATION LEVEL SECURITY FIXES:
 


### PR DESCRIPTION
### What
An additional change from [this PR](https://github.com/hashicorp/atlas/pull/12343) to the release notes.

### Why
The backport did not get captured into the release notes changelog since it was included after the changelog PR was generated.