### PR TITLE
[DO NOT MERGE UNTIL v1.3] Add redirect for optional types attributes page

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -286,10 +286,21 @@ module.exports = (async () => {
     },
   ];
 
+  // Some backends were removed in Terraform v1.3 so their old URLs will
+  // redirect into the v1.2.x docs.
+  const legacyBackendRedirects = ['artifactory', 'etcd', 'etcdv3', 'manta', 'swift'].map(
+    (slug) => ({
+      source: '/language/settings/backends/' + slug,
+      destination: '/language/v1.2.x/settings/backends/' + slug,
+      permanent: true,
+    })
+  );
+
   return [
     ...registryTopLevelRedirects,
     ...registryDocsRedirects,
     ...upgradeGuideRedirects,
+    ...legacyBackendRedirects,
     ...miscRedirects,
   ]
 })()

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -237,7 +237,8 @@ module.exports = (async () => {
     '/language/resources/provisioners/chef': '/language/v1.1.x/resources/provisioners/chef',
     '/language/resources/provisioners/habitat': '/language/v1.1.x/resources/provisioners/habitat',
     '/language/resources/provisioners/puppet': '/language/v1.1.x/resources/provisioners/puppet',
-    '/language/resources/provisioners/salt-masterless': '/language/v1.1.x/resources/provisioners/salt-masterless'
+    '/language/resources/provisioners/salt-masterless': '/language/v1.1.x/resources/provisioners/salt-masterless',
+    '/docs/language/functions/defaults': '/docs/language/expressions/type-constraints#optional-object-type-attributes',
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
### What
Add a redirect for now removed `default` function page. This page will be removed in Terraform v1.3 because we're releasing Optional Object Type Attributes : https://github.com/hashicorp/terraform/pull/31210

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.