### PR TITLE
Document option to skip backing up object storage

### DIFF
--- a/content/enterprise/admin/infrastructure/backup-restore.mdx
+++ b/content/enterprise/admin/infrastructure/backup-restore.mdx
@@ -108,9 +108,10 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path   | Type   | Default | Description                                   |
-| ---------- | ------ | ------- | --------------------------------------------- |
-| `password` | string |         | The password used to encrypt the backup blob. |
+| Key path              | Type   | Default | Description                                                |
+| --------------------- | ------ | ------- | ---------------------------------------------------------- |
+| `password`            | string |         | The password used to encrypt the backup blob.              |
+| `skip_object_storage` | bool   | `false` | Whether or not to skip backing up the object storage data. |
 
 ### Sample Payload
 


### PR DESCRIPTION
### What

Documenting the new `skip_object_storage` option for the backup/restore API.

### Why

Because new features should be documented.

### Screenshots

N/A

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
