### PR TITLE
More scoped Vault policy

### DIFF
--- a/content/enterprise/requirements/data-storage/vault.mdx
+++ b/content/enterprise/requirements/data-storage/vault.mdx
@@ -41,31 +41,31 @@ Terraform Enterprise.
   ```hcl
   # To renew leases.
   path "sys/leases/renew" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["create", "update"]
   }
   path "sys/renew" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["create", "update"]
   }
 
   # To renew tokens.
   path "auth/token/renew" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["create", "update"]
   }
   path "auth/token/renew-self" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["create", "update"]
   }
 
   # To perform a login.
   path "auth/approle/login" {
-    capabilities = ["create", "read"]
+    capabilities = ["create", "update"]
   }
 
   # To upsert transit keys used for key generation.
   path "transit/keys/atlas_*" {
-   capabilities = ["create", "read", "update"]
+   capabilities = ["read", "create", "update"]
   }
   path "transit/keys/archivist_*" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["read", "create", "update"]
   }
 
   # Encryption and decryption of data.
@@ -73,38 +73,38 @@ Terraform Enterprise.
     capabilities = ["create", "update"]
   }
   path "transit/decrypt/atlas_*" {
-    capabilities = ["update"]
+    capabilities = ["create", "update"]
   }
   path "transit/encrypt/archivist_*" {
     capabilities = ["create", "update"]
   }
   path "transit/decrypt/archivist_*" {
-    capabilities = ["update"]
+    capabilities = ["create", "update"]
   }
 
   # For performing key derivation.
   path "transit/datakey/plaintext/archivist_*" {
-    capabilities = ["update"]
+    capabilities = ["create", "update"]
   }
 
   # For backup/restore operations.
   path "transit/keys/atlas_*/config" {
-    capabilities = ["read", "update"]
+    capabilities = ["read", "create", "update"]
   }
   path "transit/backup/atlas_*" {
     capabilities = ["read"]
   }
   path "transit/restore/atlas_*" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["read", "create", "update"]
   }
   path "transit/keys/archivist_*/config" {
-    capabilities = ["read", "update"]
+    capabilities = ["read", "create", "update"]
   }
   path "transit/backup/archivist_*" {
     capabilities = ["read"]
   }
   path "transit/restore/archivist_*" {
-    capabilities = ["create", "read", "update"]
+    capabilities = ["read", "create", "update"]
   }
 
   # For health checks to read the mount table.

--- a/content/enterprise/requirements/data-storage/vault.mdx
+++ b/content/enterprise/requirements/data-storage/vault.mdx
@@ -40,15 +40,18 @@ Terraform Enterprise.
 
   ```hcl
   # To renew leases.
-  path "sys/leases/renew/*" {
+  path "sys/leases/renew" {
     capabilities = ["create", "read", "update"]
   }
-  path "sys/renew/*" {
+  path "sys/renew" {
     capabilities = ["create", "read", "update"]
   }
 
   # To renew tokens.
-  path "auth/token/renew/*" {
+  path "auth/token/renew" {
+    capabilities = ["create", "read", "update"]
+  }
+  path "auth/token/renew-self" {
     capabilities = ["create", "read", "update"]
   }
 


### PR DESCRIPTION
### What

The `/*` paths were not necessary on these paths.

Removed `read` where it was not applicable. Fixed missing `create` and/or `update` because the [Vault documentation](https://www.vaultproject.io/docs/concepts/policies#capabilities) states this:

> [`create`](https://www.vaultproject.io/docs/concepts/policies#create) (`POST/PUT`) - Allows creating data at the given path. Very few parts of Vault distinguish between `create` and `update`, so most operations require both `create` and `update` capabilities. Parts of Vault that provide such a distinction are noted in documentation.

### Why

I spoke with a Vault Engineer on this. Got this recommendation.

### Screenshots

N/A

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
