### PR TITLE
fix: cloud-docs/agents images in local preview

### DIFF
--- a/pages/cloud-docs/agents/[[...page]].tsx
+++ b/pages/cloud-docs/agents/[[...page]].tsx
@@ -54,7 +54,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
           remarkRewriteAssets({
             product: SOURCE_REPO,
             version: process.env.CURRENT_GIT_BRANCH,
-            getAssetPathParts: (nodeUrl) => [nodeUrl],
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
           }),
         ],
       }


### PR DESCRIPTION
### What

This fixes a case where images for `cloud-docs/agents` don't get re-written properly during **preview**



### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.