### PR TITLE
fix: releases pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@hashicorp/react-code-block": "^4.4.0",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.1.0",
-        "@hashicorp/react-docs-page": "^17.1.2-canary-20220706153646",
+        "@hashicorp/react-docs-page": "^17.1.2",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-hero": "8.0.3",
@@ -2829,9 +2829,9 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "17.1.2-canary-20220706153646",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.2-canary-20220706153646.tgz",
-      "integrity": "sha512-rYFietFr6ke4ok9yBj0bSQYBJ0fBdptM3oNALyHb8L6kxaduPd//T4I2RHFlKmZe3oQmGC73+omNhHBNS2wbyQ==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.2.tgz",
+      "integrity": "sha512-1CLDmRAg0fcEIM2XEtdGqu76jjaPJGRivOxmBkeAulUk5iJyRRdXyZJZouqzzxmd2ki6W2eaekyli35bJpG5dg==",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -29513,9 +29513,9 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "17.1.2-canary-20220706153646",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.2-canary-20220706153646.tgz",
-      "integrity": "sha512-rYFietFr6ke4ok9yBj0bSQYBJ0fBdptM3oNALyHb8L6kxaduPd//T4I2RHFlKmZe3oQmGC73+omNhHBNS2wbyQ==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.2.tgz",
+      "integrity": "sha512-1CLDmRAg0fcEIM2XEtdGqu76jjaPJGRivOxmBkeAulUk5iJyRRdXyZJZouqzzxmd2ki6W2eaekyli35bJpG5dg==",
       "requires": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-product-meta": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@hashicorp/react-code-block": "^4.4.0",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.1.0",
-        "@hashicorp/react-docs-page": "^17.1.1",
+        "@hashicorp/react-docs-page": "^17.1.2-canary-20220706153646",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-hero": "8.0.3",
@@ -2829,9 +2829,9 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.1.tgz",
-      "integrity": "sha512-R39aFaX0dl+CIPvb/l1uwZzTXGJIapsIRwJ1xrT0fM08pIAKgKzXPoGHjhQKOYhshK7HEDO2ucmGy/bvBvqNJA==",
+      "version": "17.1.2-canary-20220706153646",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.2-canary-20220706153646.tgz",
+      "integrity": "sha512-rYFietFr6ke4ok9yBj0bSQYBJ0fBdptM3oNALyHb8L6kxaduPd//T4I2RHFlKmZe3oQmGC73+omNhHBNS2wbyQ==",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -29513,9 +29513,9 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.1.tgz",
-      "integrity": "sha512-R39aFaX0dl+CIPvb/l1uwZzTXGJIapsIRwJ1xrT0fM08pIAKgKzXPoGHjhQKOYhshK7HEDO2ucmGy/bvBvqNJA==",
+      "version": "17.1.2-canary-20220706153646",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.1.2-canary-20220706153646.tgz",
+      "integrity": "sha512-rYFietFr6ke4ok9yBj0bSQYBJ0fBdptM3oNALyHb8L6kxaduPd//T4I2RHFlKmZe3oQmGC73+omNhHBNS2wbyQ==",
       "requires": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-product-meta": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hashicorp/react-code-block": "^4.4.0",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.1.0",
-    "@hashicorp/react-docs-page": "^17.1.1",
+    "@hashicorp/react-docs-page": "^17.1.2-canary-20220706153646",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-hero": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hashicorp/react-code-block": "^4.4.0",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.1.0",
-    "@hashicorp/react-docs-page": "^17.1.2-canary-20220706153646",
+    "@hashicorp/react-docs-page": "^17.1.2",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-hero": "8.0.3",


### PR DESCRIPTION
### What

This fixes 
- [x] https://www.terraform.io/enterprise/releases/2022/v202206-1
- [x] https://terraform-website-git-kevin-fix-releases-page-hashicorp.vercel.app/enterprise/releases/2022/v202206-1

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.