### PR TITLE
chore: remove cloud-docs-nav-data from ent

### DIFF
--- a/pages/enterprise/[[...page]].tsx
+++ b/pages/enterprise/[[...page]].tsx
@@ -23,12 +23,7 @@ const SOURCE_REPO = 'ptfe-releases'
 export default function EnterpriseLayout(props) {
   // add the "other docs" section to the bottom of the nav data
   const modifiedProps = Object.assign({}, props)
-  // This specific page is a special case as it refelcts an exact copy of the cloud docs.
-  // To do this, we pull the cloud docs data directly and massage it a little so that it
-  // works out of context on this page.
-  modifiedProps.navData = modifiedProps.navData
-    // .concat(transformCloudDocsData(props.cloudDocsNavData))
-    .concat(otherDocsData)
+  modifiedProps.navData = modifiedProps.navData.concat(otherDocsData)
 
   return (
     <DocsPage
@@ -40,102 +35,39 @@ export default function EnterpriseLayout(props) {
   )
 }
 
-const { getStaticPaths, getStaticProps: _getStaticProps } =
-  getStaticGenerationFunctions(
-    process.env.IS_CONTENT_PREVIEW &&
-      process.env.PREVIEW_FROM_REPO === SOURCE_REPO
-      ? {
-          strategy: 'fs',
-          localContentDir: CONTENT_DIR,
-          navDataFile: NAV_DATA,
-          product: SOURCE_REPO,
-          githubFileUrl(filepath) {
-            // enterprise pages will not be editable by contributors.
-            //
-            // todo: maybe link to a GitHub issue?
-            return null
-          },
-          remarkPlugins: (params) => [
-            ...remarkPlugins,
-            remarkRewriteAssets({
-              product: SOURCE_REPO,
-              version: process.env.CURRENT_GIT_BRANCH,
-              getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
-            }),
-          ],
-          rehypePlugins,
-        }
-      : {
-          fallback: 'blocking',
-          revalidate: 360, // 1 hour
-          strategy: 'remote',
-          basePath: BASE_ROUTE,
-          product: SOURCE_REPO,
-          remarkPlugins,
-          rehypePlugins,
-        }
-  )
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
+  process.env.IS_CONTENT_PREVIEW &&
+    process.env.PREVIEW_FROM_REPO === SOURCE_REPO
+    ? {
+        strategy: 'fs',
+        localContentDir: CONTENT_DIR,
+        navDataFile: NAV_DATA,
+        product: SOURCE_REPO,
+        githubFileUrl(filepath) {
+          // enterprise pages will not be editable by contributors.
+          //
+          // todo: maybe link to a GitHub issue?
+          return null
+        },
+        remarkPlugins: (params) => [
+          ...remarkPlugins,
+          remarkRewriteAssets({
+            product: SOURCE_REPO,
+            version: process.env.CURRENT_GIT_BRANCH,
+            getAssetPathParts: (nodeUrl) => ['website', nodeUrl],
+          }),
+        ],
+        rehypePlugins,
+      }
+    : {
+        fallback: 'blocking',
+        revalidate: 360, // 1 hour
+        strategy: 'remote',
+        basePath: BASE_ROUTE,
+        product: SOURCE_REPO,
+        remarkPlugins,
+        rehypePlugins,
+      }
+)
 
-export { getStaticPaths }
-
-/**
- * This is temporary helper to enable `/enterprise` to use "cloud-docs" nav data
- * which now lives in https://github.com/hashicorp/terraform-docs-common, and is
- * available via the "Content API".
- */
-async function fetchCloudDocsNavData() {
-  const url = new URL(
-    `/api/content/terraform-docs-common/nav-data/v0.0.x/cloud-docs`,
-    process.env.MKTG_CONTENT_API
-  )
-  const response = await fetch(url.toString())
-  const data = await response.json()
-
-  return data.result.navData
-}
-
-// This is a temporary workaround to fetch cloud-docs nav-data from the Content API
-// serverside, and allow the enterprise page to use it.
-export const getStaticProps = async (context) => {
-  const cloudDocsNavData = await fetchCloudDocsNavData()
-  const res = await _getStaticProps(context)
-
-  // @ts-ignore
-  res.props.cloudDocsNavData = cloudDocsNavData
-  // @ts-ignore — make sure revalidate is serializable
-  res.props.revalidate = null
-  // @ts-ignore
-  return { props: res.props }
-}
-
-// // This function is used specifically to modify the data from the cloud docs
-// // navigation so that it works on the enterprise page.
-// function transformCloudDocsData(_data) {
-//   let data = JSON.parse(JSON.stringify(_data))
-//   // remove the top headline, it is worded differently on this page
-//   data.splice(0, 1)
-//   // remove the final two items which link to the enterprise docs, not needed since
-//   // we are already on that page
-//   data.splice(data.length - 2, 2)
-//   // change over every "path" prop to be an "href" instead
-//   // path props are used to link directly to a category's own nav items, where
-//   // href can be used to arbitrarily link outside a category, which is what we're doing
-//   // here, since we're listing out cloud docs from the enterprise page
-//   data = pathToHref(data)
-//   return data
-// }
-
-// // we have to recurse here in order to get all the nested nodes
-// function pathToHref(data) {
-//   data.map((item) => {
-//     if (item.path) {
-//       item.href = `/cloud-docs/${item.path}`
-//       delete item.path
-//     }
-
-//     if (item.routes) item.routes = pathToHref(item.routes)
-
-//     return item
-//   })
-//   return data
-// }
+export { getStaticPaths, getStaticProps }

--- a/pages/enterprise/[[...page]].tsx
+++ b/pages/enterprise/[[...page]].tsx
@@ -27,7 +27,7 @@ export default function EnterpriseLayout(props) {
   // To do this, we pull the cloud docs data directly and massage it a little so that it
   // works out of context on this page.
   modifiedProps.navData = modifiedProps.navData
-    .concat(transformCloudDocsData(props.cloudDocsNavData))
+    // .concat(transformCloudDocsData(props.cloudDocsNavData))
     .concat(otherDocsData)
 
   return (
@@ -108,34 +108,34 @@ export const getStaticProps = async (context) => {
   return { props: res.props }
 }
 
-// This function is used specifically to modify the data from the cloud docs
-// navigation so that it works on the enterprise page.
-function transformCloudDocsData(_data) {
-  let data = JSON.parse(JSON.stringify(_data))
-  // remove the top headline, it is worded differently on this page
-  data.splice(0, 1)
-  // remove the final two items which link to the enterprise docs, not needed since
-  // we are already on that page
-  data.splice(data.length - 2, 2)
-  // change over every "path" prop to be an "href" instead
-  // path props are used to link directly to a category's own nav items, where
-  // href can be used to arbitrarily link outside a category, which is what we're doing
-  // here, since we're listing out cloud docs from the enterprise page
-  data = pathToHref(data)
-  return data
-}
+// // This function is used specifically to modify the data from the cloud docs
+// // navigation so that it works on the enterprise page.
+// function transformCloudDocsData(_data) {
+//   let data = JSON.parse(JSON.stringify(_data))
+//   // remove the top headline, it is worded differently on this page
+//   data.splice(0, 1)
+//   // remove the final two items which link to the enterprise docs, not needed since
+//   // we are already on that page
+//   data.splice(data.length - 2, 2)
+//   // change over every "path" prop to be an "href" instead
+//   // path props are used to link directly to a category's own nav items, where
+//   // href can be used to arbitrarily link outside a category, which is what we're doing
+//   // here, since we're listing out cloud docs from the enterprise page
+//   data = pathToHref(data)
+//   return data
+// }
 
-// we have to recurse here in order to get all the nested nodes
-function pathToHref(data) {
-  data.map((item) => {
-    if (item.path) {
-      item.href = `/cloud-docs/${item.path}`
-      delete item.path
-    }
+// // we have to recurse here in order to get all the nested nodes
+// function pathToHref(data) {
+//   data.map((item) => {
+//     if (item.path) {
+//       item.href = `/cloud-docs/${item.path}`
+//       delete item.path
+//     }
 
-    if (item.routes) item.routes = pathToHref(item.routes)
+//     if (item.routes) item.routes = pathToHref(item.routes)
 
-    return item
-  })
-  return data
-}
+//     return item
+//   })
+//   return data
+// }


### PR DESCRIPTION
This updates `/enterprise` to no longer fetch-and-concat `/cloud-docs` nav-data.

This should be paired with (deployed **after**) the merging of TFC+TFE docs, and updating of `TFE v202206-1` docs

### What
<!-- Explain what you changed and provide a list of changed page names. -->

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.