### PR TITLE
Add a redirect to the dependency-lock#checksum-verification documentation.

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -213,7 +213,8 @@ module.exports = (async () => {
     '/cloud-docs/run': '/cloud-docs/run/remote-operations',
     '/language/settings/backends': '/language/settings/backends/configuration',
     '/cloud-docs/api-docs/run-tasks': '/cloud-docs/api-docs/run-tasks/run-tasks',
-    '/cloud-docs/api-docs/run-tasks-integration': '/cloud-docs/api-docs/run-tasks/run-tasks-integration'
+    '/cloud-docs/api-docs/run-tasks-integration': '/cloud-docs/api-docs/run-tasks/run-tasks-integration',
+    '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification'
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -214,7 +214,7 @@ module.exports = (async () => {
     '/language/settings/backends': '/language/settings/backends/configuration',
     '/cloud-docs/api-docs/run-tasks': '/cloud-docs/api-docs/run-tasks/run-tasks',
     '/cloud-docs/api-docs/run-tasks-integration': '/cloud-docs/api-docs/run-tasks/run-tasks-integration',
-    '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification'
+    '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification' // Used by the Terraform CLI to short-link to documentation.
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
### What
Add a redirect to the dependency-lock#checksum-verification documentation. 

### Why
This will be referenced from the terraform CLI as it contains information about workarounds for a particular edge case in the terraform lock file lifecycle that is too difficult to explain in an error message.

We will use the redirect to make sure that even if the documentation is updated/moved older versions of terraform will can be retroactively updated to point to the wherever the new documentation is.

The original pull request that led to this decision is [here](https://github.com/hashicorp/terraform/pull/31408).

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] N/A I or someone else reviewed the content for typos, punctuation, spelling, and grammar.