### PR TITLE
fix(website): ISR: 3600s

### DIFF
--- a/pages/cdktf/[[...page]].tsx
+++ b/pages/cdktf/[[...page]].tsx
@@ -64,7 +64,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: SOURCE_REPO,

--- a/pages/cli/[[...page]].tsx
+++ b/pages/cli/[[...page]].tsx
@@ -58,7 +58,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/cloud-docs/[[...page]].tsx
+++ b/pages/cloud-docs/[[...page]].tsx
@@ -59,7 +59,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: SOURCE_REPO,

--- a/pages/cloud-docs/[[...page]].tsx
+++ b/pages/cloud-docs/[[...page]].tsx
@@ -29,6 +29,7 @@ export default function CloudDocsLayout(props) {
       baseRoute={BASE_ROUTE}
       product={PRODUCT}
       staticProps={modifiedProps}
+      showVersionSelect={false}
     />
   )
 }

--- a/pages/cloud-docs/agents/[[...page]].tsx
+++ b/pages/cloud-docs/agents/[[...page]].tsx
@@ -62,7 +62,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         navDataPrefix: NAV_DATA_PREFIX,

--- a/pages/configuration/[[...page]].tsx
+++ b/pages/configuration/[[...page]].tsx
@@ -47,7 +47,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/docs/[[...page]].tsx
+++ b/pages/docs/[[...page]].tsx
@@ -55,7 +55,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/enterprise/[[...page]].tsx
+++ b/pages/enterprise/[[...page]].tsx
@@ -67,7 +67,7 @@ const { getStaticPaths, getStaticProps: _getStaticProps } =
         }
       : {
           fallback: 'blocking',
-          revalidate: 360, // 1 hour
+          revalidate: 3600, // 1 hour
           strategy: 'remote',
           basePath: BASE_ROUTE,
           product: SOURCE_REPO,
@@ -102,8 +102,6 @@ export const getStaticProps = async (context) => {
 
   // @ts-ignore
   res.props.cloudDocsNavData = cloudDocsNavData
-  // @ts-ignore — make sure revalidate is serializable
-  res.props.revalidate = null
   // @ts-ignore
   return { props: res.props }
 }

--- a/pages/guides/[[...page]].tsx
+++ b/pages/guides/[[...page]].tsx
@@ -52,7 +52,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/internals/[[...page]].tsx
+++ b/pages/internals/[[...page]].tsx
@@ -46,7 +46,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/intro/[[...page]].tsx
+++ b/pages/intro/[[...page]].tsx
@@ -55,7 +55,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/language/[[...page]].tsx
+++ b/pages/language/[[...page]].tsx
@@ -57,7 +57,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: PRODUCT.slug,

--- a/pages/plugin/[[...page]].tsx
+++ b/pages/plugin/[[...page]].tsx
@@ -63,7 +63,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         product: SOURCE_REPO,

--- a/pages/plugin/[[...page]].tsx
+++ b/pages/plugin/[[...page]].tsx
@@ -35,6 +35,7 @@ function PluginLayout(props) {
       baseRoute={BASE_ROUTE}
       product={PRODUCT}
       staticProps={modifiedProps}
+      showVersionSelect={false}
     />
   )
 }

--- a/pages/plugin/framework/[[...page]].tsx
+++ b/pages/plugin/framework/[[...page]].tsx
@@ -59,7 +59,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         navDataPrefix: NAV_DATA_PREFIX,

--- a/pages/plugin/log/[[...page]].tsx
+++ b/pages/plugin/log/[[...page]].tsx
@@ -65,7 +65,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         navDataPrefix: NAV_DATA_PREFIX,

--- a/pages/plugin/mux/[[...page]].tsx
+++ b/pages/plugin/mux/[[...page]].tsx
@@ -59,7 +59,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         navDataPrefix: NAV_DATA_PREFIX,

--- a/pages/plugin/sdkv2/[[...page]].tsx
+++ b/pages/plugin/sdkv2/[[...page]].tsx
@@ -60,7 +60,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
       }
     : {
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         strategy: 'remote',
         basePath: BASE_ROUTE,
         navDataPrefix: NAV_DATA_PREFIX,

--- a/pages/registry/[[...page]].tsx
+++ b/pages/registry/[[...page]].tsx
@@ -61,7 +61,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions(
     : {
         strategy: 'remote',
         fallback: 'blocking',
-        revalidate: 360, // 1 hour
+        revalidate: 3600, // 1 hour
         basePath: BASE_ROUTE,
         product: SOURCE_REPO,
         remarkPlugins,


### PR DESCRIPTION
# Description

1. this explicitly disables the version select on `/cloud-docs` & `/plugin` 
   > **Note**: no perceived change today
1. this fixes ISR to be `3600` (1hr) for all subpaths
   > **Note**: this was previously `360` (6min)
1. this enables ISR on `/enterprise`