### PR TITLE
.circleci: Initial attempt at building and pushing multi-architecture images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ jobs:
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           name: Pull submodules
           command: git submodule update --init
@@ -19,19 +20,27 @@ jobs:
               exit 0
             else
               echo "Building full image..."
-              docker build -t hashicorp/terraform-website:$CIRCLE_SHA1 .
-              docker tag hashicorp/terraform-website:$CIRCLE_SHA1 hashicorp/terraform-website:full
+              docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
+              docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --push \
+                -t hashicorp/terraform-website:$CIRCLE_SHA1 \
+                -t hashicorp/terraform-website:full \
+                .
               IMAGE_TAG="$(git rev-list -n1 HEAD -- Dockerfile package-lock.json)"
               echo "Using $IMAGE_TAG for latest image"
               if curl https://hub.docker.com/v2/repositories/hashicorp/terraform-website/tags/$IMAGE_TAG -fsL > /dev/null; then
-                echo "Dependencies have not changed, not building a new website docker image."
+                echo "Dependencies have not changed, not building a new website base docker image."
               else
                 echo "Building base image..."
-                docker build --target base -t hashicorp/terraform-website:$IMAGE_TAG .
-                docker tag hashicorp/terraform-website:$IMAGE_TAG hashicorp/terraform-website:latest
+                docker buildx build \
+                  --platform linux/amd64,linux/arm64 \
+                  --push \
+                  -t hashicorp/terraform-website:$IMAGE_TAG \
+                  -t hashicorp/terraform-website:latest \
+                  --target base \
+                  .
               fi
-              docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
-              docker push hashicorp/terraform-website
             fi
 workflows:
   version: 2


### PR DESCRIPTION
### What

Setup the CircleCI website-docker-image job to build and push images for both amd64 and arm64.

I'm not exactly sure if you folks have the ability to test this job update before trying it out, as I'm more used to GitHub Actions `docker/setup-buildx-action` to handle the buildx bits and `act` for local testing. If you'd like to migrate this to GitHub Actions, happy to assist that effort (I just cannot help with the secrets side of things, but I can help coordinate with the folks who can).

### Why

Performance on arm64 architecture machines, e.g. Apple M chips.

Closes #2378
Reference: https://circleci.com/docs/building-docker-images
Reference: https://docs.docker.com/engine/reference/commandline/buildx_build

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.