### PR TITLE
Add Redirect for Resources and Providers page (CDKTF)

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -214,7 +214,8 @@ module.exports = (async () => {
     '/language/settings/backends': '/language/settings/backends/configuration',
     '/cloud-docs/api-docs/run-tasks': '/cloud-docs/api-docs/run-tasks/run-tasks',
     '/cloud-docs/api-docs/run-tasks-integration': '/cloud-docs/api-docs/run-tasks/run-tasks-integration',
-    '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification' // Used by the Terraform CLI to short-link to documentation.
+    '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification', // Used by the Terraform CLI to short-link to documentation.
+    '/cdktf/concepts/providers-and-resources' : '/cdktf/concepts/providers'
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
### What
This [CDTKF PR](https://github.com/hashicorp/terraform-cdk/pull/1948) breaks a current page on providers and resources into two separate pages. This PR adds a redirect so users don't get 404s when they click links to the old page.

### Why
Users should never get 404s!

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.