### PR TITLE
chore: redirects from /configuration/*

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -218,8 +218,8 @@ module.exports = (async () => {
     '/cdktf/concepts/providers-and-resources' : '/cdktf/concepts/providers',
     // The /configuration pages have been deleted.
     '/configuration/expressions': '/language/expressions',
-    '/configuration/modules': '/language/modules/syntax',
-    '/configuration/resources': '/language/resources/syntax',
+    '/configuration/modules': '/language/modules',
+    '/configuration/resources': '/language/resources',
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -217,7 +217,7 @@ module.exports = (async () => {
     '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification', // Used by the Terraform CLI to short-link to documentation.
     '/cdktf/concepts/providers-and-resources' : '/cdktf/concepts/providers',
     // The /configuration pages have been deleted.
-    '/configuration/expressions': '/language/expressions/types',
+    '/configuration/expressions': '/language/expressions',
     '/configuration/modules': '/language/modules/syntax',
     '/configuration/resources': '/language/resources/syntax',
   }

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -215,7 +215,11 @@ module.exports = (async () => {
     '/cloud-docs/api-docs/run-tasks': '/cloud-docs/api-docs/run-tasks/run-tasks',
     '/cloud-docs/api-docs/run-tasks-integration': '/cloud-docs/api-docs/run-tasks/run-tasks-integration',
     '/language/provider-checksum-verification': '/language/files/dependency-lock#checksum-verification', // Used by the Terraform CLI to short-link to documentation.
-    '/cdktf/concepts/providers-and-resources' : '/cdktf/concepts/providers'
+    '/cdktf/concepts/providers-and-resources' : '/cdktf/concepts/providers',
+    // The /configuration pages have been deleted.
+    '/configuration/expressions': '/language/expressions/types',
+    '/configuration/modules': '/language/modules/syntax',
+    '/configuration/resources': '/language/resources/syntax',
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
# Description

This adds redirects for 3 pages that have nearly no content and serve only as landing pages that direct to other pages


Traffic for past 30 days (from https://usefathom.com)

```
                           Entries     Visitors    Views
/configuration             2           11          15
/configuration/expressions 1.2K        3.7K        5.3K
/configuration/resources   1.4K        2.9K        4.2K
/configuration/modules     687         1.6K        2K
```