### PR TITLE
chore: bump docs-page to `17.5.0` - enables `mdxContentHook`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@hashicorp/react-code-block": "^4.4.0",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.1.0",
-        "@hashicorp/react-docs-page": "^17.4.0",
+        "@hashicorp/react-docs-page": "^17.5.0",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-hero": "8.0.3",
@@ -2829,9 +2829,9 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.4.0.tgz",
-      "integrity": "sha512-4O8zn/GW1Qq4NkX58aWZ0rdtYZpSDqOr78Kt8xAwIXb6Ws6O4FWHXE4WoOexzByUfY6hFTc98TcGbNAJXVdBxw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.5.0.tgz",
+      "integrity": "sha512-0TFTvo17t/aqTCKzydl+I8QRnzbxmSgLvyXHG/eJms43VJVrOSSVbcLl3mM47x07hZLyQkUH1nO0iYGfWZB7PA==",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -3139,16 +3139,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/@hashicorp/react-search/node_modules/react-instantsearch-dom": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.31.0.tgz",
-      "integrity": "sha512-HMjKVHDYSlAir4A76nmEkD6e1bxC2mX3JRd0s3TMVj+VHHdRHJkMxXkegCs23Qguk8tJeZo60RvZcAz9jbuEcg==",
+      "version": "6.31.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.31.1.tgz",
+      "integrity": "sha512-wM85e83K3gaCoaESZOOZee9Tb+DTDH+cIcPN1Kj0kJRCu0byTk4/zs8HDqcgTVgZA/rrVrg1pVeZOEkKYenVKg==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.10.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "6.31.0"
+        "react-instantsearch-core": "6.31.1"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 5",
@@ -21015,9 +21015,9 @@
       }
     },
     "node_modules/react-instantsearch-core": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.31.0.tgz",
-      "integrity": "sha512-iHDdcVi9mh104u+HesmylsdKWvBrhV/IA+Augx4QOe4PYHVZ04Us46WEuu9XKmA0HObjPzU/6JRRVOL2KKrQXQ==",
+      "version": "6.31.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.31.1.tgz",
+      "integrity": "sha512-8bYVxPoyIsyh/+2+tSXawV8I7mzM3YxlVosXYS3RKuJarqYCxOHBEtWn9tiY40EoeZ0gFIyG4j7tVnhmRDXbwQ==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.10.0",
@@ -29499,9 +29499,9 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.4.0.tgz",
-      "integrity": "sha512-4O8zn/GW1Qq4NkX58aWZ0rdtYZpSDqOr78Kt8xAwIXb6Ws6O4FWHXE4WoOexzByUfY6hFTc98TcGbNAJXVdBxw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-17.5.0.tgz",
+      "integrity": "sha512-0TFTvo17t/aqTCKzydl+I8QRnzbxmSgLvyXHG/eJms43VJVrOSSVbcLl3mM47x07hZLyQkUH1nO0iYGfWZB7PA==",
       "requires": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-product-meta": "^0.1.0",
@@ -29741,16 +29741,16 @@
           "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
         },
         "react-instantsearch-dom": {
-          "version": "6.31.0",
-          "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.31.0.tgz",
-          "integrity": "sha512-HMjKVHDYSlAir4A76nmEkD6e1bxC2mX3JRd0s3TMVj+VHHdRHJkMxXkegCs23Qguk8tJeZo60RvZcAz9jbuEcg==",
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.31.1.tgz",
+          "integrity": "sha512-wM85e83K3gaCoaESZOOZee9Tb+DTDH+cIcPN1Kj0kJRCu0byTk4/zs8HDqcgTVgZA/rrVrg1pVeZOEkKYenVKg==",
           "requires": {
             "@babel/runtime": "^7.1.2",
             "algoliasearch-helper": "^3.10.0",
             "classnames": "^2.2.5",
             "prop-types": "^15.6.2",
             "react-fast-compare": "^3.0.0",
-            "react-instantsearch-core": "6.31.0"
+            "react-instantsearch-core": "6.31.1"
           }
         },
         "remark": {
@@ -43470,9 +43470,9 @@
       }
     },
     "react-instantsearch-core": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.31.0.tgz",
-      "integrity": "sha512-iHDdcVi9mh104u+HesmylsdKWvBrhV/IA+Augx4QOe4PYHVZ04Us46WEuu9XKmA0HObjPzU/6JRRVOL2KKrQXQ==",
+      "version": "6.31.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.31.1.tgz",
+      "integrity": "sha512-8bYVxPoyIsyh/+2+tSXawV8I7mzM3YxlVosXYS3RKuJarqYCxOHBEtWn9tiY40EoeZ0gFIyG4j7tVnhmRDXbwQ==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hashicorp/react-code-block": "^4.4.0",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.1.0",
-    "@hashicorp/react-docs-page": "^17.4.0",
+    "@hashicorp/react-docs-page": "^17.5.0",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-hero": "8.0.3",


### PR DESCRIPTION
### What

This bumps the `react-docs-page` version to `17.5.0`

This enables the new `mdxContentHook` option introduced in https://github.com/hashicorp/react-components/pull/681

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.