### PR TITLE
Add Admin API Redirects

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -223,6 +223,14 @@ module.exports = (async () => {
     // The /guides pages have been deleted.
     '/guides': '/intro',
     '/guides/terraform-provider-development-program': '/docs/partnerships',
+    '/cloud-docs/api-docs/admin': '/enterprise/api-docs/admin',
+    '/cloud-docs/api-docs/admin/module-sharing': '/enterprise/api-docs/admin/module-sharing',
+    '/cloud-docs/api-docs/admin/organizations': '/enterprise/api-docs/admin/organizations',
+    '/cloud-docs/api-docs/admin/runs': '/enterprise/api-docs/admin/runs',
+    '/cloud-docs/api-docs/admin/settings': '/enterprise/api-docs/admin/settings',
+    '/cloud-docs/api-docs/admin/terraform-versions': '/enterprise/api-docs/admin/terraform-versions',
+    '/cloud-docs/api-docs/admin/users': '/enterprise/api-docs/admin/users',
+    '/cloud-docs/api-docs/admin/workspaces': '/enterprise/api-docs/admin/workspaces'
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
### What
We are releasing versioned docs for TFE. The TFE Admin API will now live with the other TFE-Only docs in the private `ptfe-releases` repository and be maintained by the TFE team.

This PR adds the redirects for the TFE Admin API docs that were removed in this PR: https://github.com/hashicorp/terraform-docs-common/pull/80

### Why
We need these redirects because these files will not exist in the Terraform Cloud documentation anymore.


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.