### PR TITLE
Redirect drift docs to health assessments

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -232,7 +232,8 @@ module.exports = (async () => {
     '/cloud-docs/api-docs/admin/users': '/enterprise/api-docs/admin/users',
     '/cloud-docs/api-docs/admin/workspaces': '/enterprise/api-docs/admin/workspaces',
     '/language/configuration-0-11': '/language/v1.1.x/configuration-0-11',
-    '/language/configuration-0-11/:slug*': '/language/v1.1.x/configuration-0-11/:slug*'
+    '/language/configuration-0-11/:slug*': '/language/v1.1.x/configuration-0-11/:slug*',
+    '/cloud-docs/workspaces/settings/drift-detection': '/cloud-docs/workspaces/settings/health-assessments'
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Added a misc redirect for cloud-docs drift detection page as part of https://github.com/hashicorp/terraform-docs-common/pull/119

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

Drift detection will now be part of health assessments.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.