### PR TITLE
Use `useErrorPageAnalytics` hook on 404 page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hashicorp/mktg-global-styles": "4.0.0",
         "@hashicorp/mktg-logos": "^1.2.0",
         "@hashicorp/nextjs-scripts": "^19.0.3",
-        "@hashicorp/platform-analytics": "^0.6.0",
+        "@hashicorp/platform-analytics": "^0.6.1",
         "@hashicorp/platform-code-highlighting": "^0.1.2",
         "@hashicorp/platform-edge-utils": "^0.1.1",
         "@hashicorp/platform-runtime-error-monitoring": "^0.1.0",
@@ -2009,9 +2009,9 @@
       }
     },
     "node_modules/@hashicorp/platform-analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.0.tgz",
-      "integrity": "sha512-gmKg5VRWj7FhWxIgpSLUC/QDrcjVgyliTh0E9/Rw0RtJOf+lxRh8DNqGo3HIDgB9PEqg0jU7desunFEfEb7H0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.1.tgz",
+      "integrity": "sha512-qRdHFq8Wic87dYaibso/IKLr2qXBVauqsG8HpShoI11LP0Jn1cC8uI+Lj3BiN75YPq8Q4IWrsa94MYW8I9lpvw==",
       "dependencies": {
         "fathom-client": "^3.2.0",
         "js-cookie": "^2.2.1"
@@ -29099,9 +29099,9 @@
       }
     },
     "@hashicorp/platform-analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.0.tgz",
-      "integrity": "sha512-gmKg5VRWj7FhWxIgpSLUC/QDrcjVgyliTh0E9/Rw0RtJOf+lxRh8DNqGo3HIDgB9PEqg0jU7desunFEfEb7H0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.1.tgz",
+      "integrity": "sha512-qRdHFq8Wic87dYaibso/IKLr2qXBVauqsG8HpShoI11LP0Jn1cC8uI+Lj3BiN75YPq8Q4IWrsa94MYW8I9lpvw==",
       "requires": {
         "fathom-client": "^3.2.0",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@hashicorp/mktg-global-styles": "4.0.0",
     "@hashicorp/mktg-logos": "^1.2.0",
     "@hashicorp/nextjs-scripts": "^19.0.3",
-    "@hashicorp/platform-analytics": "^0.6.0",
+    "@hashicorp/platform-analytics": "^0.6.1",
     "@hashicorp/platform-code-highlighting": "^0.1.2",
     "@hashicorp/platform-edge-utils": "^0.1.1",
     "@hashicorp/platform-runtime-error-monitoring": "^0.1.0",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,19 +1,8 @@
 import Link from 'next/link'
-import { useEffect } from 'react'
+import { useErrorPageAnalytics } from '@hashicorp/platform-analytics';
 
 export default function NotFound() {
-  useEffect(() => {
-    if (
-      typeof window !== 'undefined' &&
-      typeof window?.analytics?.track === 'function' &&
-      typeof window?.document?.referrer === 'string' &&
-      typeof window?.location?.href === 'string'
-    )
-      window.analytics.track(window.location.href, {
-        category: '404 Response',
-        label: window.document.referrer || 'No Referrer',
-      })
-  }, [])
+  useErrorPageAnalytics(404);
 
   return (
     <div id="p-404" className="g-grid-container">


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1202865459293217/f)

---

## Description
It was recently discovered that, across our various web properties, we make the following call:

`window.analytics.track(window.location.href, { ... } )`

The first parameter of the `track` method is used downstream in our various data warehouses to create a new table. Since we're using `window.location.href`, we're creating a table for _every_ URL that 404s. This is not ideal for analytics.

## Solution
This PR leverages the new `useErrorPageAnalytics` hook (see [this PR](https://github.com/hashicorp/web-platform-packages/pull/86)) for pushing 404-related data to Segment. This PR replaces the `window.analytics.track` call on the 404 page with said hook.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.