### PR TITLE
Add redirects for old provisioners

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -233,7 +233,7 @@ module.exports = (async () => {
     '/cloud-docs/api-docs/admin/workspaces': '/enterprise/api-docs/admin/workspaces',
     '/language/configuration-0-11': '/language/v1.1.x/configuration-0-11',
     '/language/configuration-0-11/:slug*': '/language/v1.1.x/configuration-0-11/:slug*',
-    '/cloud-docs/workspaces/settings/drift-detection': '/cloud-docs/workspaces/settings/health-assessments'
+    '/cloud-docs/workspaces/settings/drift-detection': '/cloud-docs/workspaces/settings/health-assessments',
     '/language/resources/provisioners/chef': '/language/v1.1.x/resources/provisioners/chef',
     '/language/resources/provisioners/habitat': '/language/v1.1.x/resources/provisioners/habitat',
     '/language/resources/provisioners/puppet': '/language/v1.1.x/resources/provisioners/puppet',

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -237,7 +237,7 @@ module.exports = (async () => {
     '/language/resources/provisioners/chef': '/language/v1.1.x/resources/provisioners/chef',
     '/language/resources/provisioners/habitat': '/language/v1.1.x/resources/provisioners/habitat',
     '/language/resources/provisioners/puppet': '/language/v1.1.x/resources/provisioners/puppet',
-    '/language/resources/provisioners/salt-masterless': '/language/v1.1.x/resources/provisioners/salt-masterless',
+    '/language/resources/provisioners/salt-masterless': '/language/v1.1.x/resources/provisioners/salt-masterless'
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -234,6 +234,10 @@ module.exports = (async () => {
     '/language/configuration-0-11': '/language/v1.1.x/configuration-0-11',
     '/language/configuration-0-11/:slug*': '/language/v1.1.x/configuration-0-11/:slug*',
     '/cloud-docs/workspaces/settings/drift-detection': '/cloud-docs/workspaces/settings/health-assessments'
+    '/language/resources/provisioners/chef': '/language/v1.1.x/resources/provisioners/chef',
+    '/language/resources/provisioners/habitat': '/language/v1.1.x/resources/provisioners/habitat',
+    '/language/resources/provisioners/puppet': '/language/v1.1.x/resources/provisioners/puppet',
+    '/language/resources/provisioners/salt-masterless': '/language/v1.1.x/resources/provisioners/salt-masterless',
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
### What
We're removing old, legacy provisioners from the Terraform docs v1.2 and later here: https://github.com/hashicorp/terraform/pull/31788 This PR adds the required redirects. 

### Why
We shouldn't keep documentation pages for features that are no longer part of our product.

