### PR TITLE
fix: make the beta opt-out query parameter work

### DIFF
--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -1,8 +1,18 @@
 import setGeoCookie from '@hashicorp/platform-edge-utils/lib/set-geo-cookie'
 // eslint-disable-next-line @next/next/no-server-import-in-page
-import type { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
 export default function middleware(request: NextRequest) {
+  /**
+   * If we're serving a beta product's io site and the betaOptOut query param exists,
+   * clear it and redirect back to the current URL without the betaOptOut query param
+   */
+  if (request.nextUrl.searchParams.get('betaOptOut') === 'true') {
+    const url = request.nextUrl.clone()
+    url.searchParams.delete('betaOptOut')
+    return NextResponse.redirect(url).clearCookie(`terraform-io-beta-opt-in`)
+  }
+
   // Sets a cookie named hc_geo on the response
   const response = setGeoCookie(request)
 

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -4,8 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export default function middleware(request: NextRequest) {
   /**
-   * If we're serving a beta product's io site and the betaOptOut query param exists,
-   * clear it and redirect back to the current URL without the betaOptOut query param
+   * If the betaOptOut query param exists, clear it, delete the opt-in cookie, and redirect back to the current URL without the betaOptOut query param
    */
   if (request.nextUrl.searchParams.get('betaOptOut') === 'true') {
     const url = request.nextUrl.clone()


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
I forgot to add the logic to handle the `betaOptOut` query parameter 🤦 This ensures that users can actually opt-out from the DevDot beta.


### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.