### PR TITLE
Add temporary redirects to exclude OPA from TFE

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -2,14 +2,27 @@
  * Redirects in this file are intended to be for documentation content only. The redirects will be applied to developer.hashicorp.com.
  */
 module.exports = [
-   {
-     source: '/terraform/enterprise/policy-enforcement/:path*',
-     destination: '/terraform/enterprise/sentinel/:path*',
-     permanent: true,
-   },
+  // Temporary Redirects to defer new/moved cloud-docs pages to their older respective enterprise pages
+  // - https://github.com/hashicorp/terraform-docs-common-internal/pull/6
+  // - https://github.com/hashicorp/terraform-docs-common/pull/141
   {
-     source: '/terraform/enterprise/policy-enforcement/sentinel/:path*',
-     destination: '/terraform/enterprise/sentinel/:path*',
-     permanent: true,
-   }
+    source: '/terraform/enterprise/policy-enforcement',
+    destination: '/terraform/enterprise/sentinel',
+    permanent: false,
+  },
+  {
+    source: '/terraform/enterprise/policy-enforcement/sentinel',
+    destination: '/terraform/enterprise/sentinel',
+    permanent: false,
+  },
+  {
+    source: '/terraform/enterprise/policy-enforcement/:path*',
+    destination: '/terraform/enterprise/sentinel/:path*',
+    permanent: false,
+  },
+  {
+    source: '/terraform/enterprise/policy-enforcement/sentinel/:path*',
+    destination: '/terraform/enterprise/sentinel/:path*',
+    permanent: false,
+  },
 ]

--- a/redirects.js
+++ b/redirects.js
@@ -2,9 +2,14 @@
  * Redirects in this file are intended to be for documentation content only. The redirects will be applied to developer.hashicorp.com.
  */
 module.exports = [
-  // {
-  //   source: '/terraform/docs/path',
-  //   destination: '/terraform/docs/new/path',
-  //   permanent: true,
-  // },
+   {
+     source: '/terraform/enterprise/policy-enforcement/:path*',
+     destination: '/terraform/enterprise/sentinel/:path*',
+     permanent: true,
+   },
+  {
+     source: '/terraform/enterprise/policy-enforcement/sentinel/:path*',
+     destination: '/terraform/enterprise/sentinel/:path*',
+     permanent: true,
+   }
 ]


### PR DESCRIPTION
### What
Add redirects to prevent 404s with TFE policy documentation.

### Why
We completely changed the policy enforcement documentation in terraform cloud for the recent OPA policy launch at HashiConf. None of these changes should be available in the versioned Terraform Enterprise documentation yet.

We've already handled keeping the actual content pages out of TFE. The issue is all of the links throughout the docs that point to sentinel pages that are now in a different path. 

Rather than manually re-write every one of these links for each TFE release until OPA is available, we're adding temporary redirects to the developer portal for this content.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.