### PR TITLE
fix: Oracle OCI provider redirect

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -73,7 +73,7 @@ module.exports = (async () => {
     nsxt: 'vmware/nsxt',
     null: 'hashicorp/null',
     nutanix: 'nutanix/nutanix',
-    oci: 'hashicorp/oci',
+    oci: 'oracle/oci',
     okta: 'oktadeveloper/okta',
     oktaasa: 'oktadeveloper/oktaasa',
     opc: 'hashicorp/opc',


### PR DESCRIPTION
### What
Oracle's OCI official Terraform provider was moved from the hashicorp namespace to oracle's. This commit fixes the redirect to the documentation of the former.

### Why
Oracle has raised this issue in the Registry's [support](https://hashicorp.zendesk.com/agent/tickets/89335) channel.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.