### PR TITLE
fix: redirect downloads to dev-dot

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,7 @@ const BASE_PATHS = [
   'intro',
   'language',
   'plugin',
-  'registry'
+  'registry',
 ]
 
 const devDotRoutes = [ ...BASE_PATHS, 'downloads']

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,10 +24,11 @@ const BASE_PATHS = [
   'intro',
   'language',
   'plugin',
-  'registry',
+  'registry'
 ]
 
-const devDotRedirectCheck = new RegExp(`^/(${BASE_PATHS.join('|')})/?`)
+const devDotRoutes = [ ...BASE_PATHS, 'downloads']
+const devDotRedirectCheck = new RegExp(`^/(${devDotRoutes.join('|')})/?`)
 
 function setHappyKitCookie(
   cookie: Parameters<NextResponse['cookies']['set']>,


### PR DESCRIPTION
This PR adds `downloads` as a route that we redirect to Dev Dot via middleware.