### PR TITLE
Update redirects.js

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -6,25 +6,15 @@ module.exports = [
   // - https://github.com/hashicorp/terraform-docs-common-internal/pull/6
   // - https://github.com/hashicorp/terraform-docs-common/pull/141
   {
-    source: '/terraform/enterprise/policy-enforcement/:path*',
-    destination: '/terraform/enterprise/sentinel/:path*',
-    permanent: false,
-  },
-  {
-    source: '/terraform/enterprise/policy-enforcement/sentinel/:path*',
-    destination: '/terraform/enterprise/sentinel/:path*',
-    permanent: false,
-  },
-  {
-    source: '/terraform/enterprise/policy-enforcement',
-    destination: '/terraform/enterprise/sentinel',
-    permanent: false,
-  },
-  {
-    source: '/terraform/enterprise/policy-enforcement/sentinel',
-    destination: '/terraform/enterprise/sentinel',
-    permanent: false,
-  },
+		source: '/terraform/enterprise/policy-enforcement/sentinel/:path*',
+		destination: '/terraform/enterprise/sentinel/:path*',
+		permanent: false,
+	},
+	{
+		source: '/terraform/enterprise/policy-enforcement',
+		destination: '/terraform/enterprise/sentinel',
+		permanent: false,
+	},
   // Redirects for restructured Terraform Plugin Framework docs for GA release of the Framework
   // - https://github.com/hashicorp/terraform-plugin-framework/pull/554
   {


### PR DESCRIPTION
The redirects for sentinel content in TFE are still broken. Hopefully this fix remedies that issue!