### PR TITLE
Remove TFE Sentinel redirects

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -2,19 +2,6 @@
  * Redirects in this file are intended to be for documentation content only. The redirects will be applied to developer.hashicorp.com.
  */
 module.exports = [
-  // Temporary Redirects to defer new/moved cloud-docs pages to their older respective enterprise pages
-  // - https://github.com/hashicorp/terraform-docs-common-internal/pull/6
-  // - https://github.com/hashicorp/terraform-docs-common/pull/141
-  {
-		source: '/terraform/enterprise/policy-enforcement/sentinel/:path*',
-		destination: '/terraform/enterprise/sentinel/:path*',
-		permanent: false,
-	},
-	{
-		source: '/terraform/enterprise/policy-enforcement',
-		destination: '/terraform/enterprise/sentinel',
-		permanent: false,
-	},
   // Redirects for restructured Terraform Plugin Framework docs for GA release of the Framework
   // - https://github.com/hashicorp/terraform-plugin-framework/pull/554
   // - https://github.com/hashicorp/terraform-docs-common/pull/252


### PR DESCRIPTION
### What
To support OPA in the latest TFE release, we've updated the policy docs to match those in TFC. Removing redirects that sent users to the Sentinel-specific TFE pages, which will no longer exist.


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.