### PR TITLE
chore: Use getRevalidateTime lib for global revalidate vals

### DIFF
--- a/lib/get-revalidate-time/index.test.ts
+++ b/lib/get-revalidate-time/index.test.ts
@@ -1,0 +1,20 @@
+import { convertPrimitiveToNumber, previewRevalidateTime as fallback } from '.'
+
+describe('convertPrimitiveToNumber', () => {
+  it('coerces a string with an integer into number', () => {
+    const time = convertPrimitiveToNumber('52')
+    expect(time).toBe(52)
+  })
+  it('returns fallback if string does not include integer', () => {
+    const time = convertPrimitiveToNumber('imastringwithoutaninteger')
+    expect(time).toBe(fallback)
+  })
+  it('returns number if type is number', () => {
+    const time = convertPrimitiveToNumber(23)
+    expect(time).toBe(23)
+  })
+  it('returns fallback if falsy', () => {
+    const time = convertPrimitiveToNumber(undefined)
+    expect(time).toBe(fallback)
+  })
+})

--- a/lib/get-revalidate-time/index.ts
+++ b/lib/get-revalidate-time/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Utility function that converts a primitive into a number. If it can't convert
+ * the argument into a number, it will return a fallback number.
+ *
+ * @param primitive - The primitive for conversion
+ * @param fallback - Fallback return value if the primitive can't be converted into a number
+ *
+ * @returns The converted number or the fallback
+ */
+
+export const convertPrimitiveToNumber = (
+  primitive: string | number | boolean,
+  fallback = 10
+): number => {
+  if (!primitive) return fallback
+
+  const isNumber = typeof primitive === 'number'
+  const isStr = typeof primitive === 'string'
+  const parsesToInteger = isStr ? !!Number.parseInt(primitive, 10) : false
+
+  if (isNumber) {
+    return primitive
+  } else if (isStr && parsesToInteger) {
+    return Number.parseInt(primitive, 10)
+  } else {
+    return fallback
+  }
+}
+
+// The shorter revalidate interval allows authors allows for
+// near-real-time ISR for content authors when drafting
+// content via Preview Mode
+export const previewRevalidateTime = 10
+
+/**
+ * Wrapper function for `convertPrimitiveToNumber` that converts the value of
+ * `process.env.GLOBAL_REVALIDATE` into a number. This can then be used to set the
+ * `revalidate` key in `getStaticProps`. Since `process.env` properties are
+ * typed as strings but `getStaticProps` expects `revalidate`to be a number, we
+ * need to convert the type into a number.
+ *
+ * @returns The converted number or the fallback
+ */
+
+export const getRevalidateTime = () => {
+  return convertPrimitiveToNumber(
+    process.env.GLOBAL_REVALIDATE,
+    previewRevalidateTime
+  )
+}

--- a/pages/home/index.tsx
+++ b/pages/home/index.tsx
@@ -3,6 +3,7 @@ import rivetQuery from '@hashicorp/platform-cms'
 import homepageQuery from './query.graphql'
 import { isInternalLink } from 'lib/utils'
 import ReactHead from '@hashicorp/react-head'
+import { getRevalidateTime } from 'lib/get-revalidate-time'
 import IoHomeHeroAlt from 'components/io-home-hero-alt'
 import IoHomeIntro from 'components/io-home-intro'
 import IoHomeInPractice from 'components/io-home-in-practice'
@@ -180,9 +181,6 @@ export async function getStaticProps() {
 
   return {
     props: { data: terraformHomepage },
-    revalidate:
-      process.env.HASHI_ENV === 'production'
-        ? process.env.GLOBAL_REVALIDATE
-        : 10,
+    revalidate: getRevalidateTime(),
   }
 }

--- a/pages/use-cases/[slug].tsx
+++ b/pages/use-cases/[slug].tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import rivetQuery from '@hashicorp/platform-cms'
 import useCasesQuery from './query.graphql'
 import ReactHead from '@hashicorp/react-head'
+import { getRevalidateTime } from 'lib/get-revalidate-time'
 import IoUsecaseHero from 'components/io-usecase-hero'
 import IoUsecaseSection from 'components/io-usecase-section'
 import IoUsecaseCustomer from 'components/io-usecase-customer'
@@ -236,9 +237,6 @@ export async function getStaticProps({ params }) {
     props: {
       data: page,
     },
-    revalidate:
-      process.env.HASHI_ENV === 'production'
-        ? process.env.GLOBAL_REVALIDATE
-        : 10,
+    revalidate: getRevalidateTime(),
   }
 }


### PR DESCRIPTION
### What

This PR implements a `getRevalidateTime()` utility for converting and setting revalidate values.

### Why

Prod builds should resume successfully building after this PR merges.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any. (N/A)

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.). (N/A)
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A)
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed. (N/A)

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.