### PR TITLE
Remove editions from nav

### DIFF
--- a/data/primary-navigation.js
+++ b/data/primary-navigation.js
@@ -4,21 +4,6 @@ export default [
     url: '/',
   },
   {
-    text: 'Editions',
-    type: 'anchor',
-    submenu: [
-      { url: '/', text: 'Terraform CLI' },
-      {
-        url: 'https://cloud.hashicorp.com/products/terraform',
-        text: 'Terraform Cloud',
-      },
-      {
-        url: 'https://www.hashicorp.com/products/terraform',
-        text: 'Terraform Enterprise',
-      },
-    ],
-  },
-  {
     text: 'Registry',
     url: 'https://registry.terraform.io/',
   },

--- a/layouts/standard/index.tsx
+++ b/layouts/standard/index.tsx
@@ -25,21 +25,6 @@ export default function StandardLayout(props: Props): React.ReactElement {
             ].sort((a, b) => a.text.localeCompare(b.text)),
           },
           {
-            text: 'Editions',
-            type: 'anchor',
-            submenu: [
-              { url: '/', text: 'Terraform CLI' },
-              {
-                url: 'https://cloud.hashicorp.com/products/terraform',
-                text: 'Terraform Cloud',
-              },
-              {
-                url: 'https://www.hashicorp.com/products/terraform',
-                text: 'Terraform Enterprise',
-              },
-            ],
-          },
-          {
             text: 'Registry',
             url: 'https://registry.terraform.io/',
           },


### PR DESCRIPTION
### What
Removes the "Editions" menu item. CLI was pointing to the homepage, and Cloud & Enterprise both now go to https://www.hashicorp.com/products/terraform so the whole entry is redundant. 

### Why
Simplifies the nav for users