### PR TITLE
Adding redirects for the ServiceNow Service Catalog pages.

### DIFF
--- a/redirects.next.js
+++ b/redirects.next.js
@@ -314,16 +314,17 @@ module.exports = (async () => {
       '/enterprise/admin/application/registry-sharing',
     // ServiceNow Service Catalog
     '/cloud-docs/integrations/service-now':
-      'bla',
+      '/cloud-docs/integrations/service-now/service-catalog',
     '/cloud-docs/integrations/service-now/service-catalog':
-      'bla',
+      '/cloud-docs/integrations/service-now/service-catalog/service-catalog-config',
     '/cloud-docs/integrations/service-now/admin-guide':
-      'bla',
+      '/cloud-docs/integrations/service-now/service-catalog/admin-guide',
     '/cloud-docs/integrations/service-now/developer-reference':
-      'bla',
+      '/cloud-docs/integrations/service-now/service-catalog/developer-reference',
+    '/cloud-docs/integrations/service-now/example-customizations':
+      '/cloud-docs/integrations/service-now/service-catalog/example-customizations',
     '/cloud-docs/integrations/service-now/service-now-v1':
-      'bla',
-      
+      '/cloud-docs/integrations/service-now/service-catalog/service-now-v1',
   }
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(

--- a/redirects.next.js
+++ b/redirects.next.js
@@ -312,6 +312,19 @@ module.exports = (async () => {
     // Registry Sharing
     '/enterprise/admin/application/module-sharing':
       '/enterprise/admin/application/registry-sharing',
+    // ServiceNow Service Catalog
+    '/cloud-docs/integrations/service-now':
+      'bla',
+    '/cloud-docs/integrations/service-now/service-catalog':
+      'bla',
+    '/cloud-docs/integrations/service-now/admin-guide':
+      'bla',
+    '/cloud-docs/integrations/service-now/developer-reference':
+      'bla',
+    '/cloud-docs/integrations/service-now/service-now-v1':
+      'bla',
+      
+  }
   }
   const miscRedirects = Object.entries(miscRedirectsMap).map(
     ([source, destination]) => {


### PR DESCRIPTION
**To be merged after the Service Graph Connector for Terraform goes GA on July 26th.** Dependent PR: https://github.com/hashicorp/terraform-docs-common/pull/369

### What
Adding redirects for the ServiceNow Service Catalog pages because of menu rearrangement. Current state: https://developer.hashicorp.com/terraform/cloud-docs/integrations/service-now Future state: https://github.com/hashicorp/terraform-docs-common/pull/369

### Why
A new ServiceNow application has been developed at HashiCorp and goes GA on July 26th. A new ServiceNow app means hat we need to rearrange the menu. Both applications will be listed as sibling items under Terraform Cloud > Integrations > ServiceNow Integrations.

### Screenshots
![Screenshot 2023-06-09 at 9 31 56 AM](https://github.com/hashicorp/terraform-website/assets/28816039/4ffc1419-53b4-4480-8bc0-f0ef39081241)

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A  New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.